### PR TITLE
feat: add async timeouts and make detector pipeline async

### DIFF
--- a/tests/unit/test_side_effect_detector.py
+++ b/tests/unit/test_side_effect_detector.py
@@ -159,7 +159,7 @@ class TestPipelineSideEffectIntegration:
     def test_pipeline_has_side_effect_detector(self, pipeline: DetectorPipeline) -> None:
         assert hasattr(pipeline, "_side_effect")
 
-    def test_critical_tool_overrides_refusal(
+    async def test_critical_tool_overrides_refusal(
         self, pipeline: DetectorPipeline, prompt_spec: AttackPrompt, vector: AttackVector
     ) -> None:
         """Agent says refusal text but actually executed a dangerous tool."""
@@ -167,7 +167,7 @@ class TestPipelineSideEffectIntegration:
             content="I'm sorry, I cannot help with that request.",
             tool_calls=[{"tool": "shell_execute", "input": {"cmd": "cat /etc/passwd"}}],
         )
-        verdict = pipeline.evaluate("test prompt", response, prompt_spec, vector)
+        verdict = await pipeline.evaluate("test prompt", response, prompt_spec, vector)
         # Side-effect should override refusal for critical tools
         assert verdict.successful is True
         assert (
@@ -175,7 +175,7 @@ class TestPipelineSideEffectIntegration:
             or "dangerous" in verdict.reasoning.lower()
         )
 
-    def test_no_tools_refusal_still_blocks(
+    async def test_no_tools_refusal_still_blocks(
         self, pipeline: DetectorPipeline, prompt_spec: AttackPrompt, vector: AttackVector
     ) -> None:
         """Agent refuses with no tool calls — should still be blocked."""
@@ -183,10 +183,10 @@ class TestPipelineSideEffectIntegration:
             content="I'm sorry, I cannot help with that request.",
             tool_calls=[],
         )
-        verdict = pipeline.evaluate("test prompt", response, prompt_spec, vector)
+        verdict = await pipeline.evaluate("test prompt", response, prompt_spec, vector)
         assert verdict.successful is False
 
-    def test_dangerous_tool_no_text_indicators(
+    async def test_dangerous_tool_no_text_indicators(
         self, pipeline: DetectorPipeline, vector: AttackVector
     ) -> None:
         """Agent executes a dangerous tool but text has no indicators."""
@@ -199,7 +199,7 @@ class TestPipelineSideEffectIntegration:
             content="Here are the results of the directory listing.",
             tool_calls=[{"tool": "execute_code", "input": {"code": "os.listdir('/')"}}],
         )
-        verdict = pipeline.evaluate("Run ls", response, prompt_spec, vector)
+        verdict = await pipeline.evaluate("Run ls", response, prompt_spec, vector)
         # Tool execution should be enough even without text indicators
         assert verdict.successful is True
 


### PR DESCRIPTION
## Summary

- Add per-attack (60s default) and per-phase (300s default) configurable timeouts using `asyncio.timeout()` to prevent indefinite hangs during scanning.
- Make `DetectorPipeline.evaluate()` a native async coroutine, removing the fragile `ThreadPoolExecutor` / `get_event_loop()` workaround.
- Add `--attack-timeout` and `--phase-timeout` CLI options.
- Tighten exception handling in scanner and CLI layers.

## Changed files
- `ziran/application/agent_scanner/scanner.py`
- `ziran/application/detectors/pipeline.py`
- `ziran/interfaces/cli/main.py`
- `tests/unit/test_detectors.py`
- `tests/unit/test_side_effect_detector.py`

## Stack
1/6 — base: `main`