### PR TITLE
feat: add business impact categorization to findings

### DIFF
--- a/tests/unit/test_business_impact.py
+++ b/tests/unit/test_business_impact.py
@@ -1,0 +1,64 @@
+"""Unit tests for business impact categorization."""
+
+from __future__ import annotations
+
+from ziran.domain.entities.attack import (
+    AttackCategory,
+    BusinessImpact,
+    get_business_impacts,
+)
+
+SEVERITIES = ("low", "medium", "high", "critical")
+
+
+class TestGetBusinessImpacts:
+    """Tests for the get_business_impacts mapping function."""
+
+    def test_all_categories_have_at_least_one_impact(self) -> None:
+        for cat in AttackCategory:
+            for sev in SEVERITIES:
+                impacts = get_business_impacts(cat, sev)
+                assert len(impacts) >= 1, f"{cat}/{sev} has no impacts"
+
+    def test_critical_has_at_least_as_many_as_low(self) -> None:
+        for cat in AttackCategory:
+            low = get_business_impacts(cat, "low")
+            critical = get_business_impacts(cat, "critical")
+            assert len(critical) >= len(low), (
+                f"{cat}: critical ({len(critical)}) < low ({len(low)})"
+            )
+
+    def test_returns_business_impact_enums(self) -> None:
+        impacts = get_business_impacts(AttackCategory.PROMPT_INJECTION, "medium")
+        for imp in impacts:
+            assert isinstance(imp, BusinessImpact)
+
+    def test_data_exfiltration_includes_privacy(self) -> None:
+        impacts = get_business_impacts(AttackCategory.DATA_EXFILTRATION, "high")
+        assert BusinessImpact.PRIVACY_VIOLATION in impacts
+        assert BusinessImpact.FINANCIAL_LOSS in impacts
+
+    def test_prompt_injection_critical_adds_system_compromise(self) -> None:
+        low = get_business_impacts(AttackCategory.PROMPT_INJECTION, "low")
+        crit = get_business_impacts(AttackCategory.PROMPT_INJECTION, "critical")
+        assert BusinessImpact.SYSTEM_COMPROMISE not in low
+        assert BusinessImpact.SYSTEM_COMPROMISE in crit
+
+    def test_authorization_bypass_high_escalates(self) -> None:
+        high = get_business_impacts(AttackCategory.AUTHORIZATION_BYPASS, "high")
+        assert BusinessImpact.FINANCIAL_LOSS in high
+        assert BusinessImpact.SYSTEM_COMPROMISE in high
+
+    def test_memory_poisoning_includes_misinformation(self) -> None:
+        impacts = get_business_impacts(AttackCategory.MEMORY_POISONING, "medium")
+        assert BusinessImpact.MISINFORMATION in impacts
+
+    def test_system_prompt_extraction_includes_property_loss(self) -> None:
+        impacts = get_business_impacts(AttackCategory.SYSTEM_PROMPT_EXTRACTION, "low")
+        assert BusinessImpact.PROPERTY_LOSS in impacts
+
+    def test_no_duplicates(self) -> None:
+        for cat in AttackCategory:
+            for sev in SEVERITIES:
+                impacts = get_business_impacts(cat, sev)
+                assert len(impacts) == len(set(impacts)), f"{cat}/{sev} has duplicate impacts"

--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -9,6 +9,7 @@ from ziran.domain.entities.attack import (
     AttackPrompt,
     AttackResult,
     AttackVector,
+    BusinessImpact,
 )
 from ziran.domain.entities.capability import (
     AgentCapability,
@@ -394,3 +395,25 @@ class TestQualityScore:
             successful=False,
         )
         assert result.quality_score is None
+
+    def test_attack_result_default_empty_business_impact(self) -> None:
+        result = AttackResult(
+            vector_id="test",
+            vector_name="Test",
+            category=AttackCategory.PROMPT_INJECTION,
+            severity="high",
+            successful=False,
+        )
+        assert result.business_impact == []
+
+    def test_attack_result_with_business_impact(self) -> None:
+        result = AttackResult(
+            vector_id="test",
+            vector_name="Test",
+            category=AttackCategory.PROMPT_INJECTION,
+            severity="high",
+            successful=True,
+            business_impact=[BusinessImpact.UNAUTHORIZED_ACTIONS, BusinessImpact.REPUTATION_DAMAGE],
+        )
+        assert BusinessImpact.UNAUTHORIZED_ACTIONS in result.business_impact
+        assert len(result.business_impact) == 2

--- a/tests/unit/test_reports.py
+++ b/tests/unit/test_reports.py
@@ -77,6 +77,11 @@ def _campaign_data(*, vulnerable: bool = False) -> dict[str, Any]:
                 "detection_confidence": 0.95,
                 "detection_method": "indicator",
                 "owasp_mapping": ["LLM01"],
+                "business_impact": [
+                    "unauthorized_actions",
+                    "reputation_damage",
+                    "system_compromise",
+                ],
             }
         ]
         base["token_usage"] = {"prompt_tokens": 100, "completion_tokens": 200, "total_tokens": 300}
@@ -164,6 +169,21 @@ class TestReportGenerator:
         out = gen.save_markdown(result)
         content = out.read_text()
         assert "Something went wrong" in content
+
+    def test_markdown_business_impact_section(self, tmp_path: Path) -> None:
+        gen = ReportGenerator(output_dir=tmp_path)
+        result = _make_result(vulnerable=True)
+        out = gen.save_markdown(result)
+        content = out.read_text()
+        assert "Business Impact Summary" in content
+        assert "unauthorized_actions" in content
+
+    def test_markdown_no_business_impact_when_clean(self, tmp_path: Path) -> None:
+        gen = ReportGenerator(output_dir=tmp_path)
+        result = _make_result(vulnerable=False)
+        out = gen.save_markdown(result)
+        content = out.read_text()
+        assert "Business Impact Summary" not in content
 
     def test_markdown_many_critical_paths(self, tmp_path: Path) -> None:
         gen = ReportGenerator(output_dir=tmp_path)

--- a/ziran/application/agent_scanner/scanner.py
+++ b/ziran/application/agent_scanner/scanner.py
@@ -34,7 +34,13 @@ from ziran.application.strategies.protocol import (
     CampaignStrategy,
     PhaseDecision,
 )
-from ziran.domain.entities.attack import AttackPrompt, AttackResult, AttackVector, TokenUsage
+from ziran.domain.entities.attack import (
+    AttackPrompt,
+    AttackResult,
+    AttackVector,
+    TokenUsage,
+    get_business_impacts,
+)
 from ziran.domain.entities.phase import (
     CORE_PHASES,
     CampaignResult,
@@ -769,6 +775,7 @@ class AgentScanner:
                 successful=False,
                 error="No prompts defined for this attack vector",
                 owasp_mapping=attack.owasp_mapping,
+                business_impact=get_business_impacts(attack.category, attack.severity),
             )
 
         # Delegate to TacticExecutor for multi-turn tactics
@@ -876,6 +883,7 @@ class AgentScanner:
                         prompt_used=rendered_prompt,
                         encoding_applied=encoding_used,
                         owasp_mapping=attack.owasp_mapping,
+                        business_impact=get_business_impacts(attack.category, attack.severity),
                         quality_score=quality,
                         token_usage=attack_tokens,
                     )
@@ -900,6 +908,7 @@ class AgentScanner:
             agent_response=last_response_content,
             prompt_used=last_prompt_used,
             owasp_mapping=attack.owasp_mapping,
+            business_impact=get_business_impacts(attack.category, attack.severity),
             token_usage=attack_tokens,
         )
 

--- a/ziran/domain/entities/attack.py
+++ b/ziran/domain/entities/attack.py
@@ -97,7 +97,121 @@ OWASP_LLM_DESCRIPTIONS: dict[OwaspLlmCategory, str] = {
 }
 
 
+class BusinessImpact(StrEnum):
+    """Business impact categories aligned with Agent-SafetyBench taxonomy."""
+
+    FINANCIAL_LOSS = "financial_loss"
+    REPUTATION_DAMAGE = "reputation_damage"
+    PROPERTY_LOSS = "property_loss"
+    PRIVACY_VIOLATION = "privacy_violation"
+    UNAUTHORIZED_ACTIONS = "unauthorized_actions"
+    SYSTEM_COMPROMISE = "system_compromise"
+    MISINFORMATION = "misinformation"
+
+
+#: Human-readable descriptions for each business impact category.
+BUSINESS_IMPACT_DESCRIPTIONS: dict[BusinessImpact, str] = {
+    BusinessImpact.FINANCIAL_LOSS: "Financial Loss",
+    BusinessImpact.REPUTATION_DAMAGE: "Reputation Damage",
+    BusinessImpact.PROPERTY_LOSS: "Property Loss",
+    BusinessImpact.PRIVACY_VIOLATION: "Privacy Violation",
+    BusinessImpact.UNAUTHORIZED_ACTIONS: "Unauthorized Actions",
+    BusinessImpact.SYSTEM_COMPROMISE: "System Compromise",
+    BusinessImpact.MISINFORMATION: "Misinformation",
+}
+
+
 Severity = Literal["low", "medium", "high", "critical"]
+
+
+# ── Business impact mapping ──────────────────────────────────────────
+
+#: Base impacts for each attack category (always included).
+_BASE_IMPACTS: dict[AttackCategory, list[BusinessImpact]] = {
+    AttackCategory.PROMPT_INJECTION: [
+        BusinessImpact.UNAUTHORIZED_ACTIONS,
+        BusinessImpact.REPUTATION_DAMAGE,
+    ],
+    AttackCategory.TOOL_MANIPULATION: [
+        BusinessImpact.UNAUTHORIZED_ACTIONS,
+        BusinessImpact.SYSTEM_COMPROMISE,
+    ],
+    AttackCategory.PRIVILEGE_ESCALATION: [
+        BusinessImpact.UNAUTHORIZED_ACTIONS,
+        BusinessImpact.SYSTEM_COMPROMISE,
+    ],
+    AttackCategory.DATA_EXFILTRATION: [
+        BusinessImpact.PRIVACY_VIOLATION,
+        BusinessImpact.FINANCIAL_LOSS,
+        BusinessImpact.REPUTATION_DAMAGE,
+    ],
+    AttackCategory.SYSTEM_PROMPT_EXTRACTION: [
+        BusinessImpact.PROPERTY_LOSS,
+        BusinessImpact.REPUTATION_DAMAGE,
+    ],
+    AttackCategory.INDIRECT_INJECTION: [
+        BusinessImpact.UNAUTHORIZED_ACTIONS,
+        BusinessImpact.REPUTATION_DAMAGE,
+    ],
+    AttackCategory.MEMORY_POISONING: [
+        BusinessImpact.MISINFORMATION,
+        BusinessImpact.REPUTATION_DAMAGE,
+    ],
+    AttackCategory.CHAIN_OF_THOUGHT_MANIPULATION: [
+        BusinessImpact.MISINFORMATION,
+        BusinessImpact.REPUTATION_DAMAGE,
+    ],
+    AttackCategory.MULTI_AGENT: [
+        BusinessImpact.SYSTEM_COMPROMISE,
+        BusinessImpact.UNAUTHORIZED_ACTIONS,
+    ],
+    AttackCategory.AUTHORIZATION_BYPASS: [
+        BusinessImpact.UNAUTHORIZED_ACTIONS,
+        BusinessImpact.PRIVACY_VIOLATION,
+    ],
+}
+
+#: Extra impacts added when severity is critical (or critical/high for some).
+_CRITICAL_EXTRAS: dict[AttackCategory, list[BusinessImpact]] = {
+    AttackCategory.PROMPT_INJECTION: [BusinessImpact.SYSTEM_COMPROMISE],
+    AttackCategory.TOOL_MANIPULATION: [BusinessImpact.FINANCIAL_LOSS],
+    AttackCategory.PRIVILEGE_ESCALATION: [BusinessImpact.FINANCIAL_LOSS],
+    AttackCategory.INDIRECT_INJECTION: [BusinessImpact.FINANCIAL_LOSS],
+    AttackCategory.MEMORY_POISONING: [BusinessImpact.UNAUTHORIZED_ACTIONS],
+    AttackCategory.MULTI_AGENT: [BusinessImpact.FINANCIAL_LOSS],
+    AttackCategory.AUTHORIZATION_BYPASS: [
+        BusinessImpact.FINANCIAL_LOSS,
+        BusinessImpact.SYSTEM_COMPROMISE,
+    ],
+}
+
+#: Categories where "high" severity also triggers critical extras.
+_HIGH_ALSO_ESCALATES: frozenset[AttackCategory] = frozenset(
+    {
+        AttackCategory.PRIVILEGE_ESCALATION,
+        AttackCategory.AUTHORIZATION_BYPASS,
+    }
+)
+
+
+def get_business_impacts(
+    category: AttackCategory,
+    severity: Severity,
+) -> list[BusinessImpact]:
+    """Derive business impact categories from an attack category and severity.
+
+    Returns a deterministic list of :class:`BusinessImpact` values.  Higher
+    severity may add additional impacts on top of the base set.
+    """
+    impacts = list(_BASE_IMPACTS.get(category, []))
+
+    escalate = severity == "critical" or (severity == "high" and category in _HIGH_ALSO_ESCALATES)
+    if escalate:
+        for extra in _CRITICAL_EXTRAS.get(category, []):
+            if extra not in impacts:
+                impacts.append(extra)
+
+    return impacts
 
 
 class AttackPrompt(BaseModel):
@@ -195,6 +309,10 @@ class AttackResult(BaseModel):
     owasp_mapping: list[OwaspLlmCategory] = Field(
         default_factory=list,
         description="OWASP Top 10 for LLM Applications categories for this finding",
+    )
+    business_impact: list[BusinessImpact] = Field(
+        default_factory=list,
+        description="Business impact categories derived from attack category and severity",
     )
     quality_score: float | None = Field(
         default=None,

--- a/ziran/interfaces/cli/reports.py
+++ b/ziran/interfaces/cli/reports.py
@@ -11,7 +11,14 @@ from collections import Counter
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
-from ziran.domain.entities.attack import OWASP_LLM_DESCRIPTIONS, OwaspLlmCategory
+from ziran.domain.entities.attack import (
+    BUSINESS_IMPACT_DESCRIPTIONS,
+    OWASP_LLM_DESCRIPTIONS,
+    AttackCategory,
+    BusinessImpact,
+    OwaspLlmCategory,
+    get_business_impacts,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -221,6 +228,47 @@ class ReportGenerator:
                     status = "⚪ Not tested"
                     findings = "—"
                 lines.append(f"| {cat.value} | {desc} | {status} | {findings} |")
+            lines.append("")
+
+        # Business Impact Summary (successful findings only)
+        impact_counts: Counter[BusinessImpact] = Counter()
+        for ar in getattr(result, "attack_results", []):
+            successful = (
+                ar.get("successful") if isinstance(ar, dict) else getattr(ar, "successful", False)
+            )
+            if not successful:
+                continue
+            # Prefer stored business_impact; fall back to computing it
+            raw_impacts = (
+                ar.get("business_impact", [])
+                if isinstance(ar, dict)
+                else getattr(ar, "business_impact", [])
+            )
+            if raw_impacts:
+                impacts = [BusinessImpact(v) for v in raw_impacts]
+            else:
+                cat_val = (
+                    ar.get("category") if isinstance(ar, dict) else getattr(ar, "category", None)
+                )
+                sev_val = (
+                    ar.get("severity") if isinstance(ar, dict) else getattr(ar, "severity", None)
+                )
+                if cat_val and sev_val:
+                    impacts = get_business_impacts(AttackCategory(cat_val), sev_val)
+                else:
+                    impacts = []
+            for imp in impacts:
+                impact_counts[imp] += 1
+
+        if impact_counts:
+            lines.append("## Business Impact Summary")
+            lines.append("")
+            lines.append("| Impact Category | Description | Findings |")
+            lines.append("|-----------------|-------------|----------|")
+            for imp in BusinessImpact:
+                if imp in impact_counts:
+                    desc = BUSINESS_IMPACT_DESCRIPTIONS.get(imp, imp.value)
+                    lines.append(f"| {imp.value} | {desc} | {impact_counts[imp]} |")
             lines.append("")
 
         # Phase Results


### PR DESCRIPTION
## Summary

- Add `BusinessImpact` enum with 7 categories aligned with Agent-SafetyBench taxonomy (financial loss, reputation damage, property loss, privacy violation, unauthorized actions, system compromise, misinformation)
- Deterministic mapping from `(AttackCategory, severity)` derives impacts automatically -- higher severities add additional categories
- New "Business Impact Summary" section in Markdown reports showing impact counts for successful findings
- Backward-compatible: `business_impact` defaults to empty list on existing data, with fallback computation in reports

## Test plan

- [x] 9 mapping tests: all categories produce impacts, critical >= low, no duplicates, specific mappings verified
- [x] 2 report tests: section present when vulnerable, absent when clean
- [x] 2 entity tests: default empty list, explicit business_impact field
- [x] Lint, mypy, formatting all clean

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)