### PR TITLE
fix: remove dead code in side_effect detector

### DIFF
--- a/ziran/application/detectors/side_effect.py
+++ b/ziran/application/detectors/side_effect.py
@@ -92,7 +92,6 @@ class SideEffectDetector:
         critical_tools = [c for c in classifications if c["risk"] == "critical"]
         high_tools = [c for c in classifications if c["risk"] == "high"]
         medium_tools = [c for c in classifications if c["risk"] == "medium"]
-        [c for c in classifications if c["risk"] == "low"]
 
         matched_indicators = [f"{c['tool_name']} ({c['description']})" for c in classifications]
 


### PR DESCRIPTION
## Summary

- Remove unused list comprehension on line 95 of `side_effect.py` that filtered low-risk tool classifications but never assigned the result to a variable

Closes #71