### PR TITLE
feat: handle HTTP 429 rate limits with Retry-After header support

### DIFF
--- a/ziran/infrastructure/adapters/http_adapter.py
+++ b/ziran/infrastructure/adapters/http_adapter.py
@@ -392,7 +392,11 @@ class HttpAgentAdapter(BaseAgentAdapter):
     # ── Retry Logic ──────────────────────────────────────────────
 
     async def _send_with_retry(self, message: str, **kwargs: Any) -> dict[str, Any]:
-        """Send with configurable retry on transient failures."""
+        """Send with configurable retry on transient failures.
+
+        Respects the ``Retry-After`` header on 429 responses when available,
+        falling back to exponential backoff otherwise.
+        """
         if self._handler is None:
             raise RuntimeError("Handler not initialized — call initialize() first")
 
@@ -407,7 +411,7 @@ class HttpAgentAdapter(BaseAgentAdapter):
                 if exc.status_code and exc.status_code not in retry.retry_on:
                     raise
                 if attempt < retry.max_retries:
-                    wait = retry.backoff_factor * (2**attempt)
+                    wait = self._compute_retry_wait(exc, retry.backoff_factor, attempt)
                     logger.warning(
                         "Request failed (attempt %d/%d), retrying in %.1fs: %s",
                         attempt + 1,
@@ -420,6 +424,22 @@ class HttpAgentAdapter(BaseAgentAdapter):
         if last_error is None:
             raise RuntimeError("Retry loop exited without capturing an error")
         raise last_error
+
+    @staticmethod
+    def _compute_retry_wait(exc: ProtocolError, backoff_factor: float, attempt: int) -> float:
+        """Compute the wait time for a retry attempt.
+
+        Uses the ``Retry-After`` header value (in seconds) for 429 responses
+        when present, otherwise falls back to exponential backoff.
+        """
+        if exc.status_code == 429 and exc.headers:
+            retry_after = exc.headers.get("Retry-After") or exc.headers.get("retry-after")
+            if retry_after is not None:
+                try:
+                    return max(0.0, min(float(retry_after), 120.0))
+                except (ValueError, TypeError):
+                    pass
+        return float(backoff_factor * (2**attempt))
 
     # ── Probe-Based Discovery ────────────────────────────────────
 

--- a/ziran/infrastructure/adapters/protocols/__init__.py
+++ b/ziran/infrastructure/adapters/protocols/__init__.py
@@ -22,9 +22,16 @@ if TYPE_CHECKING:
 class ProtocolError(Exception):
     """Raised when a protocol-level error occurs."""
 
-    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> None:
         super().__init__(message)
         self.status_code = status_code
+        self.headers = headers
 
 
 class BaseProtocolHandler(ABC):

--- a/ziran/infrastructure/adapters/protocols/a2a_handler.py
+++ b/ziran/infrastructure/adapters/protocols/a2a_handler.py
@@ -202,7 +202,9 @@ class A2AProtocolHandler(BaseProtocolHandler):
             response.raise_for_status()
         except httpx.HTTPStatusError as exc:
             msg = f"Failed to fetch Agent Card: HTTP {exc.response.status_code}"
-            raise ProtocolError(msg, status_code=exc.response.status_code) from exc
+            raise ProtocolError(
+                msg, status_code=exc.response.status_code, headers=dict(exc.response.headers)
+            ) from exc
         except httpx.HTTPError as exc:
             msg = f"Failed to fetch Agent Card: {exc}"
             raise ProtocolError(msg) from exc
@@ -268,7 +270,9 @@ class A2AProtocolHandler(BaseProtocolHandler):
             response.raise_for_status()
         except httpx.HTTPStatusError as exc:
             msg = f"A2A SendMessage failed: HTTP {exc.response.status_code}"
-            raise ProtocolError(msg, status_code=exc.response.status_code) from exc
+            raise ProtocolError(
+                msg, status_code=exc.response.status_code, headers=dict(exc.response.headers)
+            ) from exc
         except httpx.HTTPError as exc:
             msg = f"A2A SendMessage failed: {exc}"
             raise ProtocolError(msg) from exc
@@ -298,7 +302,9 @@ class A2AProtocolHandler(BaseProtocolHandler):
             response.raise_for_status()
         except httpx.HTTPStatusError as exc:
             msg = f"A2A JSON-RPC SendMessage failed: HTTP {exc.response.status_code}"
-            raise ProtocolError(msg, status_code=exc.response.status_code) from exc
+            raise ProtocolError(
+                msg, status_code=exc.response.status_code, headers=dict(exc.response.headers)
+            ) from exc
         except httpx.HTTPError as exc:
             msg = f"A2A JSON-RPC SendMessage failed: {exc}"
             raise ProtocolError(msg) from exc

--- a/ziran/infrastructure/adapters/protocols/mcp_handler.py
+++ b/ziran/infrastructure/adapters/protocols/mcp_handler.py
@@ -197,7 +197,9 @@ class MCPProtocolHandler(BaseProtocolHandler):
             response.raise_for_status()
         except httpx.HTTPStatusError as exc:
             msg = f"MCP JSON-RPC call '{method}' failed with HTTP {exc.response.status_code}"
-            raise ProtocolError(msg, status_code=exc.response.status_code) from exc
+            raise ProtocolError(
+                msg, status_code=exc.response.status_code, headers=dict(exc.response.headers)
+            ) from exc
         except httpx.HTTPError as exc:
             msg = f"MCP JSON-RPC call '{method}' failed: {exc}"
             raise ProtocolError(msg) from exc

--- a/ziran/infrastructure/adapters/protocols/openai_handler.py
+++ b/ziran/infrastructure/adapters/protocols/openai_handler.py
@@ -72,7 +72,9 @@ class OpenAIProtocolHandler(BaseProtocolHandler):
             response.raise_for_status()
         except httpx.HTTPStatusError as exc:
             msg = f"OpenAI request failed with status {exc.response.status_code}"
-            raise ProtocolError(msg, status_code=exc.response.status_code) from exc
+            raise ProtocolError(
+                msg, status_code=exc.response.status_code, headers=dict(exc.response.headers)
+            ) from exc
         except httpx.HTTPError as exc:
             msg = f"OpenAI request failed: {exc}"
             raise ProtocolError(msg) from exc

--- a/ziran/infrastructure/adapters/protocols/rest_handler.py
+++ b/ziran/infrastructure/adapters/protocols/rest_handler.py
@@ -60,7 +60,11 @@ class RestProtocolHandler(BaseProtocolHandler):
             response.raise_for_status()
         except httpx.HTTPStatusError as exc:
             msg = f"REST request failed with status {exc.response.status_code}"
-            raise ProtocolError(msg, status_code=exc.response.status_code) from exc
+            raise ProtocolError(
+                msg,
+                status_code=exc.response.status_code,
+                headers=dict(exc.response.headers),
+            ) from exc
         except httpx.HTTPError as exc:
             msg = f"REST request failed: {exc}"
             raise ProtocolError(msg) from exc

--- a/ziran/infrastructure/adapters/protocols/sse_handler.py
+++ b/ziran/infrastructure/adapters/protocols/sse_handler.py
@@ -168,7 +168,9 @@ class SSEProtocolHandler(BaseProtocolHandler):
                 if response.status_code >= 400:
                     await response.aread()
                     msg = f"SSE request failed with status {response.status_code}"
-                    raise ProtocolError(msg, status_code=response.status_code)
+                    raise ProtocolError(
+                        msg, status_code=response.status_code, headers=dict(response.headers)
+                    )
 
                 accumulated_tool_calls: dict[int, dict[str, Any]] = {}
                 async for chunk in self._parse_sse_stream(response, accumulated_tool_calls):


### PR DESCRIPTION
## Summary
- Add `headers` field to `ProtocolError` to carry response headers
- All protocol handlers now pass response headers when raising `ProtocolError` from HTTP errors
- Retry loop parses `Retry-After` header on 429 responses, capped at 120s
- Falls back to exponential backoff when header is absent

## Test plan
- [x] All 60 HTTP adapter tests pass
- [x] ruff format/check clean
- [x] mypy clean

Closes #119