### PR TITLE
refactor: replace dict[str, Any] with ProtocolResponse TypedDict

### DIFF
--- a/ziran/infrastructure/adapters/http_adapter.py
+++ b/ziran/infrastructure/adapters/http_adapter.py
@@ -26,7 +26,11 @@ from ziran.domain.interfaces.adapter import (
     BaseAgentAdapter,
 )
 from ziran.domain.tool_classifier import is_dangerous as _is_dangerous_tool
-from ziran.infrastructure.adapters.protocols import BaseProtocolHandler, ProtocolError
+from ziran.infrastructure.adapters.protocols import (
+    BaseProtocolHandler,
+    ProtocolError,
+    ProtocolResponse,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -407,7 +411,7 @@ class HttpAgentAdapter(BaseAgentAdapter):
 
     # ── Retry Logic ──────────────────────────────────────────────
 
-    async def _send_with_retry(self, message: str, **kwargs: Any) -> dict[str, Any]:
+    async def _send_with_retry(self, message: str, **kwargs: Any) -> ProtocolResponse:
         """Send with configurable retry on transient failures.
 
         Respects the ``Retry-After`` header on 429 responses when available,

--- a/ziran/infrastructure/adapters/protocols/__init__.py
+++ b/ziran/infrastructure/adapters/protocols/__init__.py
@@ -8,7 +8,7 @@ agents over different wire protocols.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -17,6 +17,18 @@ if TYPE_CHECKING:
 
     from ziran.domain.entities.streaming import AgentResponseChunk
     from ziran.domain.entities.target import TargetConfig
+
+
+class ProtocolResponse(TypedDict):
+    """Structured response from a protocol handler's ``send`` method."""
+
+    content: str
+    tool_calls: NotRequired[list[dict[str, Any]]]
+    metadata: NotRequired[dict[str, Any]]
+    prompt_tokens: NotRequired[int]
+    completion_tokens: NotRequired[int]
+    total_tokens: NotRequired[int]
+    model: NotRequired[str]
 
 
 class ProtocolError(Exception):
@@ -50,7 +62,7 @@ class BaseProtocolHandler(ABC):
         self._config = config
 
     @abstractmethod
-    async def send(self, message: str, **kwargs: Any) -> dict[str, Any]:
+    async def send(self, message: str, **kwargs: Any) -> ProtocolResponse:
         """Send a prompt to the remote agent and return the raw response.
 
         Args:
@@ -58,10 +70,13 @@ class BaseProtocolHandler(ABC):
             **kwargs: Protocol-specific options.
 
         Returns:
-            A dict containing at minimum:
+            A ``ProtocolResponse`` containing at minimum:
             - ``content`` (str): The agent's text response.
-            - ``tool_calls`` (list[dict]): Any tool invocations observed.
-            - ``metadata`` (dict): Protocol-specific metadata.
+            Optionally:
+            - ``tool_calls``: Any tool invocations observed.
+            - ``metadata``: Protocol-specific metadata.
+            - ``prompt_tokens``, ``completion_tokens``, ``total_tokens``: Usage.
+            - ``model``: Model identifier.
 
         Raises:
             ProtocolError: On transport or protocol-level failures.

--- a/ziran/infrastructure/adapters/protocols/a2a_handler.py
+++ b/ziran/infrastructure/adapters/protocols/a2a_handler.py
@@ -25,7 +25,11 @@ from ziran.domain.entities.a2a import (
     A2ATask,
 )
 from ziran.domain.entities.target import A2AConfig, TargetConfig
-from ziran.infrastructure.adapters.protocols import BaseProtocolHandler, ProtocolError
+from ziran.infrastructure.adapters.protocols import (
+    BaseProtocolHandler,
+    ProtocolError,
+    ProtocolResponse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +55,7 @@ class A2AProtocolHandler(BaseProtocolHandler):
 
     # ── Public API ───────────────────────────────────────────────
 
-    async def send(self, message: str, **kwargs: Any) -> dict[str, Any]:
+    async def send(self, message: str, **kwargs: Any) -> ProtocolResponse:
         """Send a message to the A2A agent.
 
         Builds a ``SendMessageRequest``, dispatches it via the

--- a/ziran/infrastructure/adapters/protocols/mcp_handler.py
+++ b/ziran/infrastructure/adapters/protocols/mcp_handler.py
@@ -12,7 +12,11 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
-from ziran.infrastructure.adapters.protocols import BaseProtocolHandler, ProtocolError
+from ziran.infrastructure.adapters.protocols import (
+    BaseProtocolHandler,
+    ProtocolError,
+    ProtocolResponse,
+)
 
 if TYPE_CHECKING:
     from ziran.domain.entities.target import TargetConfig
@@ -33,7 +37,7 @@ class MCPProtocolHandler(BaseProtocolHandler):
         super().__init__(client, config)
         self._request_id = 0
 
-    async def send(self, message: str, **kwargs: Any) -> dict[str, Any]:
+    async def send(self, message: str, **kwargs: Any) -> ProtocolResponse:
         """Send a message by invoking the MCP server's chat/prompt method.
 
         Since MCP servers are primarily tool providers, this wraps the
@@ -147,7 +151,7 @@ class MCPProtocolHandler(BaseProtocolHandler):
         except ProtocolError:
             return False
 
-    async def _call_tool(self, tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    async def _call_tool(self, tool_name: str, arguments: dict[str, Any]) -> ProtocolResponse:
         """Invoke a specific MCP tool.
 
         Args:

--- a/ziran/infrastructure/adapters/protocols/openai_handler.py
+++ b/ziran/infrastructure/adapters/protocols/openai_handler.py
@@ -14,7 +14,11 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 from ziran.domain.entities.streaming import AgentResponseChunk
-from ziran.infrastructure.adapters.protocols import BaseProtocolHandler, ProtocolError
+from ziran.infrastructure.adapters.protocols import (
+    BaseProtocolHandler,
+    ProtocolError,
+    ProtocolResponse,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -44,7 +48,7 @@ class OpenAIProtocolHandler(BaseProtocolHandler):
         self._max_tokens = max_tokens
         self._conversation: list[dict[str, str]] = []
 
-    async def send(self, message: str, **kwargs: Any) -> dict[str, Any]:
+    async def send(self, message: str, **kwargs: Any) -> ProtocolResponse:
         """Send a message via the chat completions endpoint.
 
         Maintains conversation history for multi-turn interactions.

--- a/ziran/infrastructure/adapters/protocols/rest_handler.py
+++ b/ziran/infrastructure/adapters/protocols/rest_handler.py
@@ -12,7 +12,11 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
-from ziran.infrastructure.adapters.protocols import BaseProtocolHandler, ProtocolError
+from ziran.infrastructure.adapters.protocols import (
+    BaseProtocolHandler,
+    ProtocolError,
+    ProtocolResponse,
+)
 
 if TYPE_CHECKING:
     from ziran.domain.entities.target import TargetConfig
@@ -32,7 +36,7 @@ class RestProtocolHandler(BaseProtocolHandler):
         super().__init__(client, config)
         self._rest = config.rest or _default_rest()
 
-    async def send(self, message: str, **kwargs: Any) -> dict[str, Any]:
+    async def send(self, message: str, **kwargs: Any) -> ProtocolResponse:
         """Send a message via REST API.
 
         Args:

--- a/ziran/infrastructure/adapters/protocols/sse_handler.py
+++ b/ziran/infrastructure/adapters/protocols/sse_handler.py
@@ -17,7 +17,11 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 from ziran.domain.entities.streaming import AgentResponseChunk
-from ziran.infrastructure.adapters.protocols import BaseProtocolHandler, ProtocolError
+from ziran.infrastructure.adapters.protocols import (
+    BaseProtocolHandler,
+    ProtocolError,
+    ProtocolResponse,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -109,7 +113,7 @@ class SSEProtocolHandler(BaseProtocolHandler):
 
     # ── BaseProtocolHandler Implementation ───────────────────────
 
-    async def send(self, message: str, **kwargs: Any) -> dict[str, Any]:
+    async def send(self, message: str, **kwargs: Any) -> ProtocolResponse:
         """Non-streaming send (accumulates full SSE stream into one response).
 
         This fallback collects all SSE chunks and returns the full response,

--- a/ziran/infrastructure/adapters/protocols/ws_handler.py
+++ b/ziran/infrastructure/adapters/protocols/ws_handler.py
@@ -18,7 +18,11 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 from ziran.domain.entities.streaming import AgentResponseChunk
-from ziran.infrastructure.adapters.protocols import BaseProtocolHandler, ProtocolError
+from ziran.infrastructure.adapters.protocols import (
+    BaseProtocolHandler,
+    ProtocolError,
+    ProtocolResponse,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -135,7 +139,7 @@ class WebSocketProtocolHandler(BaseProtocolHandler):
 
     # ── BaseProtocolHandler Implementation ───────────────────────
 
-    async def send(self, message: str, **kwargs: Any) -> dict[str, Any]:
+    async def send(self, message: str, **kwargs: Any) -> ProtocolResponse:
         """Non-streaming send (accumulates full WebSocket stream into one response).
 
         Collects all streamed frames and returns the full response.


### PR DESCRIPTION
## Summary
- Add `ProtocolResponse` TypedDict to the protocol handler interface
- Update all 6 concrete handlers (REST, OpenAI, MCP, A2A, SSE, WebSocket) to use it as the `send()` return type
- Provides compile-time type checking for response fields (`content`, `tool_calls`, `metadata`, token usage)

## Test plan
- [x] All 60 HTTP adapter tests pass
- [x] ruff format/check clean
- [x] mypy clean

Closes #120