### PR TITLE
docs: update documentation for v0.5.0 Adaptive Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ That's a fundamentally different attack surface.
 | Agent-aware (tools + memory) | **Yes** | — | Partial | — | — |
 | Tool chain analysis | **Yes** | — | — | — | — |
 | Multi-phase campaigns | **Yes** | — | — | Partial | Yes |
+| Multi-agent coordination | **Yes** | — | — | — | — |
+| Adaptive campaigns | **Yes** | — | — | — | — |
+| Streaming (SSE/WebSocket) | **Yes** | — | — | — | — |
 | Knowledge graph tracking | **Yes** | — | — | — | — |
 | Remote agent scanning (HTTPS) | **Yes** | REST only | HTTP provider | Partial | — |
 | Multi-protocol (REST/OpenAI/MCP/A2A) | **Yes** | — | — | — | — |
@@ -43,6 +46,9 @@ That's a fundamentally different attack surface.
 
 - **Tool Chain Analysis** — Detects dangerous tool combinations (`read_file` → `http_request` = data exfiltration). No other tool does this.
 - **Multi-Phase Trust Exploitation** — Progressive campaigns that build trust before testing boundaries, like a real attacker.
+- **Multi-Agent Coordination** — Discover topologies (supervisor, router, peer-to-peer) and test cross-agent trust boundaries and delegation patterns.
+- **Adaptive Campaigns** — Three execution strategies — fixed, rule-based adaptive, and LLM-driven — that adjust attack plans in real-time based on knowledge graph state.
+- **Streaming Support** — Real-time attack monitoring via SSE and WebSocket protocols for long-running agent responses.
 - **Knowledge Graph** — Every discovered capability, relationship, and attack path is tracked in a live graph.
 - **Remote Agent Scanning** — Test any published agent over HTTPS with YAML-driven target configuration. Supports REST, OpenAI-compatible, MCP, and A2A protocols with automatic detection.
 - **A2A Protocol Support** — First security tool to test [Agent-to-Agent](https://google.github.io/A2A/) agents, including Agent Card discovery, task lifecycle attacks, and multi-turn manipulation.
@@ -59,6 +65,7 @@ pip install ziran
 pip install ziran[langchain]    # LangChain support
 pip install ziran[crewai]       # CrewAI support
 pip install ziran[a2a]          # A2A protocol support
+pip install ziran[streaming]    # SSE/WebSocket streaming
 pip install ziran[all]          # everything
 ```
 
@@ -74,6 +81,15 @@ ziran scan --framework langchain --agent-path my_agent.py
 
 # scan a remote agent over HTTPS
 ziran scan --target target.yaml
+
+# adaptive campaign with LLM-driven strategy
+ziran scan --target target.yaml --strategy llm-adaptive
+
+# stream responses in real-time
+ziran scan --target target.yaml --streaming
+
+# scan a multi-agent system
+ziran multi-agent-scan --target target.yaml
 
 # discover capabilities of a remote agent
 ziran discover --target target.yaml
@@ -220,6 +236,37 @@ flowchart LR
 | Exfiltration | Extract sensitive data *(opt-in)* |
 
 Each phase builds on the knowledge graph from previous phases.
+
+### Campaign Strategies
+
+| Strategy | Description |
+|----------|-------------|
+| `fixed` | Sequential phases in order (default) |
+| `adaptive` | Rule-based adaptation — skips, repeats, or re-orders phases based on knowledge graph state |
+| `llm-adaptive` | LLM-driven strategy — uses an LLM to analyze findings and plan the next phase dynamically |
+
+```bash
+ziran scan --target target.yaml --strategy adaptive
+ziran scan --target target.yaml --strategy llm-adaptive
+```
+
+### Multi-Agent Scanning
+
+Test coordinated multi-agent systems — supervisors, routers, peer-to-peer networks:
+
+```bash
+ziran multi-agent-scan --target target.yaml
+```
+
+ZIRAN discovers the agent topology, scans each agent individually, then runs cross-agent attacks targeting trust boundaries and delegation patterns.
+
+### Streaming
+
+Monitor attack responses in real-time via SSE or WebSocket:
+
+```bash
+ziran scan --target target.yaml --streaming
+```
 
 ---
 

--- a/docs/community/roadmap.md
+++ b/docs/community/roadmap.md
@@ -36,13 +36,44 @@
 - :white_check_mark: 11 dedicated A2A attack vectors
 - :white_check_mark: 15 runnable examples
 
-## Next: v0.4 — Hardening
+### v0.4 — Multi-Vendor & LLM Backbone
 
-- [ ] **Multi-agent coordination testing** — Test interactions between cooperating agents in supervisor/router architectures
-- [ ] **Streaming support** — SSE/WebSocket streaming for long-running agent responses
-- [ ] **Coverage for OWASP LLM04, LLM05, LLM10** — Model DoS, supply chain, and unbounded consumption vectors
-- [ ] **Remediation engine** — Auto-generate fix suggestions and guardrail configurations
-- [ ] **Adaptive campaigns** — Adjust attack strategy in real-time based on knowledge graph state
+- :white_check_mark: Multi-vendor LLM support via LiteLLM (OpenAI, Anthropic, AWS Bedrock, Google, and more)
+- :white_check_mark: LLM-as-a-Judge detection for nuanced semantic analysis
+- :white_check_mark: Amazon Bedrock Agent and AgentCore adapters
+- :white_check_mark: Dependency capping and compatibility hardening
+
+### v0.5 — Adaptive Intelligence
+
+- :white_check_mark: **Streaming support** — SSE and WebSocket protocol handlers for real-time attack monitoring
+- :white_check_mark: **Multi-agent coordination** — Topology discovery, individual and cross-agent scanning for supervisor, router, peer-to-peer, hierarchical, and pipeline architectures
+- :white_check_mark: **Adaptive campaigns** — Three execution strategies: fixed (sequential), adaptive (rule-based), and LLM-adaptive (LLM-driven phase orchestration)
+- :white_check_mark: **Campaign strategy protocol** — Extensible interface for custom campaign strategies
+- :white_check_mark: **327 multi-agent attack vectors** — Cross-agent prompt injection, delegation chain manipulation, shared memory poisoning
+- :white_check_mark: **18 runnable examples** — Including multi-agent, streaming, and adaptive campaign demos
+
+## Next: v0.6 — Pentesting Agent
+
+The flagship feature — an autonomous AI agent that performs penetration testing:
+
+- [ ] **Autonomous pentesting agent** — An LLM-powered agent that plans, executes, and adapts attack campaigns with minimal human intervention
+- [ ] **Attack chain reasoning** — The agent reasons about discovered vulnerabilities to chain multi-step exploits
+- [ ] **Interactive red-team mode** — Collaborate with the pentesting agent in a conversational interface
+- [ ] **Finding deduplication** — Intelligent merging of related findings across automated and agent-driven scans
+
+## v0.7 — Remediation Engine
+
+- [ ] **Auto-generated fix suggestions** — Concrete code patches and guardrail configurations for discovered vulnerabilities
+- [ ] **Guardrail templates** — Pre-built guardrail configurations for common agent frameworks
+- [ ] **Remediation validation** — Re-scan after applying fixes to verify remediation effectiveness
+- [ ] **Security policy generator** — Generate policy files from scan results
+
+## v0.8 — MCP Server Mode
+
+- [ ] **ZIRAN as an MCP server** — Expose scanning capabilities via the Model Context Protocol, enabling any MCP-compatible client to trigger scans
+- [ ] **Tool-based scanning interface** — Scan agents, browse results, and manage campaigns through MCP tool calls
+- [ ] **Integration with AI IDEs** — Use ZIRAN directly from Cursor, Windsurf, Claude Desktop, and other MCP clients
+- [ ] **Continuous monitoring** — Long-running MCP server mode for periodic security assessments
 
 ## Future
 

--- a/docs/concepts/adaptive-campaigns.md
+++ b/docs/concepts/adaptive-campaigns.md
@@ -1,0 +1,126 @@
+# Adaptive Campaigns
+
+ZIRAN supports three campaign execution strategies that control how scan phases are orchestrated. Choose the strategy that fits your testing scenario.
+
+## Strategies
+
+### Fixed (Default)
+
+Runs phases in their defined sequential order. Simple, predictable, and deterministic.
+
+```bash
+ziran scan --target target.yaml --strategy fixed
+```
+
+Best for: CI/CD pipelines, reproducible scans, benchmarking.
+
+### Adaptive (Rule-Based)
+
+Analyzes knowledge graph state after each phase and applies rules to decide the next action:
+
+- **Skip phases** that are unlikely to yield findings based on discovered capabilities
+- **Re-order phases** to prioritize the most promising attack surface
+- **Repeat phases** with adjusted parameters when partial findings suggest deeper vulnerabilities
+- **Early termination** when the graph shows the agent is fully hardened
+
+```bash
+ziran scan --target target.yaml --strategy adaptive
+```
+
+Best for: Thorough manual assessments, complex agents with many capabilities.
+
+### LLM-Adaptive
+
+Uses an LLM to analyze the current knowledge graph, all previous findings, and the agent's capabilities to dynamically plan the next phase. The LLM acts as a strategy advisor — it doesn't execute attacks, it decides *which* attacks to run and in *what order*.
+
+```bash
+ziran scan --target target.yaml --strategy llm-adaptive
+```
+
+Best for: Maximum coverage on high-value targets, red-team exercises.
+
+!!! note "LLM Required"
+
+    The `llm-adaptive` strategy requires an LLM provider. Set `--llm-provider` and `--llm-model`, or use the `ZIRAN_LLM_PROVIDER` and `ZIRAN_LLM_MODEL` environment variables.
+
+## Comparison
+
+| Aspect | Fixed | Adaptive | LLM-Adaptive |
+|--------|-------|----------|-------------|
+| Deterministic | Yes | Partially | No |
+| LLM required | No | No | Yes |
+| Phase ordering | Sequential | Rule-driven | LLM-driven |
+| Can skip phases | No | Yes | Yes |
+| Can repeat phases | No | Yes | Yes |
+| Token cost | None | None | Moderate |
+| Best for | CI/CD | Manual assessment | Red-teaming |
+
+## How Adaptive Strategies Work
+
+```mermaid
+flowchart TD
+    S["Start Campaign"] --> P["Execute Phase"]
+    P --> A["Analyze Results"]
+    A --> D{"Strategy\nDecision"}
+    D -->|"Fixed"| N["Next Phase\n(sequential)"]
+    D -->|"Adaptive"| R["Rule Engine\n(graph analysis)"]
+    D -->|"LLM-Adaptive"| L["LLM Advisor\n(dynamic planning)"]
+    R --> P
+    L --> P
+    N --> P
+    N --> E["End"]
+    R --> E
+    L --> E
+
+    style S fill:#16213e,stroke:#0ea5e9,color:#fff
+    style P fill:#16213e,stroke:#0ea5e9,color:#fff
+    style A fill:#16213e,stroke:#0ea5e9,color:#fff
+    style D fill:#16213e,stroke:#e94560,color:#fff
+    style R fill:#0f3460,stroke:#10b981,color:#fff
+    style L fill:#0f3460,stroke:#10b981,color:#fff
+    style N fill:#0f3460,stroke:#10b981,color:#fff
+    style E fill:#1e293b,stroke:#10b981,color:#fff
+```
+
+## Python API
+
+```python
+from ziran.application.strategies.adaptive import AdaptiveCampaignStrategy
+from ziran.application.strategies.llm_adaptive import LLMAdaptiveCampaignStrategy
+from ziran.application.strategies.fixed import FixedCampaignStrategy
+
+# Use directly with the scanner
+scanner = AgentScanner(adapter=adapter, attack_library=library)
+
+# Fixed (default)
+result = await scanner.run_campaign(strategy=FixedCampaignStrategy())
+
+# Adaptive
+result = await scanner.run_campaign(strategy=AdaptiveCampaignStrategy())
+
+# LLM-Adaptive (requires LLM client)
+result = await scanner.run_campaign(strategy=LLMAdaptiveCampaignStrategy(llm_client=client))
+```
+
+## Custom Strategies
+
+Implement the `CampaignStrategy` protocol to create your own strategy:
+
+```python
+from ziran.application.strategies.protocol import CampaignStrategy
+
+class MyStrategy(CampaignStrategy):
+    async def select_next_phase(self, context):
+        # Your logic here
+        ...
+
+    async def should_continue(self, context):
+        # Your logic here
+        ...
+```
+
+## See Also
+
+- [Architecture](architecture.md) — Overall system design
+- [Trust Exploitation](romance-scan.md) — The 8-phase methodology
+- [CLI Reference](../reference/cli.md) — `--strategy` option documentation

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -22,6 +22,8 @@ graph TB
         PoC[PoC Generator]
         PE[Policy Engine]
         QG[Quality Gate]
+        MA[Multi-Agent Scanner]
+        ST[Campaign Strategies]
     end
 
     subgraph Domain["Domain Layer"]
@@ -35,6 +37,8 @@ graph TB
         BR[Bedrock Adapter]
         HTTP[HTTP Agent Adapter]
         Protocols[Protocol Handlers]
+        SSE[SSE/WS Streaming]
+        LLM[LLM Backbone]
     end
 
     CLI --> Scanner
@@ -63,8 +67,10 @@ ziran/
 │   │   ├── campaign.py         # CampaignResult, PhaseResult, AttackResult
 │   │   ├── ci.py               # QualityGateConfig, GateResult
 │   │   ├── detection.py        # DetectorResult, Verdict
+│   │   ├── multi_agent.py      # MultiAgentTopology, AgentNode, AgentEdge
 │   │   ├── phase.py            # ScanPhase (8 phases)
 │   │   ├── policy.py           # Policy, PolicyRule, PolicyVerdict
+│   │   ├── streaming.py        # AgentResponseChunk, LLMResponseChunk
 │   │   └── target.py           # TargetConfig, ProtocolType, AuthConfig
 │   └── interfaces/             # Port interfaces (ABCs)
 │       ├── adapter.py          # AgentAdapter — the core extension point
@@ -80,6 +86,8 @@ ziran/
 │   ├── dynamic_vectors/        # LLM-powered vector generation
 │   ├── poc_generator/          # Exploit PoC generation
 │   ├── policy/                 # Policy engine
+│   ├── multi_agent/            # Multi-agent topology discovery & scanning
+│   ├── strategies/             # Campaign execution strategies (fixed, adaptive, llm-adaptive)
 │   └── cicd/                   # Quality gate + SARIF
 │
 ├── infrastructure/             # External integrations
@@ -88,7 +96,9 @@ ziran/
 │       ├── crewai_adapter.py
 │       ├── bedrock_adapter.py
 │       ├── http_agent_adapter.py  # Remote agent scanning
-│       └── protocols/             # REST, OpenAI, MCP, A2A handlers
+│       └── protocols/             # REST, OpenAI, MCP, A2A, SSE, WebSocket handlers
+│   ├── llm/                    # LLM backbone (LiteLLM, streaming)
+│   └── logging/                # Structured logging
 │
 └── interfaces/                 # Entry points
     └── cli/                    # Typer CLI application
@@ -135,12 +145,13 @@ The `AttackKnowledgeGraph` is the **shared state** across all scan phases. Each 
 | New attack vectors | YAML files | `--custom-attacks ./my_vectors/` |
 | New report format | `ReportGenerator` | Custom output format |
 | New protocol | `BaseProtocolHandler` | Custom wire protocol |
+| Campaign strategy | `CampaignStrategy` | Custom phase orchestration |
 | Static analysis check | `CheckDefinition` | New SA0xx check |
 | Policy rules | `PolicyRule` | Custom compliance rules |
 
 ## Testing
 
-ZIRAN has 428+ tests organized by architecture layer:
+ZIRAN has 840+ tests organized by architecture layer:
 
 ```bash
 # Run all tests

--- a/docs/concepts/multi-agent.md
+++ b/docs/concepts/multi-agent.md
@@ -1,0 +1,111 @@
+# Multi-Agent Coordination
+
+ZIRAN can discover and test coordinated multi-agent systems — supervisors, routers, peer-to-peer networks, pipelines, and hierarchical architectures.
+
+## Why Multi-Agent Testing Matters
+
+Modern AI systems increasingly use multiple cooperating agents. A supervisor delegates tasks to specialized workers; a router dispatches requests to domain experts; agents pass context to each other through delegation chains. Each inter-agent boundary is a potential attack surface:
+
+- **Trust boundary exploitation** — An attacker who compromises one agent may escalate through delegation chains
+- **Cross-agent prompt injection** — Injected content in Agent A's response may be trusted by Agent B
+- **Privilege escalation** — A worker agent may have capabilities the supervisor doesn't directly expose
+- **Data leakage** — Full-context delegation patterns may forward sensitive information to less-privileged agents
+
+## How It Works
+
+The multi-agent scanner operates in three stages:
+
+```mermaid
+flowchart LR
+    D["1 · DISCOVER\nTopology discovery\nvia probing"] --> I["2 · INDIVIDUAL\nScan each agent\nin isolation"] --> X["3 · CROSS-AGENT\nAttack trust boundaries\nand delegation patterns"]
+
+    style D fill:#16213e,stroke:#0ea5e9,color:#fff
+    style I fill:#16213e,stroke:#0ea5e9,color:#fff
+    style X fill:#16213e,stroke:#e94560,color:#fff
+```
+
+### Stage 1: Topology Discovery
+
+ZIRAN probes the entry-point agent with targeted prompts to discover:
+
+- Other agents in the system
+- Delegation patterns (full context, task-only, tool calls)
+- Trust boundaries (same process, network, cross-organization)
+- Agent roles (supervisor, router, worker, specialist)
+
+The discovered topology is classified as one of:
+
+| Type | Description |
+|------|-------------|
+| **Supervisor** | One orchestrator delegates to multiple workers |
+| **Router** | A routing agent dispatches to specialized agents |
+| **Peer-to-Peer** | Agents communicate directly with each other |
+| **Hierarchical** | Multi-level supervisor hierarchy |
+| **Pipeline** | Sequential chain of agents (output → input) |
+
+### Stage 2: Individual Scans
+
+Each agent is scanned in isolation using the standard multi-phase campaign. Results are merged into a shared knowledge graph with agent-prefixed node IDs to avoid collisions.
+
+### Stage 3: Cross-Agent Campaign
+
+Using the entry-point agent, ZIRAN executes attacks that exploit inter-agent communication:
+
+- Prompt injection that propagates through delegation chains
+- Trust boundary probing across agent boundaries
+- Privilege escalation through capability gaps between agents
+- Data exfiltration via cross-agent context leakage
+
+## Usage
+
+### CLI
+
+```bash
+# Scan a multi-agent system
+ziran multi-agent-scan --target target.yaml
+
+# Comprehensive coverage, 10 concurrent attacks
+ziran multi-agent-scan --target target.yaml --coverage comprehensive --concurrency 10
+
+# Skip individual agent scans (cross-agent only)
+ziran multi-agent-scan --target target.yaml --skip-individual
+```
+
+### Python API
+
+```python
+import asyncio
+from ziran.application.multi_agent.scanner import MultiAgentScanner
+
+scanner = MultiAgentScanner(
+    adapters={"supervisor": sup_adapter, "worker": wrk_adapter},
+    entry_point="supervisor",
+)
+
+result = asyncio.run(scanner.run_multi_agent_campaign())
+
+print(f"Topology: {result.topology.topology_type}")
+print(f"Agents scanned: {result.total_agents}")
+print(f"Total vulnerabilities: {result.total_vulnerabilities}")
+print(f"Cross-agent vulnerabilities: {result.cross_agent_vulnerabilities}")
+```
+
+## Attack Vectors
+
+ZIRAN ships with 327 multi-agent attack vectors in `ziran/application/attacks/vectors/multi_agent.yaml`, covering:
+
+- **Cross-agent prompt injection** — Injected content that propagates through delegation
+- **Delegation chain manipulation** — Exploiting trust between supervisor and worker agents
+- **Shared memory poisoning** — Corrupting shared state between agents
+- **Agent impersonation** — Impersonating other agents in the system
+- **Routing bypass** — Redirecting requests to unintended agents
+
+## Knowledge Graph
+
+Discovered topologies are imported into the attack knowledge graph. Each agent becomes a node, each delegation or trust boundary becomes an edge. This enables cross-agent attack path analysis — finding multi-hop exploitation chains that span agent boundaries.
+
+## See Also
+
+- [Architecture](architecture.md) — Overall system design
+- [Trust Exploitation](romance-scan.md) — Multi-phase methodology used for individual agent scans
+- [Knowledge Graph](knowledge-graph.md) — How the graph tracks cross-agent relationships

--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -1,0 +1,115 @@
+# Streaming Support
+
+ZIRAN supports real-time response monitoring via Server-Sent Events (SSE) and WebSocket protocols. This enables observing agent responses as they stream in, rather than waiting for the full response to complete.
+
+## Why Streaming?
+
+Many modern agents produce long-running responses — multi-step reasoning, tool call chains, or extended text generation. Streaming provides:
+
+- **Real-time monitoring** — See agent responses as they arrive, token by token
+- **Early detection** — Identify suspicious content before the response completes
+- **Long-running agents** — Avoid timeouts on agents that take minutes to respond
+- **Protocol fidelity** — Test agents over the same protocol they use in production
+
+## Supported Protocols
+
+| Protocol | Transport | Use Case |
+|----------|-----------|----------|
+| **SSE** | HTTP with `text/event-stream` | OpenAI-compatible APIs, most LLM gateways |
+| **WebSocket** | Persistent bidirectional connection | Real-time chat agents, interactive sessions |
+
+## Usage
+
+### CLI
+
+```bash
+# Enable streaming for a scan
+ziran scan --target target.yaml --streaming
+
+# Combine with adaptive strategy
+ziran scan --target target.yaml --streaming --strategy adaptive
+```
+
+### Python API
+
+```python
+from ziran.application.agent_scanner.scanner import AgentScanner
+
+scanner = AgentScanner(adapter=adapter, attack_library=library)
+result = await scanner.run_campaign(streaming=True)
+```
+
+### Streaming with the Adapter
+
+The adapter layer handles streaming transparently. When streaming is enabled, adapters that support it will use `invoke_streaming()` instead of `invoke()`:
+
+```python
+from ziran.domain.interfaces.adapter import BaseAgentAdapter
+
+class MyStreamingAdapter(BaseAgentAdapter):
+    async def invoke_streaming(self, prompt: str):
+        async for chunk in my_agent.stream(prompt):
+            yield AgentResponseChunk(
+                content=chunk.text,
+                is_final=chunk.is_last,
+            )
+```
+
+## Architecture
+
+```mermaid
+flowchart LR
+    S["Scanner"] -->|"streaming=True"| A["Adapter"]
+    A -->|"SSE"| SSE["SSE Handler\n(text/event-stream)"]
+    A -->|"WebSocket"| WS["WS Handler\n(ws:// / wss://)"]
+    SSE --> Agent["Agent"]
+    WS --> Agent
+
+    style S fill:#16213e,stroke:#0ea5e9,color:#fff
+    style A fill:#16213e,stroke:#0ea5e9,color:#fff
+    style SSE fill:#0f3460,stroke:#10b981,color:#fff
+    style WS fill:#0f3460,stroke:#10b981,color:#fff
+    style Agent fill:#1a1a2e,stroke:#e94560,color:#fff
+```
+
+## Domain Entities
+
+### AgentResponseChunk
+
+Each streamed chunk is represented as an `AgentResponseChunk`:
+
+```python
+class AgentResponseChunk(BaseModel):
+    content: str          # Partial response text
+    is_final: bool        # Whether this is the last chunk
+    tool_calls: list      # Tool calls discovered in this chunk
+    metadata: dict        # Protocol-specific metadata
+```
+
+### LLMResponseChunk
+
+For the LLM backbone layer, streaming responses use `LLMResponseChunk`:
+
+```python
+class LLMResponseChunk(BaseModel):
+    content: str          # Partial LLM output
+    is_final: bool        # Last chunk flag
+    model: str            # Model that generated this chunk
+    usage: dict           # Token usage (available on final chunk)
+```
+
+## Installation
+
+Streaming support requires the `streaming` extra:
+
+```bash
+pip install ziran[streaming]
+```
+
+This installs the `websockets` library for WebSocket support. SSE streaming uses `httpx` which is included in the base installation.
+
+## See Also
+
+- [Remote Scanning](remote-scanning.md) — Protocol configuration for remote agents
+- [Architecture](architecture.md) — How streaming fits into the adapter layer
+- [CLI Reference](../reference/cli.md) — `--streaming` option documentation

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,6 +38,7 @@ Install support for your agent framework:
 pip install ziran[langchain]   # LangChain agents
 pip install ziran[crewai]      # CrewAI agents
 pip install ziran[a2a]         # A2A protocol (Agent-to-Agent)
+pip install ziran[streaming]   # SSE/WebSocket streaming
 pip install ziran[all]         # Everything
 ```
 
@@ -50,6 +51,22 @@ ziran scan --framework langchain --agent-path my_agent.py
 ```
 
 Your agent file should export an `agent_executor` (LangChain) or `crew` (CrewAI) object.
+
+#### With adaptive strategy
+
+```bash
+# Rule-based adaptive campaign
+ziran scan --framework langchain --agent-path my_agent.py --strategy adaptive
+
+# LLM-driven adaptive campaign
+ziran scan --target target.yaml --strategy llm-adaptive
+```
+
+#### With streaming
+
+```bash
+ziran scan --target target.yaml --streaming
+```
 
 ### Option 2: Scan a Remote Agent
 
@@ -89,7 +106,15 @@ print(f"Found {result.total_vulnerabilities} vulnerabilities")
 print(f"Dangerous tool chains: {len(result.dangerous_tool_chains)}")
 ```
 
-### Option 4: Run an Example
+### Option 4: Scan a Multi-Agent System
+
+```bash
+ziran multi-agent-scan --target target.yaml
+```
+
+ZIRAN discovers the agent topology, scans each agent individually, then runs cross-agent attacks targeting trust boundaries and delegation patterns.
+
+### Option 5: Run an Example
 
 ZIRAN ships with 15 examples — from static analysis to multi-agent scanning:
 
@@ -105,6 +130,10 @@ uv run python examples/10-vulnerable-agent/main.py
 ```
 
 See the full [examples catalog](https://github.com/taoq-ai/ziran/tree/main/examples).
+
+!!! tip "18 examples available"
+
+    From static analysis and policy engines to multi-agent scanning, adaptive campaigns, and streaming — all runnable out of the box.
 
 ## Understanding Results
 
@@ -146,6 +175,9 @@ open reports/campaign_*_report.html
 |------|-------|
 | Understand how multi-phase scanning works | [Trust Exploitation Methodology](concepts/romance-scan.md) |
 | Learn about tool chain analysis | [Tool Chain Analysis](concepts/tool-chains.md) |
+| Scan multi-agent systems | [Multi-Agent Coordination](concepts/multi-agent.md) |
+| Use adaptive campaigns | [Adaptive Campaigns](concepts/adaptive-campaigns.md) |
+| Enable real-time streaming | [Streaming Support](concepts/streaming.md) |
 | Scan remote agents over HTTPS | [Remote Agent Scanning](guides/remote-agents.md) |
 | Set up CI/CD quality gates | [CI/CD Integration](guides/cicd-integration.md) |
 | Scan source code without running agents | [Static Analysis](guides/static-analysis.md) |

--- a/docs/guides/scanning-agents.md
+++ b/docs/guides/scanning-agents.md
@@ -127,6 +127,29 @@ ziran scan --framework langchain --agent-path agent.py --no-stop-on-critical
 ziran scan --target target.yaml --concurrency 10
 ```
 
+### Campaign Strategy
+
+Choose how ZIRAN orchestrates scan phases:
+
+```bash
+# Fixed: run phases sequentially (default)
+ziran scan --target target.yaml --strategy fixed
+
+# Adaptive: rule-based phase ordering based on findings
+ziran scan --target target.yaml --strategy adaptive
+
+# LLM-Adaptive: LLM analyzes findings and plans the next phase
+ziran scan --target target.yaml --strategy llm-adaptive
+```
+
+### Streaming
+
+Enable real-time response monitoring via SSE or WebSocket:
+
+```bash
+ziran scan --target target.yaml --streaming
+```
+
 ### Custom Attack Vectors
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,9 @@ ZIRAN is the first open-source framework designed specifically for **agent secur
 
     - :link: **Tool Chain Analysis** — Automatically detects dangerous tool combinations across 30+ known patterns
     - :shield: **Multi-Phase Trust Exploitation** — Progressive campaigns that build trust before testing boundaries
+    - :people_holding_hands: **Multi-Agent Coordination** — Discover topologies and test cross-agent trust boundaries in supervisor, router, and peer-to-peer systems
+    - :brain: **Adaptive Campaigns** — Three execution strategies (fixed, rule-based adaptive, LLM-driven) that adjust attack plans based on findings
+    - :zap: **Streaming Support** — Real-time attack monitoring via SSE and WebSocket protocols
     - :globe_with_meridians: **Remote Agent Scanning** — Test any published agent over HTTPS (REST, OpenAI, MCP, A2A)
     - :world_map: **Knowledge Graph** — Every capability, relationship, and attack path tracked in a live graph
     - :bar_chart: **CI/CD Quality Gate** — Block deployments that fail security thresholds, with SARIF output
@@ -46,6 +49,9 @@ uv run python examples/10-vulnerable-agent/main.py
 | Agent-aware (tools + memory) | **Yes** | — | Partial | — | — |
 | Tool chain analysis | **Yes** | — | — | — | — |
 | Multi-phase campaigns | **Yes** | — | — | Partial | Yes |
+| Multi-agent coordination | **Yes** | — | — | — | — |
+| Adaptive campaigns | **Yes** | — | — | — | — |
+| Streaming (SSE/WebSocket) | **Yes** | — | — | — | — |
 | Knowledge graph tracking | **Yes** | — | — | — | — |
 | Remote agent scanning (HTTPS) | **Yes** | REST only | HTTP provider | Partial | — |
 | Multi-protocol (REST/OpenAI/MCP/A2A) | **Yes** | — | — | — | — |
@@ -56,5 +62,8 @@ uv run python examples/10-vulnerable-agent/main.py
 
 - :rocket: [Getting Started](getting-started.md) — Your first scan in 5 minutes
 - :brain: [Concepts](concepts/architecture.md) — Understand how ZIRAN works
+- :people_holding_hands: [Multi-Agent Scanning](concepts/multi-agent.md) — Test coordinated agent systems
+- :zap: [Streaming](concepts/streaming.md) — Real-time attack monitoring
+- :dart: [Adaptive Campaigns](concepts/adaptive-campaigns.md) — Intelligent attack strategies
 - :books: [Scanning Agents](guides/scanning-agents.md) — Scan your own agents
-- :test_tube: [Examples](https://github.com/taoq-ai/ziran/tree/main/examples) — 15 runnable examples from basic to advanced
+- :test_tube: [Examples](https://github.com/taoq-ai/ziran/tree/main/examples) — 18 runnable examples from basic to advanced

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-ZIRAN provides 7 commands for scanning, reporting, and CI/CD integration.
+ZIRAN provides 8 commands for scanning, reporting, and CI/CD integration.
 
 ## Global Options
 
@@ -33,6 +33,12 @@ ziran scan [OPTIONS]
 | `--custom-attacks` | No | — | Directory with custom YAML attack vectors |
 | `--stop-on-critical` | No | `true` | Stop if critical vulnerability found |
 | `--concurrency` | No | `5` | Max concurrent attacks |
+| `--strategy` | No | `fixed` | Campaign strategy: `fixed`, `adaptive`, `llm-adaptive` |
+| `--streaming` | No | `false` | Enable real-time SSE/WebSocket response streaming |
+| `--llm-provider` | No | — | LLM provider for AI-powered features |
+| `--llm-model` | No | — | LLM model name (e.g. `gpt-4o`, `claude-sonnet-4-20250514`) |
+| `--attack-timeout` | No | `60` | Per-attack timeout in seconds |
+| `--phase-timeout` | No | `300` | Per-phase timeout in seconds |
 
 \* Either `--framework` + `--agent-path` (local) or `--target` (remote) is required.
 
@@ -48,6 +54,40 @@ ziran scan --target target.yaml
 # Full audit with custom vectors
 ziran scan --target target.yaml --coverage comprehensive \
   --custom-attacks ./my_attacks/ --concurrency 10
+
+# Adaptive campaign
+ziran scan --target target.yaml --strategy adaptive
+
+# LLM-driven adaptive with streaming
+ziran scan --target target.yaml --strategy llm-adaptive --streaming
+```
+
+---
+
+### `ziran multi-agent-scan`
+
+Scan a multi-agent system — discovers topology and runs cross-agent attacks.
+
+```
+ziran multi-agent-scan [OPTIONS]
+```
+
+| Option | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `--target` | Yes | — | YAML target config for the entry-point agent |
+| `--coverage` | No | `standard` | Coverage level: `essential`, `standard`, `comprehensive` |
+| `--concurrency` | No | `5` | Max concurrent attacks |
+| `--skip-individual` | No | `false` | Skip individual agent scans |
+| `--output`, `-o` | No | `ziran_results` | Output directory |
+
+**Examples:**
+
+```bash
+# Scan a multi-agent system
+ziran multi-agent-scan --target target.yaml
+
+# Full coverage, skip individual scans
+ziran multi-agent-scan --target target.yaml --coverage comprehensive --skip-individual
 ```
 
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,9 @@ nav:
     - Detection Pipeline: concepts/detection-pipeline.md
     - OWASP Mapping: concepts/owasp-mapping.md
     - Architecture: concepts/architecture.md
+    - Multi-Agent Coordination: concepts/multi-agent.md
+    - Adaptive Campaigns: concepts/adaptive-campaigns.md
+    - Streaming: concepts/streaming.md
   - Guides:
     - Scanning Agents: guides/scanning-agents.md
     - Remote Agents: guides/remote-agents.md


### PR DESCRIPTION
- README: add streaming, multi-agent, adaptive campaigns to comparison table and CLI examples
- Getting Started: add streaming extra, strategy/streaming CLI options, multi-agent scan section
- Architecture: update diagram with multi-agent, streaming, strategy components
- Scanning Agents: add campaign strategy and streaming sections
- CLI Reference: add multi-agent-scan command and new scan options
- Index: update capabilities, comparison table, and next steps
- Roadmap: mark v0.4 and v0.5 as released, add v0.6 Pentesting Agent, v0.7 Remediation Engine, v0.8 MCP Server Mode
- New concept docs: multi-agent coordination, adaptive campaigns, streaming
- mkdocs.yml: add nav entries for 3 new concept pages
