### PR TITLE
fix: handle JSONDecodeError in LLM adaptive strategy

### DIFF
--- a/ziran/application/strategies/llm_adaptive.py
+++ b/ziran/application/strategies/llm_adaptive.py
@@ -267,4 +267,8 @@ class LLMAdaptiveStrategy(AdaptiveStrategy):
                 lines = lines[:-1]
             content = "\n".join(lines)
 
-        return json.loads(content)
+        try:
+            return json.loads(content)
+        except json.JSONDecodeError:
+            logger.warning("Failed to parse LLM response as JSON: %s", content)
+            return {}


### PR DESCRIPTION
## Summary
- Wrap `json.loads()` in `_parse_json_response()` with a try-except for `json.JSONDecodeError`
- On failure, log a warning and return an empty dict so both callers degrade gracefully

Closes #64

## Test plan
- [x] All 1532 existing tests pass
- Malformed LLM responses now return `{}` instead of crashing the strategy