### PR TITLE
docs: reposition ZIRAN and reshape roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,39 +22,52 @@
 
 ## Why ZIRAN?
 
-Most security tools test the **LLM** (prompt injection, jailbreaks) or the **web app** (XSS, SQLi).
-ZIRAN tests the **AI agent** — the system that wields tools, retains memory, and chains reasoning.
-That's a fundamentally different attack surface.
+Most security tools test individual prompts or tools in isolation. ZIRAN discovers how tool **combinations** create attack paths — an agent with `read_file` and `http_request` has a critical data exfiltration vulnerability, even if neither tool is dangerous alone.
 
-| Capability | ZIRAN | [Garak](https://github.com/NVIDIA/garak) | [Promptfoo](https://github.com/promptfoo/promptfoo) | [PyRIT](https://github.com/Azure/PyRIT) | [Shannon](https://github.com/KeygraphHQ/shannon) |
-|---|:---:|:---:|:---:|:---:|:---:|
-| Agent-aware (tools + memory) | **Yes** | — | Partial | — | — |
-| Tool chain analysis | **Yes** | — | — | — | — |
-| Multi-phase campaigns | **Yes** | — | — | Partial | Yes |
-| Multi-agent coordination | **Yes** | — | — | — | — |
-| Adaptive campaigns | **Yes** | — | — | — | — |
-| Autonomous pentesting agent | **Yes** | — | — | — | — |
-| Streaming (SSE/WebSocket) | **Yes** | — | — | — | — |
-| Knowledge graph tracking | **Yes** | — | — | — | — |
-| Remote agent scanning (HTTPS) | **Yes** | REST only | HTTP provider | Partial | — |
-| Multi-protocol (REST/OpenAI/MCP/A2A) | **Yes** | — | — | — | — |
-| A2A protocol support | **Yes** | — | — | — | — |
-| Protocol auto-detection | **Yes** | — | — | — | — |
-| CI/CD quality gate | **Yes** | — | Yes | — | Pro |
-| Open source | Apache-2.0 | Apache-2.0 | MIT | MIT | AGPL-3.0 |
+| Capability | ZIRAN | [Promptfoo](https://github.com/promptfoo/promptfoo) | [Invariant](https://invariantlabs.ai/) (Snyk) | [Garak](https://github.com/NVIDIA/garak) | [PyRIT](https://github.com/Azure/PyRIT) | [Inspect AI](https://github.com/UKGovernmentBEIS/inspect_ai) |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| Tool chain discovery (graph-based) | **Yes** | — | Policy-based | — | — | — |
+| Side-effect detection (execution-level) | **Yes** | — | Trace-based | — | — | Sandbox |
+| Multi-phase campaigns w/ graph feedback | **Yes** | Turn-level | Flow analysis | — | Composable | Multi-turn |
+| Autonomous pentesting agent | **Yes** | — | — | — | — | — |
+| Multi-agent coordination | **Yes** | — | — | — | — | — |
+| Knowledge graph tracking | **Yes** | — | Policy lang. | — | — | — |
+| Agent-aware (tools + memory) | **Yes** | Partial | **Yes** | — | — | Partial |
+| A2A protocol support | **Yes** | — | — | — | — | — |
+| MCP protocol support | **Yes** | Partial | **Yes** | — | — | — |
+| Encoding/obfuscation attacks | — | **Yes** (12+) | — | — | — | — |
+| Industry compliance plugins | — | **Yes** (46) | — | — | — | — |
+| Streaming (SSE/WebSocket) | **Yes** | — | — | — | — | — |
+| CI/CD quality gate | **Yes** | **Yes** | — | — | — | — |
+| Open source | Apache-2.0 | MIT | Partial | Apache-2.0 | MIT | MIT |
 
 **Key differentiators:**
 
-- **Tool Chain Analysis** — Detects dangerous tool combinations (`read_file` → `http_request` = data exfiltration). No other tool does this.
-- **Multi-Phase Trust Exploitation** — Progressive campaigns that build trust before testing boundaries, like a real attacker.
-- **Multi-Agent Coordination** — Discover topologies (supervisor, router, peer-to-peer) and test cross-agent trust boundaries and delegation patterns.
-- **Adaptive Campaigns** — Three execution strategies — fixed, rule-based adaptive, and LLM-driven — that adjust attack plans in real-time based on knowledge graph state.
-- **Streaming Support** — Real-time attack monitoring via SSE and WebSocket protocols for long-running agent responses.
-- **Knowledge Graph** — Every discovered capability, relationship, and attack path is tracked in a live graph.
-- **Remote Agent Scanning** — Test any published agent over HTTPS with YAML-driven target configuration. Supports REST, OpenAI-compatible, MCP, and A2A protocols with automatic detection.
-- **A2A Protocol Support** — First security tool to test [Agent-to-Agent](https://google.github.io/A2A/) agents, including Agent Card discovery, task lifecycle attacks, and multi-turn manipulation.
+- **Tool Chain Discovery** — Automatically detects dangerous tool combinations via NetworkX graph analysis (`read_file` → `http_request` = data exfiltration). Discovery-based, not policy-based — finds what you didn't know to look for.
+- **Side-Effect Detection** — Catches when agents refuse in text but execute dangerous tools anyway. Priority-based conflict resolution between detectors gives execution-level visibility that text-only evaluation misses.
+- **Multi-Phase Campaigns with Knowledge Graph Feedback** — 8-phase trust exploitation where each phase updates a live knowledge graph, and results from phase N inform attack selection in phase N+1.
 - **Autonomous Pentesting Agent** — An LLM-driven agent that plans, executes, and adapts attack campaigns autonomously, with finding deduplication and interactive red-team mode.
-- **Framework Agnostic** — LangChain, CrewAI, MCP, remote HTTPS agents, or [write your own adapter](examples/08-custom-adapter/).
+- **Multi-Agent Coordination** — Discovers topologies (supervisor, router, peer-to-peer) and tests cross-agent trust boundaries and delegation patterns.
+- **A2A + MCP Protocol Depth** — First security tool to test [Agent-to-Agent](https://google.github.io/A2A/) agents, including Agent Card discovery, task lifecycle attacks, and multi-turn manipulation.
+- **Framework Agnostic** — LangChain, CrewAI, Bedrock, MCP, browser-based chat UIs, remote HTTPS agents, or [write your own adapter](examples/08-custom-adapter/).
+
+### What ZIRAN Is / What ZIRAN Is Not
+
+**ZIRAN is** an agent security scanner that discovers dangerous tool compositions via graph analysis, detects execution-level side effects, and runs multi-phase campaigns that model real attacker behavior.
+
+**ZIRAN is not:**
+
+- An LLM safety/alignment tool — for prompt injection breadth, jailbreak templates, encoding attacks, and compliance testing, use [Promptfoo](https://github.com/promptfoo/promptfoo) or [Garak](https://github.com/NVIDIA/garak)
+- A runtime guardrail — for real-time input/output protection, use [NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails), [Lakera Guard](https://www.lakera.ai/), or [LLM Guard](https://github.com/protectai/llm-guard)
+- A general-purpose eval framework — for model evaluation and benchmarking, use [Inspect AI](https://github.com/UKGovernmentBEIS/inspect_ai) or [Deepeval](https://github.com/confident-ai/deepeval)
+
+### Works With
+
+ZIRAN is complementary to other tools in the AI security ecosystem:
+
+- **[Promptfoo](https://github.com/promptfoo/promptfoo)** for attack breadth (encoding strategies, jailbreak templates, compliance plugins) + **ZIRAN** for agent depth (tool chains, side-effects, campaigns)
+- **[Garak](https://github.com/NVIDIA/garak)** for LLM-layer vulnerability scanning + **ZIRAN** for agent-layer tool chain analysis
+- **[NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails)** / **[Lakera](https://www.lakera.ai/)** for runtime protection + **ZIRAN** for pre-deployment testing
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -2,9 +2,25 @@
 
 ## What is this project?
 
-ZIRAN is an open-source security testing framework for AI agents. It tests agents with tools, memory, and multi-step reasoning — not just LLMs. It runs multi-phase trust exploitation campaigns, analyzes dangerous tool chain combinations, and tracks attack paths via knowledge graphs.
+ZIRAN is an open-source security testing framework for AI agents. It discovers dangerous tool chain compositions via knowledge graph analysis, detects execution-level side effects (not just text output), and runs multi-phase trust exploitation campaigns that model real attacker behavior.
 
 Built by [TaoQ AI](https://www.taoq.ai). Licensed under Apache-2.0.
+
+## Positioning — what ZIRAN is and is not
+
+**ZIRAN IS:**
+- An agent security scanner that discovers dangerous tool compositions via graph analysis (e.g., `read_file` + `http_request` = data exfiltration)
+- An execution-level detector that catches when agents refuse in text but execute dangerous tools anyway
+- A multi-phase campaign orchestrator with knowledge graph feedback across phases
+- An autonomous pentesting agent that plans, executes, and adapts attack campaigns
+
+**ZIRAN IS NOT:**
+- An LLM safety/alignment tool (for jailbreak breadth, encoding attacks, and compliance plugins → Promptfoo or Garak)
+- A runtime guardrail (for real-time input/output protection → NeMo Guardrails, Lakera Guard, or LLM Guard)
+- A general-purpose eval framework (for model evaluation and benchmarking → Inspect AI or Deepeval)
+- A pentesting tool for web apps or networks (for AI-driven pentesting of infrastructure → Shannon or PentestGPT)
+
+When contributing, keep features aligned with agent security testing. Don't add LLM alignment checks, compliance plugins, or runtime guardrail features — those belong in complementary tools.
 
 ## Tech stack
 

--- a/docs/community/roadmap.md
+++ b/docs/community/roadmap.md
@@ -52,23 +52,38 @@
 - :white_check_mark: **327 multi-agent attack vectors** — Cross-agent prompt injection, delegation chain manipulation, shared memory poisoning
 - :white_check_mark: **18 runnable examples** — Including multi-agent, streaming, and adaptive campaign demos
 
-## Next: v0.6 — Pentesting Agent
+### v0.6 — Pentesting Agent
 
-The flagship feature — an autonomous AI agent that performs penetration testing:
+- :white_check_mark: **Autonomous pentesting agent** — An LLM-powered agent that plans, executes, and adapts attack campaigns with minimal human intervention
+- :white_check_mark: **Attack chain reasoning** — The agent reasons about discovered vulnerabilities to chain multi-step exploits
+- :white_check_mark: **Interactive red-team mode** — Collaborate with the pentesting agent in a conversational interface
+- :white_check_mark: **Finding deduplication** — Intelligent merging of related findings across automated and agent-driven scans
 
-- [x] **Autonomous pentesting agent** — An LLM-powered agent that plans, executes, and adapts attack campaigns with minimal human intervention
-- [x] **Attack chain reasoning** — The agent reasons about discovered vulnerabilities to chain multi-step exploits
-- [x] **Interactive red-team mode** — Collaborate with the pentesting agent in a conversational interface
-- [x] **Finding deduplication** — Intelligent merging of related findings across automated and agent-driven scans
+### v0.7 — Browser Scanning
 
-## v0.7 — Remediation Engine
+- :white_check_mark: **Browser-based agent scanning** — Headless Playwright adapter for testing agents exposed via web chat UIs
+- :white_check_mark: **Network interception** — Primary extraction via intercepted API calls (WebSocket, SSE, HTTP)
+- :white_check_mark: **DOM fallback** — Secondary extraction from rendered page content when network interception is unavailable
+
+## Next: v0.8 — Depth & Ecosystem
+
+Deepen ZIRAN's unique strengths and build bridges to complementary tools:
+
+- [ ] **Expanded tool chain patterns** — Grow from 32 to 100+ dangerous patterns (framework-specific chains, MCP tool combinations, A2A flows)
+- [ ] **Encoding/obfuscation strategies** — Base64, leetspeak, ROT13, homoglyph attack variants (closing the gap vs Promptfoo)
+- [ ] **Multi-turn jailbreak tactics** — Crescendo-style escalation within campaign phases
+- [ ] **BOLA/BFLA authorization testing** — Broken Object/Function Level Authorization testing for agents with user-scoped data
+- [ ] **Promptfoo provider bridge** — `ziran-promptfoo` package: use ZIRAN as an analysis backend for Promptfoo's attack generation
+- [ ] **OpenTelemetry trace integration** — Complement side-effect detection with full observability traces
+
+## v0.9 — Remediation Engine
 
 - [ ] **Auto-generated fix suggestions** — Concrete code patches and guardrail configurations for discovered vulnerabilities
 - [ ] **Guardrail templates** — Pre-built guardrail configurations for common agent frameworks
 - [ ] **Remediation validation** — Re-scan after applying fixes to verify remediation effectiveness
 - [ ] **Security policy generator** — Generate policy files from scan results
 
-## v0.8 — MCP Server Mode
+## v0.10 — MCP Server Mode
 
 - [ ] **ZIRAN as an MCP server** — Expose scanning capabilities via the Model Context Protocol, enabling any MCP-compatible client to trigger scans
 - [ ] **Tool-based scanning interface** — Scan agents, browse results, and manage campaigns through MCP tool calls
@@ -77,9 +92,11 @@ The flagship feature — an autonomous AI agent that performs penetration testin
 
 ## Future
 
-- [ ] **Cloud dashboard** — Centralized vulnerability management across agents
+- [ ] **Custom chain rule language** — User-defined tool chain patterns complementing ZIRAN's auto-discovery
+- [ ] **Community chain patterns** — Crowdsourced dangerous tool chain submissions (like Skill CVEs but for tool compositions)
+- [ ] **AgentSecBench** — Purpose-built benchmark: vulnerable agents with known tool chain vulnerabilities, demonstrating what ZIRAN catches that other tools miss
+- [ ] **Tool chain methodology paper** — Publish the discovery-based approach as research
 - [ ] **Community CVE portal** — Web-based CVE submission and search
-- [ ] **IDE extension** — VS Code extension for inline security feedback
 - [ ] **Agent benchmarking** — Comparative security scoring across agent versions
 - [ ] **Compliance reports** — SOC 2, ISO 27001, and NIST AI RMF report templates
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,14 +6,13 @@
 
 ## The Problem
 
-Traditional security tools test the **LLM** (prompt injection, jailbreaks) or the **web app** (XSS, SQLi). But modern AI agents have a fundamentally different attack surface:
+Most security tools test individual prompts or tools in isolation. But AI agents have a fundamentally different attack surface — **tool combinations**:
 
-- **Tools** that read files, query databases, and make HTTP requests
-- **Memory** that persists across conversations
-- **Multi-step reasoning** that chains tool calls together
-- **Protocol endpoints** (REST, OpenAI, MCP, A2A) exposed over HTTPS
+- An agent with `read_file` and `http_request` has a **critical data exfiltration vulnerability** — even if neither tool is dangerous alone
+- An agent that says "I can't do that" but **executes the tool anyway** will pass text-based evaluation but fail in production
+- Vulnerabilities that only emerge after **building trust across multiple interactions** are invisible to single-pass testing
 
-An agent with `read_file` and `http_request` has a **critical data exfiltration vulnerability** — even if neither tool is dangerous alone. No existing tool catches this.
+ZIRAN discovers these composition-level risks through knowledge graph analysis, execution-level detection, and multi-phase campaigns.
 
 ## What ZIRAN Does
 
@@ -44,19 +43,22 @@ uv run python examples/10-vulnerable-agent/main.py
 
 ## How It Compares
 
-| Capability | ZIRAN | Garak | Promptfoo | PyRIT | Shannon |
-|---|:---:|:---:|:---:|:---:|:---:|
-| Agent-aware (tools + memory) | **Yes** | — | Partial | — | — |
-| Tool chain analysis | **Yes** | — | — | — | — |
-| Multi-phase campaigns | **Yes** | — | — | Partial | Yes |
-| Multi-agent coordination | **Yes** | — | — | — | — |
-| Adaptive campaigns | **Yes** | — | — | — | — |
-| Streaming (SSE/WebSocket) | **Yes** | — | — | — | — |
-| Knowledge graph tracking | **Yes** | — | — | — | — |
-| Remote agent scanning (HTTPS) | **Yes** | REST only | HTTP provider | Partial | — |
-| Multi-protocol (REST/OpenAI/MCP/A2A) | **Yes** | — | — | — | — |
-| A2A protocol support | **Yes** | — | — | — | — |
-| CI/CD quality gate | **Yes** | — | Yes | — | Pro |
+| Capability | ZIRAN | Promptfoo | Invariant (Snyk) | Garak | PyRIT | Inspect AI |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| Tool chain discovery (graph-based) | **Yes** | — | Policy-based | — | — | — |
+| Side-effect detection (execution-level) | **Yes** | — | Trace-based | — | — | Sandbox |
+| Multi-phase campaigns w/ graph feedback | **Yes** | Turn-level | Flow analysis | — | Composable | Multi-turn |
+| Autonomous pentesting agent | **Yes** | — | — | — | — | — |
+| Multi-agent coordination | **Yes** | — | — | — | — | — |
+| Agent-aware (tools + memory) | **Yes** | Partial | **Yes** | — | — | Partial |
+| A2A + MCP protocol support | **Yes** | MCP only | MCP only | — | — | — |
+| Encoding/obfuscation attacks | — | **Yes** (12+) | — | — | — | — |
+| Industry compliance plugins | — | **Yes** (46) | — | — | — | — |
+| CI/CD quality gate | **Yes** | **Yes** | — | — | — | — |
+
+!!! info "What ZIRAN Is Not"
+
+    ZIRAN focuses on agent-level security testing. For **LLM safety/alignment** (jailbreaks, compliance), use [Promptfoo](https://github.com/promptfoo/promptfoo) or [Garak](https://github.com/NVIDIA/garak). For **runtime guardrails**, use [NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails) or [Lakera Guard](https://www.lakera.ai/). For **model evaluation**, use [Inspect AI](https://github.com/UKGovernmentBEIS/inspect_ai) or [Deepeval](https://github.com/confident-ai/deepeval). ZIRAN is complementary to all of these.
 
 ## Next Steps
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: ZIRAN — AI Agent Security Testing
 site_url: https://taoq-ai.github.io/ziran/
-site_description: Test AI agents for vulnerabilities using multi-phase trust exploitation methodology and knowledge graphs.
+site_description: Discover dangerous tool chain compositions in AI agents using knowledge graph analysis, multi-phase campaigns, and autonomous pentesting.
 site_author: TaoQ AI
 
 repo_name: taoq-ai/ziran

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ziran"
 dynamic = ["version"]
-description = "AI Agent Security Testing Framework — multi-phase scan campaigns with knowledge graph tracking"
+description = "AI Agent Security Testing — discovers dangerous tool chain compositions via knowledge graph analysis"
 readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## Summary

- **Repositioned** ZIRAN's public-facing content based on a competitive gap analysis against 20+ tools (Promptfoo, Invariant/Snyk, Garak, PyRIT, Inspect AI, NeMo Guardrails, Lakera, etc.)
- **Updated comparison table** in README and docs — now includes 6 tools with honest, accurate marks (e.g., Promptfoo marked "Partial" for agent-aware/MCP, Invariant marked "Policy-based" for tool chains)
- **Added "What ZIRAN Is / Is Not"** section naming specific alternative tools for use cases outside ZIRAN's scope
- **Added "Works With"** section showing complementary positioning with Promptfoo, Garak, NeMo Guardrails/Lakera
- **Reshaped roadmap** — v0.6/v0.7 marked as released; new v0.8 "Depth & Ecosystem" focused on moat-deepening (expanded chain patterns, encoding strategies, BOLA/BFLA, Promptfoo bridge, OpenTelemetry); remediation bumped to v0.9, MCP server to v0.10
- **Updated SKILL.md** with positioning guidance for AI coding agents
- **Updated metadata** in pyproject.toml and mkdocs.yml to emphasize tool chain discovery

## Test plan

- [x] `mkdocs build` succeeds with no errors
- [ ] Review comparison table accuracy against current tool capabilities
- [ ] Review roadmap version sequencing and item prioritization
- [ ] Read full README narrative flow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)