### PR TITLE
feat: add AgentCoreAdapter for Amazon Bedrock AgentCore

### DIFF
--- a/tests/unit/test_agentcore_adapter.py
+++ b/tests/unit/test_agentcore_adapter.py
@@ -1,0 +1,197 @@
+"""Unit tests for the AgentCoreAdapter."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ziran.domain.entities.capability import CapabilityType
+from ziran.domain.interfaces.adapter import AgentResponse
+from ziran.infrastructure.adapters.agentcore_adapter import AgentCoreAdapter
+
+# ──────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _sync_entrypoint(payload: dict) -> dict:
+    """Simple sync entrypoint returning echoed content."""
+    return {"result": f"Echo: {payload.get('prompt', '')}"}
+
+
+async def _async_entrypoint(payload: dict) -> dict:
+    """Simple async entrypoint."""
+    return {"result": f"Async echo: {payload.get('prompt', '')}"}
+
+
+def _entrypoint_with_tools(payload: dict) -> dict:
+    """Entrypoint returning tool calls."""
+    return {
+        "result": "Done with tools",
+        "tool_calls": [
+            {"name": "search", "input": {"q": "test"}, "output": "found"},
+            {"name": "email", "input": {"to": "user"}, "output": "sent"},
+        ],
+    }
+
+
+def _string_entrypoint(payload: dict) -> str:
+    """Entrypoint returning a raw string."""
+    return f"Raw: {payload.get('prompt', '')}"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Tests
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestAgentCoreAdapterInvoke:
+    """Tests for AgentCoreAdapter.invoke()."""
+
+    async def test_sync_entrypoint(self) -> None:
+        adapter = AgentCoreAdapter(entrypoint=_sync_entrypoint)
+        response = await adapter.invoke("Hello")
+
+        assert isinstance(response, AgentResponse)
+        assert response.content == "Echo: Hello"
+        assert response.metadata["protocol"] == "agentcore"
+
+    async def test_async_entrypoint(self) -> None:
+        adapter = AgentCoreAdapter(entrypoint=_async_entrypoint)
+        response = await adapter.invoke("Hello")
+
+        assert response.content == "Async echo: Hello"
+
+    async def test_custom_request_response_fields(self) -> None:
+        def custom_fn(payload: dict) -> dict:
+            return {"output": f"Got: {payload['input']}"}
+
+        adapter = AgentCoreAdapter(
+            entrypoint=custom_fn,
+            request_field="input",
+            response_field="output",
+        )
+        response = await adapter.invoke("Hi")
+
+        assert response.content == "Got: Hi"
+
+    async def test_tool_calls_parsed(self) -> None:
+        adapter = AgentCoreAdapter(entrypoint=_entrypoint_with_tools)
+        response = await adapter.invoke("Do things")
+
+        assert len(response.tool_calls) == 2
+        assert response.tool_calls[0]["tool"] == "search"
+        assert response.tool_calls[1]["tool"] == "email"
+
+    async def test_string_response(self) -> None:
+        adapter = AgentCoreAdapter(entrypoint=_string_entrypoint)
+        response = await adapter.invoke("Hello")
+
+        assert response.content == "Raw: Hello"
+        assert response.tool_calls == []
+
+    async def test_kwargs_merged_into_payload(self) -> None:
+        received_payloads: list[dict] = []
+
+        def capturing_fn(payload: dict) -> dict:
+            received_payloads.append(payload)
+            return {"result": "ok"}
+
+        adapter = AgentCoreAdapter(entrypoint=capturing_fn)
+        await adapter.invoke("Test", extra_field="extra_value")
+
+        assert received_payloads[0]["prompt"] == "Test"
+        assert received_payloads[0]["extra_field"] == "extra_value"
+
+    async def test_conversation_history_updated(self) -> None:
+        adapter = AgentCoreAdapter(entrypoint=_sync_entrypoint)
+        await adapter.invoke("First")
+        await adapter.invoke("Second")
+
+        state = adapter.get_state()
+        assert len(state.conversation_history) == 4  # 2 turns x 2 messages
+
+
+@pytest.mark.unit
+class TestAgentCoreAdapterCapabilities:
+    """Tests for AgentCoreAdapter.discover_capabilities()."""
+
+    async def test_no_app_returns_empty(self) -> None:
+        adapter = AgentCoreAdapter(entrypoint=_sync_entrypoint, app=None)
+        caps = await adapter.discover_capabilities()
+        assert caps == []
+
+    async def test_discover_from_dict_tools(self) -> None:
+        mock_app = MagicMock()
+        tool_a = MagicMock()
+        tool_a.name = "search"
+        tool_a.description = "Search the web"
+        del tool_a.input_schema  # Ensure no input_schema attr
+
+        tool_b = MagicMock()
+        tool_b.name = "execute_shell"
+        tool_b.description = "Run shell commands"
+        del tool_b.input_schema
+
+        mock_app.tools = {"search": tool_a, "execute_shell": tool_b}
+
+        adapter = AgentCoreAdapter(entrypoint=_sync_entrypoint, app=mock_app)
+        caps = await adapter.discover_capabilities()
+
+        assert len(caps) == 2
+        assert caps[0].name == "search"
+        assert caps[0].type == CapabilityType.TOOL
+        assert caps[0].dangerous is False
+        # "execute_shell" contains "execute" and "shell" → dangerous
+        assert caps[1].name == "execute_shell"
+        assert caps[1].dangerous is True
+
+    async def test_discover_from_list_tools(self) -> None:
+        mock_app = MagicMock()
+        tool = MagicMock()
+        tool.name = "database_query"
+        tool.description = "Query a database"
+        del tool.input_schema
+
+        mock_app.tools = [tool]
+
+        adapter = AgentCoreAdapter(entrypoint=_sync_entrypoint, app=mock_app)
+        caps = await adapter.discover_capabilities()
+
+        assert len(caps) == 1
+        assert caps[0].name == "database_query"
+        assert caps[0].dangerous is True  # "database" is a dangerous keyword
+
+
+@pytest.mark.unit
+class TestAgentCoreAdapterState:
+    """Tests for state management."""
+
+    async def test_get_state(self) -> None:
+        adapter = AgentCoreAdapter(entrypoint=_sync_entrypoint)
+        await adapter.invoke("Hello")
+
+        state = adapter.get_state()
+        assert state.session_id is not None
+        assert len(state.conversation_history) == 2
+
+    async def test_reset_state(self) -> None:
+        adapter = AgentCoreAdapter(entrypoint=_sync_entrypoint)
+        await adapter.invoke("Hello")
+        adapter.observe_tool_call("test_tool", {"k": "v"}, "output")
+
+        adapter.reset_state()
+
+        state = adapter.get_state()
+        assert len(state.conversation_history) == 0
+        assert len(adapter._observed_tool_calls) == 0
+
+    def test_observe_tool_call(self) -> None:
+        adapter = AgentCoreAdapter(entrypoint=_sync_entrypoint)
+        adapter.observe_tool_call("my_tool", {"p": "1"}, "result")
+
+        assert len(adapter._observed_tool_calls) == 1
+        assert adapter._observed_tool_calls[0]["tool"] == "my_tool"
+        assert adapter._observed_tool_calls[0]["output"] == "result"

--- a/ziran/infrastructure/adapters/agentcore_adapter.py
+++ b/ziran/infrastructure/adapters/agentcore_adapter.py
@@ -1,0 +1,265 @@
+"""Amazon Bedrock AgentCore adapter.
+
+Wraps agents built with the ``bedrock-agentcore`` SDK
+(``BedrockAgentCoreApp``) to implement the ZIRAN BaseAgentAdapter
+interface. Enables in-process security scanning of AgentCore agents
+before or after deployment.
+
+Requires the ``agentcore`` extra::
+
+    uv sync --extra agentcore
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+from ziran.domain.entities.capability import AgentCapability, CapabilityType
+from ziran.domain.interfaces.adapter import AgentResponse, AgentState, BaseAgentAdapter
+
+logger = logging.getLogger(__name__)
+
+
+# Tool names that heuristically indicate dangerous capabilities
+_DANGEROUS_KEYWORDS: frozenset[str] = frozenset(
+    {
+        "execute",
+        "shell",
+        "bash",
+        "code",
+        "eval",
+        "run",
+        "file",
+        "write",
+        "delete",
+        "remove",
+        "database",
+        "sql",
+        "query",
+        "api",
+        "web",
+        "http",
+        "request",
+        "fetch",
+        "email",
+        "send",
+        "system",
+        "os",
+        "lambda",
+        "invoke",
+        "browser",
+    }
+)
+
+
+class AgentCoreAdapter(BaseAgentAdapter):
+    """Adapter for Amazon Bedrock AgentCore agents.
+
+    Wraps a ``BedrockAgentCoreApp`` entrypoint function or any
+    callable that accepts a dict payload and returns a dict response.
+    This enables scanning AgentCore agents in-process without
+    deploying them first.
+
+    Example:
+        ```python
+        from bedrock_agentcore import BedrockAgentCoreApp
+        from ziran.infrastructure.adapters.agentcore_adapter import AgentCoreAdapter
+
+        app = BedrockAgentCoreApp()
+
+        @app.entrypoint
+        def invoke(payload):
+            return {"result": my_agent(payload["prompt"])}
+
+        adapter = AgentCoreAdapter(invoke)
+        response = await adapter.invoke("What can you do?")
+        ```
+    """
+
+    def __init__(
+        self,
+        entrypoint: Any,
+        *,
+        request_field: str = "prompt",
+        response_field: str = "result",
+        app: Any | None = None,
+    ) -> None:
+        """Initialize with an AgentCore entrypoint.
+
+        Args:
+            entrypoint: The ``@app.entrypoint``-decorated callable, or
+                        any function ``f(payload: dict) -> dict``.
+            request_field: Key in the payload dict for the user message.
+            response_field: Key in the response dict for the agent reply.
+            app: Optional ``BedrockAgentCoreApp`` instance for capability
+                 discovery and introspection.
+        """
+        self._entrypoint = entrypoint
+        self._request_field = request_field
+        self._response_field = response_field
+        self._app = app
+        self._conversation_history: list[dict[str, str]] = []
+        self._observed_tool_calls: list[dict[str, Any]] = []
+
+    async def invoke(self, message: str, **kwargs: Any) -> AgentResponse:
+        """Send a message to the AgentCore agent.
+
+        Constructs a payload dict matching the entrypoint's expected
+        format and executes it. Runs in a thread if the entrypoint
+        is synchronous.
+
+        Args:
+            message: The user prompt.
+            **kwargs: Additional fields merged into the payload.
+
+        Returns:
+            Standardized agent response.
+        """
+        payload = {self._request_field: message, **kwargs}
+
+        # Run entrypoint — use thread for sync functions
+        if asyncio.iscoroutinefunction(self._entrypoint):
+            result = await self._entrypoint(payload)
+        else:
+            result = await asyncio.to_thread(self._entrypoint, payload)
+
+        # Extract content
+        if isinstance(result, dict):
+            content = str(result.get(self._response_field, result))
+            tool_calls_raw = result.get("tool_calls", [])
+        elif isinstance(result, str):
+            content = result
+            tool_calls_raw = []
+        else:
+            content = str(result)
+            tool_calls_raw = []
+
+        # Parse tool calls
+        tool_calls: list[dict[str, Any]] = []
+        for tc in tool_calls_raw:
+            if isinstance(tc, dict):
+                tool_calls.append(
+                    {
+                        "tool": tc.get("name", tc.get("tool", "unknown")),
+                        "input": tc.get("input", tc.get("arguments", {})),
+                        "output": tc.get("output", ""),
+                    }
+                )
+                self._observed_tool_calls.append(tool_calls[-1])
+
+        self._conversation_history.append({"role": "user", "content": message})
+        self._conversation_history.append({"role": "assistant", "content": content})
+
+        return AgentResponse(
+            content=content,
+            tool_calls=tool_calls,
+            metadata={"protocol": "agentcore"},
+        )
+
+    async def discover_capabilities(self) -> list[AgentCapability]:
+        """Discover AgentCore agent capabilities.
+
+        Introspects the ``BedrockAgentCoreApp`` instance for
+        registered tools and handlers. Falls back to empty list
+        if no app reference is available.
+
+        Returns:
+            List of discovered capabilities.
+        """
+        capabilities: list[AgentCapability] = []
+
+        if self._app is None:
+            logger.debug("No BedrockAgentCoreApp instance — skipping capability discovery")
+            return capabilities
+
+        # Introspect registered tools from the app
+        tools = getattr(self._app, "tools", None) or getattr(self._app, "_tools", None) or {}
+
+        tool_items: Iterable[tuple[Any, Any]]
+        if isinstance(tools, dict):
+            tool_items = tools.items()
+        elif isinstance(tools, list):
+            tool_items = ((getattr(t, "name", str(i)), t) for i, t in enumerate(tools))
+        else:
+            tool_items = ()
+
+        for name, tool in tool_items:
+            tool_name = getattr(tool, "name", str(name))
+            description = getattr(tool, "description", None)
+
+            # Try to extract parameter schema
+            params: dict[str, Any] = {}
+            if hasattr(tool, "input_schema"):
+                with contextlib.suppress(Exception):
+                    params = {"schema": tool.input_schema}
+
+            capabilities.append(
+                AgentCapability(
+                    id=f"agentcore_tool_{tool_name}",
+                    name=tool_name,
+                    type=CapabilityType.TOOL,
+                    description=description,
+                    parameters=params,
+                    dangerous=_is_dangerous_tool(tool_name),
+                )
+            )
+
+        logger.info(
+            "Discovered %d AgentCore capabilities (%d dangerous)",
+            len(capabilities),
+            sum(1 for c in capabilities if c.dangerous),
+        )
+        return capabilities
+
+    def get_state(self) -> AgentState:
+        """Get current agent state snapshot.
+
+        Returns:
+            Agent state with conversation history.
+        """
+        return AgentState(
+            session_id=str(id(self._entrypoint)),
+            conversation_history=list(self._conversation_history),
+            memory={},
+        )
+
+    def reset_state(self) -> None:
+        """Reset agent to initial state.
+
+        Clears conversation history and observed tool calls.
+        """
+        self._conversation_history.clear()
+        self._observed_tool_calls.clear()
+
+    def observe_tool_call(
+        self,
+        tool_name: str,
+        inputs: dict[str, Any],
+        outputs: Any,
+    ) -> None:
+        """Record an observed tool call.
+
+        Args:
+            tool_name: Name of the tool invoked.
+            inputs: Input parameters.
+            outputs: Tool output.
+        """
+        self._observed_tool_calls.append(
+            {
+                "tool": tool_name,
+                "input": inputs,
+                "output": str(outputs),
+            }
+        )
+
+
+def _is_dangerous_tool(tool_name: str) -> bool:
+    """Heuristic check for potentially dangerous tools."""
+    name_lower = tool_name.lower()
+    return any(keyword in name_lower for keyword in _DANGEROUS_KEYWORDS)


### PR DESCRIPTION
## Summary

Adds a new `AgentCoreAdapter` for scanning Amazon Bedrock AgentCore agents in-process, wrapping either callable entrypoints or `BedrockAgentCoreApp` instances.

Stacked on #7.

## Changes

- **`ziran/infrastructure/adapters/agentcore_adapter.py`** — New adapter implementing `BaseAgentAdapter`:
  - Wraps sync or async entrypoints with automatic detection
  - Configurable `request_field`/`response_field` for flexible payloads
  - Tool introspection from app instances with `_is_dangerous_tool()` heuristic
  - Conversation history tracking, state management, observed tool calls

## Tests

- **`tests/unit/test_agentcore_adapter.py`** — 11 tests:
  - Sync/async entrypoints, custom request/response fields
  - Tool call parsing, string responses, kwargs merging
  - Conversation history, capability discovery (dict/list tools)
  - State management, reset, observe tool call
