### PR TITLE
feat: add OpenAIConfig model and handler forwarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ site/
 reports/
 ziran_results/
 ziran-results.sarif
+.claude/

--- a/examples/15-remote-agent-scan/target-ollama.yaml
+++ b/examples/15-remote-agent-scan/target-ollama.yaml
@@ -1,0 +1,17 @@
+# Ziran Target Config: Ollama (Local LLM)
+# Scans a local Ollama instance via its OpenAI-compatible API.
+# Start Ollama first:  ollama serve && ollama pull llama3
+
+url: http://localhost:11434
+protocol: openai
+timeout: 120.0
+
+# OpenAI-specific settings
+openai:
+  model: llama3                   # Model pulled in Ollama
+  temperature: 0.8
+
+# No auth needed for local Ollama
+# No TLS for localhost
+tls:
+  verify: false

--- a/examples/15-remote-agent-scan/target-openai-custom.yaml
+++ b/examples/15-remote-agent-scan/target-openai-custom.yaml
@@ -1,0 +1,28 @@
+# Ziran Target Config: OpenAI-Compatible with Custom Model
+# Demonstrates overriding model name and parameters for any
+# OpenAI-compatible endpoint (vLLM, Ollama, LiteLLM proxy, etc.).
+
+url: https://api.openai.com
+protocol: openai
+timeout: 60.0
+
+# OpenAI-specific settings
+openai:
+  model: gpt-4o                   # Override model (default: gpt-4)
+  temperature: 0.7                # Sampling temperature (optional)
+  max_tokens: 4096                # Max response tokens (optional)
+
+# Authentication
+auth:
+  type: bearer
+  env_var: OPENAI_API_KEY         # Reads from $OPENAI_API_KEY
+
+# TLS
+tls:
+  verify: true
+
+# Retry
+retry:
+  max_retries: 3
+  backoff_factor: 1.0
+  retry_on: [429, 500, 502, 503, 504]

--- a/ziran/domain/entities/target.py
+++ b/ziran/domain/entities/target.py
@@ -150,6 +150,31 @@ class RestConfig(BaseModel):
     )
 
 
+class OpenAIConfig(BaseModel):
+    """Configuration specific to the OpenAI-compatible protocol.
+
+    Allows overriding the model name, temperature, and max_tokens
+    sent to any OpenAI-compatible endpoint (OpenAI, Azure OpenAI,
+    vLLM, Ollama, LiteLLM proxies, etc.).
+    """
+
+    model: str = Field(
+        default="gpt-4",
+        description="Model name to request (e.g. 'gpt-4o', 'llama3', 'claude-3-haiku')",
+    )
+    temperature: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=2.0,
+        description="Sampling temperature (omitted from request if None)",
+    )
+    max_tokens: int | None = Field(
+        default=None,
+        gt=0,
+        description="Maximum tokens in the response (omitted from request if None)",
+    )
+
+
 class A2AConfig(BaseModel):
     """Configuration specific to the A2A protocol."""
 
@@ -207,6 +232,9 @@ class TargetConfig(BaseModel):
 
     # Protocol-specific config
     rest: RestConfig | None = Field(default=None, description="REST-specific configuration")
+    openai: OpenAIConfig | None = Field(
+        default=None, description="OpenAI-compatible protocol configuration"
+    )
     a2a: A2AConfig | None = Field(default=None, description="A2A-specific configuration")
 
     # Security
@@ -228,6 +256,8 @@ class TargetConfig(BaseModel):
             self.a2a = A2AConfig()
         if self.protocol == ProtocolType.REST and self.rest is None:
             self.rest = RestConfig()
+        if self.protocol == ProtocolType.OPENAI and self.openai is None:
+            self.openai = OpenAIConfig()
         return self
 
     @property

--- a/ziran/infrastructure/adapters/http_adapter.py
+++ b/ziran/infrastructure/adapters/http_adapter.py
@@ -292,7 +292,14 @@ class HttpAgentAdapter(BaseAgentAdapter):
                 OpenAIProtocolHandler,
             )
 
-            return OpenAIProtocolHandler(self._client, self._config)
+            openai_cfg = self._config.openai
+            return OpenAIProtocolHandler(
+                self._client,
+                self._config,
+                model=openai_cfg.model if openai_cfg else "gpt-4",
+                temperature=openai_cfg.temperature if openai_cfg else None,
+                max_tokens=openai_cfg.max_tokens if openai_cfg else None,
+            )
 
         if protocol == ProtocolType.MCP:
             from ziran.infrastructure.adapters.protocols.mcp_handler import (

--- a/ziran/infrastructure/adapters/protocols/openai_handler.py
+++ b/ziran/infrastructure/adapters/protocols/openai_handler.py
@@ -31,9 +31,13 @@ class OpenAIProtocolHandler(BaseProtocolHandler):
         client: httpx.AsyncClient,
         config: TargetConfig,
         model: str = _DEFAULT_MODEL,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
     ) -> None:
         super().__init__(client, config)
         self._model = model
+        self._temperature = temperature
+        self._max_tokens = max_tokens
         self._conversation: list[dict[str, str]] = []
 
     async def send(self, message: str, **kwargs: Any) -> dict[str, Any]:
@@ -54,6 +58,10 @@ class OpenAIProtocolHandler(BaseProtocolHandler):
             "model": self._model,
             "messages": list(self._conversation),
         }
+        if self._temperature is not None:
+            body["temperature"] = self._temperature
+        if self._max_tokens is not None:
+            body["max_tokens"] = self._max_tokens
 
         try:
             response = await self._client.post(url, json=body)


### PR DESCRIPTION
## Summary

Adds structured configuration for OpenAI-compatible protocol targets, enabling model, temperature, and max_tokens to be specified in YAML target configs and forwarded through the protocol handler chain.

## Changes

- **`ziran/domain/entities/target.py`** — New `OpenAIConfig` Pydantic model with `model` (default `gpt-4`), `temperature` (0-2), `max_tokens` (>0). Auto-created when `protocol=openai` via `_ensure_protocol_config` validator.
- **`ziran/infrastructure/adapters/protocols/openai_handler.py`** — `OpenAIProtocolHandler` accepts `model`, `temperature`, `max_tokens` params and includes them in the request body.
- **`ziran/infrastructure/adapters/http_adapter.py`** — `_create_handler()` reads `TargetConfig.openai` and passes fields to the handler.
- **`examples/15-remote-agent-scan/`** — Example YAML configs for custom OpenAI and Ollama targets.

## Tests

- `TestOpenAIConfig` — defaults, custom values, temperature bounds, max_tokens validation
- `TestTargetConfigOpenAI` — auto-creation, custom preservation, non-OpenAI exclusion, YAML loading
- `TestOpenAIHandlerConfig` — temperature/max_tokens forwarded in request, omitted when unset
