### PR TITLE
perf: pre-compile regex patterns in static analysis checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# ziran Development Guidelines
+
+Auto-generated from all feature plans. Last updated: 2026-03-20
+
+## Active Technologies
+- Python 3.11+ (CI matrix: 3.11, 3.12, 3.13) + asyncio, dataclasses, logging, OpenTelemetry (tracing) (003-split-agent-scanner)
+- N/A (in-memory knowledge graph via NetworkX) (003-split-agent-scanner)
+- Python 3.11+ (CI matrix: 3.11, 3.12, 3.13) + Pydantic (config models), re (stdlib regex) (003-precompile-regex-patterns)
+
+- Python 3.11+ (CI matrix: 3.11, 3.12, 3.13) + click (CLI only), PyYAML, Playwright (optional), boto3 (optional), LangChain (optional), CrewAI (optional) (002-extract-shared-factories)
+
+## Project Structure
+
+```text
+src/
+tests/
+```
+
+## Commands
+
+cd src [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECHNOLOGIES] pytest [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECHNOLOGIES] ruff check .
+
+## Code Style
+
+Python 3.11+ (CI matrix: 3.11, 3.12, 3.13): Follow standard conventions
+
+## Recent Changes
+- 003-precompile-regex-patterns: Added Python 3.11+ (CI matrix: 3.11, 3.12, 3.13) + Pydantic (config models), re (stdlib regex)
+- 003-split-agent-scanner: Added Python 3.11+ (CI matrix: 3.11, 3.12, 3.13) + asyncio, dataclasses, logging, OpenTelemetry (tracing)
+
+- 002-extract-shared-factories: Added Python 3.11+ (CI matrix: 3.11, 3.12, 3.13) + click (CLI only), PyYAML, Playwright (optional), boto3 (optional), LangChain (optional), CrewAI (optional)
+
+<!-- MANUAL ADDITIONS START -->
+<!-- MANUAL ADDITIONS END -->

--- a/specs/003-precompile-regex-patterns/checklists/requirements.md
+++ b/specs/003-precompile-regex-patterns/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Pre-compile Regex Patterns
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-20
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.plan`.

--- a/specs/003-precompile-regex-patterns/data-model.md
+++ b/specs/003-precompile-regex-patterns/data-model.md
@@ -1,0 +1,22 @@
+# Data Model: Pre-compile Regex Patterns
+
+This is a pure optimization — no new entities. Existing entities gain compiled pattern fields.
+
+## Modified Entities
+
+| Entity | Current Fields | New Field | Notes |
+|--------|---------------|-----------|-------|
+| `PatternRule` | `pattern: str`, `description: str` | `compiled: re.Pattern` | Compiled from `pattern` at construction |
+| `CheckDefinition` | `patterns: list[PatternRule]`, ... | `compiled_patterns: list[re.Pattern]` | Derived from `patterns` list |
+| `DangerousToolCheck` | `pattern: str`, ... | `compiled_pattern: re.Pattern` | Compiled from `pattern` at construction |
+| `InputValidationCheck` | `tool_definition_pattern: str`, `validation_pattern: str` | `compiled_tool_pattern: re.Pattern`, `compiled_validation_pattern: re.Pattern` | Both compiled at construction |
+
+## Dependency Graph (unchanged)
+
+```
+StaticAnalysisConfig
+├── CheckDefinition (multiple lists)
+│   └── PatternRule
+├── DangerousToolCheck
+└── InputValidationCheck
+```

--- a/specs/003-precompile-regex-patterns/plan.md
+++ b/specs/003-precompile-regex-patterns/plan.md
@@ -1,0 +1,60 @@
+# Implementation Plan: Pre-compile Regex Patterns in Static Analysis
+
+**Branch**: `perf/003-precompile-regex-patterns` | **Date**: 2026-03-20 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/003-precompile-regex-patterns/spec.md`
+
+## Summary
+
+Pre-compile regex patterns in the static analysis module so that patterns are compiled once at configuration load time rather than on every file analysis call. This eliminates ~3,000 redundant `re.compile()` calls when scanning a 100-file codebase. Pure performance optimization with zero behavior change.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+ (CI matrix: 3.11, 3.12, 3.13)
+**Primary Dependencies**: Pydantic (config models), re (stdlib regex)
+**Storage**: N/A
+**Testing**: pytest
+**Target Platform**: Linux/macOS (CI + developer machines)
+**Project Type**: Library (security scanning toolkit)
+**Performance Goals**: Each regex pattern compiled exactly once per config load (down from once per file per check)
+**Constraints**: Zero behavior change; all existing tests must pass unmodified
+**Scale/Scope**: 10 checks, ~30 patterns, codebases of 100+ files
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| Hexagonal Architecture | PASS | Change is within application layer only (static_analysis) |
+| Type Safety | PASS | Will add `re.Pattern` type annotations for compiled patterns |
+| Test Coverage | PASS | Existing tests cover behavior; will add compilation verification tests |
+| Async-First | N/A | Static analysis is synchronous (CPU-bound, no I/O) |
+| Extensibility | PASS | Pre-compilation is transparent to config consumers |
+| Simplicity | PASS | Minimal change — add compiled pattern fields to existing Pydantic models |
+| Quality Gates | PASS | Will run ruff, mypy, pytest before merge |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-precompile-regex-patterns/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+└── tasks.md             # Phase 2 output
+```
+
+### Source Code (repository root)
+
+```text
+ziran/application/static_analysis/
+├── config.py            # MODIFY: Add compiled_patterns fields to models
+├── analyzer.py          # MODIFY: Use pre-compiled patterns instead of re.compile() per call
+
+tests/unit/application/
+└── test_static_analysis.py  # EXISTING: Must pass unmodified
+```
+
+**Structure Decision**: No new files needed. Changes are confined to two existing files in the static_analysis package. The config models gain compiled pattern fields; the analyzer functions consume them instead of calling `re.compile()` inline.

--- a/specs/003-precompile-regex-patterns/quickstart.md
+++ b/specs/003-precompile-regex-patterns/quickstart.md
@@ -1,0 +1,33 @@
+# Quickstart: Pre-compile Regex Patterns
+
+## Usage (unchanged — this is a performance optimization)
+
+```python
+from ziran.application.static_analysis.config import StaticAnalysisConfig
+from ziran.application.static_analysis.analyzer import StaticAnalyzer
+
+config = StaticAnalysisConfig.default()
+analyzer = StaticAnalyzer(config=config)
+findings = analyzer.analyze_file(Path("my_agent.py"))
+```
+
+## What Changed Internally
+
+Patterns are now pre-compiled at config load time. No API changes.
+
+```python
+# Before: compiled per file, per check (in _run_check)
+compiled = [re.compile(p.pattern) for p in check.patterns]
+
+# After: compiled once at config load (in model validator)
+# _run_check uses check.compiled_patterns directly
+```
+
+## Verifying the Optimization
+
+```python
+config = StaticAnalysisConfig.default()
+# Patterns are already compiled
+for check in config.secret_checks:
+    assert all(hasattr(p, 'compiled') for p in check.patterns)
+```

--- a/specs/003-precompile-regex-patterns/research.md
+++ b/specs/003-precompile-regex-patterns/research.md
@@ -1,0 +1,24 @@
+# Research: Pre-compile Regex Patterns
+
+## Decision 1: Compilation Strategy
+
+**Decision**: Eager compilation via Pydantic `model_validator` (or `@computed_field`) on the config models.
+
+**Rationale**: Compiling patterns eagerly at model construction time surfaces invalid regex errors immediately at config load time, rather than at first file analysis. Pydantic's `model_validator(mode="after")` is the idiomatic way to derive computed fields after model validation.
+
+**Alternatives considered**:
+- `functools.lru_cache` on `re.compile()` — Python already caches the last 512 compiled patterns, but this is implicit, fragile (eviction under load), and doesn't surface errors early.
+- `@cached_property` on `CheckDefinition` — Would work but Pydantic models require special handling for non-field attributes. `model_validator` is cleaner.
+- Compile in `_run_check()` with a module-level cache dict — Moves state management outside the model. Less clean.
+
+## Decision 2: Storage of Compiled Patterns
+
+**Decision**: Store compiled patterns in a non-serialized field (`exclude=True` in Pydantic) so they don't interfere with YAML serialization or model comparison.
+
+**Rationale**: Compiled `re.Pattern` objects are not JSON/YAML serializable. Marking the field as excluded keeps serialization clean while allowing the compiled patterns to be used at runtime.
+
+## Decision 3: DangerousToolCheck and InputValidationCheck
+
+**Decision**: Apply the same pattern to all check types — `DangerousToolCheck.compiled_pattern` and `InputValidationCheck.compiled_tool_pattern` / `compiled_validation_pattern`.
+
+**Rationale**: Consistency across all check types. Even though `InputValidationCheck` runs once per file (not per line), pre-compiling keeps the pattern uniform and surfaces errors early.

--- a/specs/003-precompile-regex-patterns/spec.md
+++ b/specs/003-precompile-regex-patterns/spec.md
@@ -1,0 +1,73 @@
+# Feature Specification: Pre-compile Regex Patterns in Static Analysis
+
+**Feature Branch**: `003-precompile-regex-patterns`
+**Created**: 2026-03-20
+**Status**: Active
+**Input**: User description: "Pre-compile regex patterns in static analysis checks (issue #113). Currently, CheckDefinition patterns are recompiled from YAML-defined strings on every file analysis call. For large codebases this is wasteful. Fix: pre-compile patterns when CheckDefinition is loaded. No behavior change, purely a performance optimization."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Faster Static Analysis on Large Codebases (Priority: P1)
+
+As a security engineer scanning a large codebase with hundreds of files, I need the static analyzer to avoid redundant work so that scans complete faster and I get results sooner.
+
+**Why this priority**: This is the core value — eliminating thousands of redundant regex compilations per scan directly reduces wall-clock time for every user.
+
+**Independent Test**: Run static analysis on a directory with 100+ files and verify that regex patterns are compiled only once regardless of how many files are analyzed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a static analysis configuration with 10 checks totaling 30 patterns, **When** I analyze a directory containing 100 files, **Then** each regex pattern is compiled exactly once (not 100 times)
+2. **Given** a custom configuration with additional patterns, **When** I load the config and run analysis, **Then** custom patterns are also pre-compiled and reused across files
+3. **Given** a scan of any size, **When** I compare results before and after this change, **Then** the findings are identical (zero behavior change)
+
+---
+
+### User Story 2 - Existing Tests and Integrations Continue Working (Priority: P2)
+
+As a developer maintaining the static analysis module, I need all existing tests to pass without modification after this optimization so that I can be confident the refactor introduced no regressions.
+
+**Why this priority**: Correctness is a hard constraint — any behavior change means the optimization has failed.
+
+**Independent Test**: Run the full test suite and verify all static analysis tests pass without assertion changes.
+
+**Acceptance Scenarios**:
+
+1. **Given** the existing test suite, **When** I run all static analysis tests after the change, **Then** all tests pass without modification to test assertions
+2. **Given** a configuration loaded from a file, **When** I merge two configurations and run analysis, **Then** merged patterns are correctly compiled and produce identical results
+
+---
+
+### Edge Cases
+
+- What happens when a pattern string is invalid regex? (Should fail at load time rather than at first file analysis)
+- What happens when a check definition has zero patterns? (Should produce no findings, same as before)
+- What happens with the input validation check patterns which are stored as plain strings, not pattern rule objects?
+- How does pre-compilation interact with config merging (two configs merged should produce correctly compiled patterns)?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Regex patterns MUST be compiled once when check definitions are created or loaded, not on each file analysis call
+- **FR-002**: Analysis results MUST be identical before and after this change for any given input
+- **FR-003**: Invalid regex patterns MUST raise errors at configuration load time rather than during file analysis
+- **FR-004**: The dangerous tool check patterns MUST also be pre-compiled, not just standard check definition patterns
+- **FR-005**: The input validation check patterns MUST also be pre-compiled
+- **FR-006**: Configuration merging MUST produce correctly compiled patterns in the merged result
+- **FR-007**: All existing tests MUST pass without changes to test assertions
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Each regex pattern is compiled exactly once per configuration load, regardless of the number of files analyzed
+- **SC-002**: All existing static analysis tests pass without modification
+- **SC-003**: Scanning a 100-file codebase with 10 checks and 30 patterns performs no more than 30 regex compilations (down from 3,000)
+- **SC-004**: All quality gates pass (formatting, linting, type checking, tests)
+
+## Assumptions
+
+- The performance improvement is proportional to the number of files scanned — single-file scans see negligible benefit, which is acceptable
+- Pre-compilation happens eagerly (at config load time), not lazily (at first use), to surface invalid patterns early
+- The input validation function's patterns should also be pre-compiled for consistency, even though they run once per file (not per line)

--- a/specs/003-precompile-regex-patterns/tasks.md
+++ b/specs/003-precompile-regex-patterns/tasks.md
@@ -1,0 +1,133 @@
+# Tasks: Pre-compile Regex Patterns in Static Analysis
+
+**Input**: Design documents from `/specs/003-precompile-regex-patterns/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md
+
+**Tests**: Included — the constitution requires unit tests for all business logic (application layer).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Source**: `ziran/application/static_analysis/` at repository root
+- **Tests**: `tests/unit/application/` at repository root
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No setup needed — existing files are being modified
+
+(No tasks — this feature modifies existing files only)
+
+---
+
+## Phase 2: Foundational (Pre-compile Pattern Fields)
+
+**Purpose**: Add compiled pattern fields to all config models — MUST complete before user stories
+
+- [x] T001 [P] Add `compiled` field to `PatternRule` via `model_validator(mode="after")` in `ziran/application/static_analysis/config.py` — compile `self.pattern` into `re.Pattern`, store as excluded field
+- [x] T002 [P] Add `compiled_patterns` property or field to `CheckDefinition` in `ziran/application/static_analysis/config.py` — derive from `self.patterns` list of `PatternRule` objects
+- [x] T003 [P] Add `compiled_pattern` field to `DangerousToolCheck` via `model_validator(mode="after")` in `ziran/application/static_analysis/config.py` — compile `self.pattern` into `re.Pattern`
+- [x] T004 [P] Add `compiled_tool_pattern` and `compiled_validation_pattern` fields to `InputValidationCheck` via `model_validator(mode="after")` in `ziran/application/static_analysis/config.py` — compile both pattern strings
+
+**Checkpoint**: All config models have pre-compiled pattern fields
+
+---
+
+## Phase 3: User Story 1 — Faster Static Analysis on Large Codebases (Priority: P1) 🎯 MVP
+
+**Goal**: Eliminate redundant regex compilations by using pre-compiled patterns in the analyzer
+
+**Independent Test**: Run static analysis on a multi-file directory and verify each pattern is compiled once
+
+### Tests for User Story 1
+
+- [x] T005 [P] [US1] Write unit tests for pre-compiled patterns in `tests/unit/application/test_precompiled_patterns.py` — test that `PatternRule`, `CheckDefinition`, `DangerousToolCheck`, and `InputValidationCheck` have compiled patterns after construction; test invalid regex raises error at construction time; test patterns survive config merging
+- [x] T006 [P] [US1] Write unit test verifying no `re.compile()` calls happen during analysis in `tests/unit/application/test_precompiled_patterns.py` — mock `re.compile` during `_run_check` / `_run_dangerous_tool_checks` / `_check_input_validation` calls and assert it is not called
+
+### Implementation for User Story 1
+
+- [x] T007 [US1] Update `_run_check()` in `ziran/application/static_analysis/analyzer.py` — replace `compiled = [re.compile(p.pattern) for p in check.patterns]` with `compiled = check.compiled_patterns` (or equivalent using `PatternRule.compiled`)
+- [x] T008 [US1] Update `_run_dangerous_tool_checks()` in `ziran/application/static_analysis/analyzer.py` — replace `compiled = [(re.compile(c.pattern), c) for c in checks]` with `compiled = [(c.compiled_pattern, c) for c in checks]`
+- [x] T009 [US1] Update `_check_input_validation()` in `ziran/application/static_analysis/analyzer.py` — replace `re.search(check.tool_definition_pattern, ...)` and `re.search(check.validation_pattern, ...)` with `check.compiled_tool_pattern.search(...)` and `check.compiled_validation_pattern.search(...)`
+- [x] T010 [US1] Remove `import re` from `ziran/application/static_analysis/analyzer.py` if no longer needed (verify no other uses remain)
+
+**Checkpoint**: Static analysis uses pre-compiled patterns. All existing tests pass.
+
+---
+
+## Phase 4: User Story 2 — Existing Tests and Integrations Continue Working (Priority: P2)
+
+**Goal**: Verify zero behavior change
+
+**Independent Test**: Run full test suite — all tests pass without modification
+
+### Implementation for User Story 2
+
+- [x] T011 [US2] Run existing static analysis tests: `pytest tests/unit/application/test_static_analysis.py -v` — verify all pass without any assertion changes
+- [x] T012 [US2] Run full test suite: `pytest` — verify no regressions anywhere
+
+**Checkpoint**: All tests pass, zero behavior change confirmed
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation
+
+- [x] T013 Run quality gates: `ruff check .`, `ruff format --check .`, `mypy ziran/` — fix any issues
+- [x] T014 Run full test suite with coverage: `pytest --cov=ziran` — verify coverage >= 85%
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Foundational (Phase 2)**: T001-T004 all parallel — add compiled fields to config models
+- **User Story 1 (Phase 3)**: Depends on Phase 2 — uses compiled fields in analyzer
+- **User Story 2 (Phase 4)**: Depends on Phase 3 — validates zero behavior change
+- **Polish (Phase 5)**: Depends on all stories complete
+
+### Parallel Opportunities
+
+- T001, T002, T003, T004 — all modify different classes in the same file but are logically independent
+- T005, T006 — test files can be written in parallel with implementation
+- T007, T008, T009 — modify different functions in analyzer.py (sequential recommended)
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 2: Add compiled fields to config models (T001-T004)
+2. Complete Phase 3: Use compiled patterns in analyzer (T005-T010)
+3. **STOP and VALIDATE**: Run existing test suite
+4. Ready for review/merge
+
+### Incremental Delivery
+
+1. Foundational → Config models have compiled patterns
+2. User Story 1 → Analyzer uses pre-compiled patterns → **MVP complete**
+3. User Story 2 → Full regression validation
+4. Polish → All gates pass
+
+---
+
+## Notes
+
+- [P] tasks = different files or independent functions, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Total tasks: 14
+- US1: 6 tasks (core optimization), US2: 2 tasks (regression validation)
+- Foundational: 4 tasks, Polish: 2 tasks
+- This is a pure optimization — no new features, no new external dependencies
+- All T001-T004 touch the same file (config.py) but different classes — implement sequentially for safety

--- a/tests/unit/application/test_precompiled_patterns.py
+++ b/tests/unit/application/test_precompiled_patterns.py
@@ -1,0 +1,177 @@
+"""Tests for pre-compiled regex patterns in static analysis config models."""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import patch
+
+import pytest
+
+from ziran.application.static_analysis.config import (
+    CheckDefinition,
+    DangerousToolCheck,
+    InputValidationCheck,
+    PatternRule,
+    StaticAnalysisConfig,
+)
+
+
+class TestPatternRuleCompilation:
+    """T001: PatternRule compiles pattern eagerly at construction."""
+
+    def test_pattern_rule_has_compiled_field(self) -> None:
+        rule = PatternRule(pattern=r"\bsecret\b", description="test")
+        assert isinstance(rule.compiled, re.Pattern)
+
+    def test_pattern_rule_compiled_matches(self) -> None:
+        rule = PatternRule(pattern=r"\bsecret\b")
+        assert rule.compiled.search("my secret key")
+        assert not rule.compiled.search("no match here")
+
+    def test_invalid_pattern_raises_at_construction(self) -> None:
+        with pytest.raises(Exception):  # noqa: B017
+            PatternRule(pattern=r"[invalid")
+
+
+class TestCheckDefinitionCompilation:
+    """T002: CheckDefinition exposes compiled_patterns property."""
+
+    def test_compiled_patterns_returns_list(self) -> None:
+        check = CheckDefinition(
+            check_id="SA001",
+            message="test",
+            severity="high",
+            patterns=[
+                PatternRule(pattern=r"\bfoo\b"),
+                PatternRule(pattern=r"\bbar\b"),
+            ],
+        )
+        compiled = check.compiled_patterns
+        assert len(compiled) == 2
+        assert all(isinstance(p, re.Pattern) for p in compiled)
+
+    def test_compiled_patterns_empty_when_no_patterns(self) -> None:
+        check = CheckDefinition(check_id="SA001", message="test", severity="low")
+        assert check.compiled_patterns == []
+
+    def test_compiled_patterns_match_correctly(self) -> None:
+        check = CheckDefinition(
+            check_id="SA001",
+            message="test",
+            severity="high",
+            patterns=[PatternRule(pattern=r"api[_-]?key")],
+        )
+        assert check.compiled_patterns[0].search("my_api_key = 'abc'")
+
+
+class TestDangerousToolCheckCompilation:
+    """T003: DangerousToolCheck compiles pattern eagerly."""
+
+    def test_has_compiled_pattern(self) -> None:
+        check = DangerousToolCheck(pattern=r"\bexec\b", description="exec call")
+        assert isinstance(check.compiled_pattern, re.Pattern)
+
+    def test_compiled_pattern_matches(self) -> None:
+        check = DangerousToolCheck(pattern=r"\bexec\b", description="exec call")
+        assert check.compiled_pattern.search("exec('code')")
+        assert not check.compiled_pattern.search("execute('code')")
+
+    def test_invalid_pattern_raises(self) -> None:
+        with pytest.raises(Exception):  # noqa: B017
+            DangerousToolCheck(pattern=r"[bad", description="bad")
+
+
+class TestInputValidationCheckCompilation:
+    """T004: InputValidationCheck compiles both patterns eagerly."""
+
+    def test_has_compiled_tool_pattern(self) -> None:
+        check = InputValidationCheck()
+        assert isinstance(check.compiled_tool_pattern, re.Pattern)
+
+    def test_has_compiled_validation_pattern(self) -> None:
+        check = InputValidationCheck()
+        assert isinstance(check.compiled_validation_pattern, re.Pattern)
+
+    def test_tool_pattern_matches_default(self) -> None:
+        check = InputValidationCheck()
+        assert check.compiled_tool_pattern.search("@tool")
+
+    def test_validation_pattern_matches_default(self) -> None:
+        check = InputValidationCheck()
+        assert check.compiled_validation_pattern.search("validate(input)")
+
+
+class TestNoRuntimeCompilation:
+    """T006: Verify no re.compile() during analysis."""
+
+    def test_run_check_does_not_call_compile(self) -> None:
+        from ziran.application.static_analysis.analyzer import _run_check
+
+        check = CheckDefinition(
+            check_id="SA001",
+            message="test",
+            severity="high",
+            patterns=[PatternRule(pattern=r"\bsecret\b")],
+        )
+        lines = ["secret = 'abc'", "normal line"]
+
+        with patch("re.compile", side_effect=AssertionError("re.compile called")) as mock:
+            # _run_check should NOT call re.compile — it uses pre-compiled patterns
+            # We need to be careful: the check object already has compiled patterns
+            # so _run_check should just use them
+            findings = _run_check(check, lines, "test.py")
+            mock.assert_not_called()
+        assert len(findings) == 1
+
+    def test_run_dangerous_tool_checks_does_not_call_compile(self) -> None:
+        from ziran.application.static_analysis.analyzer import _run_dangerous_tool_checks
+
+        checks = [DangerousToolCheck(pattern=r"\bexec\b", description="exec")]
+        lines = ["exec('code')"]
+
+        with patch("re.compile", side_effect=AssertionError("re.compile called")) as mock:
+            findings = _run_dangerous_tool_checks(checks, lines, "test.py")
+            mock.assert_not_called()
+        assert len(findings) == 1
+
+    def test_check_input_validation_does_not_call_compile(self) -> None:
+        from ziran.application.static_analysis.analyzer import _check_input_validation
+
+        check = InputValidationCheck()
+        content = "@tool\ndef my_tool() -> str:\n    return 'result'"
+
+        with patch("re.compile", side_effect=AssertionError("re.compile called")) as mock:
+            findings = _check_input_validation(check, content, "test.py")
+            mock.assert_not_called()
+        assert len(findings) == 1  # no validation detected
+
+
+class TestConfigMergingPreservesCompilation:
+    """Verify compiled patterns survive config merging."""
+
+    def test_merged_config_has_compiled_patterns(self) -> None:
+        config1 = StaticAnalysisConfig(
+            secret_checks=[
+                CheckDefinition(
+                    check_id="SA001",
+                    message="secrets",
+                    severity="critical",
+                    patterns=[PatternRule(pattern=r"\bapi_key\b")],
+                )
+            ]
+        )
+        config2 = StaticAnalysisConfig(
+            secret_checks=[
+                CheckDefinition(
+                    check_id="SA099",
+                    message="custom",
+                    severity="high",
+                    patterns=[PatternRule(pattern=r"\btoken\b")],
+                )
+            ]
+        )
+        merged = config1.merge(config2)
+        assert len(merged.secret_checks) == 2
+        for check in merged.secret_checks:
+            for p in check.patterns:
+                assert isinstance(p.compiled, re.Pattern)

--- a/ziran/application/static_analysis/analyzer.py
+++ b/ziran/application/static_analysis/analyzer.py
@@ -36,7 +36,6 @@ Example::
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal
 
@@ -186,7 +185,7 @@ def _run_check(
 ) -> list[StaticFinding]:
     """Run a generic check definition against lines of source code."""
     findings: list[StaticFinding] = []
-    compiled = [re.compile(p.pattern) for p in check.patterns]
+    compiled = check.compiled_patterns
 
     for i, line in enumerate(lines, 1):
         if check.skip_comments and _is_comment_or_docstring(line):
@@ -215,7 +214,7 @@ def _run_dangerous_tool_checks(
 ) -> list[StaticFinding]:
     """Run dangerous-tool pattern checks."""
     findings: list[StaticFinding] = []
-    compiled = [(re.compile(c.pattern), c) for c in checks]
+    compiled = [(c.compiled_pattern, c) for c in checks]
 
     for i, line in enumerate(lines, 1):
         for pattern, check in compiled:
@@ -243,10 +242,10 @@ def _check_input_validation(
     file_path: str,
 ) -> list[StaticFinding]:
     """Heuristic: flag tool definitions with no validation logic."""
-    if not re.search(check.tool_definition_pattern, content):
+    if not check.compiled_tool_pattern.search(content):
         return []
 
-    has_validation = bool(re.search(check.validation_pattern, content))
+    has_validation = bool(check.compiled_validation_pattern.search(content))
     if not has_validation:
         return [
             StaticFinding(

--- a/ziran/application/static_analysis/config.py
+++ b/ziran/application/static_analysis/config.py
@@ -15,11 +15,12 @@ Example::
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 # ── Building blocks ──────────────────────────────────────────────────
 
@@ -28,10 +29,18 @@ class PatternRule(BaseModel):
     """A single regex pattern with associated metadata."""
 
     pattern: str
-    """Regex pattern string (will be compiled at runtime)."""
+    """Regex pattern string — compiled eagerly at construction time."""
 
     description: str = ""
     """Optional human-readable description of what this pattern detects."""
+
+    compiled: re.Pattern[str] = Field(default=None, exclude=True)  # type: ignore[arg-type]
+    """Pre-compiled regex pattern (excluded from serialization)."""
+
+    @model_validator(mode="after")
+    def _compile_pattern(self) -> PatternRule:
+        object.__setattr__(self, "compiled", re.compile(self.pattern))
+        return self
 
 
 class CheckDefinition(BaseModel):
@@ -59,6 +68,11 @@ class CheckDefinition(BaseModel):
     skip_comments: bool = True
     """Whether to skip lines that look like comments / docstrings."""
 
+    @property
+    def compiled_patterns(self) -> list[re.Pattern[str]]:
+        """Pre-compiled regex patterns derived from the patterns list."""
+        return [p.compiled for p in self.patterns]
+
 
 class DangerousToolCheck(BaseModel):
     """A dangerous-tool pattern with its own description."""
@@ -71,6 +85,14 @@ class DangerousToolCheck(BaseModel):
         "Restrict tool permissions and add guardrails. Consider sandboxing or an approval workflow."
     )
     skip_comments: bool = True
+
+    compiled_pattern: re.Pattern[str] = Field(default=None, exclude=True)  # type: ignore[arg-type]
+    """Pre-compiled regex pattern (excluded from serialization)."""
+
+    @model_validator(mode="after")
+    def _compile_pattern(self) -> DangerousToolCheck:
+        object.__setattr__(self, "compiled_pattern", re.compile(self.pattern))
+        return self
 
 
 class InputValidationCheck(BaseModel):
@@ -90,6 +112,18 @@ class InputValidationCheck(BaseModel):
         r"if\s+not\s+\w+|raise\s+ValueError)"
     )
     """Pattern that indicates validation is present."""
+
+    compiled_tool_pattern: re.Pattern[str] = Field(default=None, exclude=True)  # type: ignore[arg-type]
+    """Pre-compiled tool definition pattern (excluded from serialization)."""
+
+    compiled_validation_pattern: re.Pattern[str] = Field(default=None, exclude=True)  # type: ignore[arg-type]
+    """Pre-compiled validation pattern (excluded from serialization)."""
+
+    @model_validator(mode="after")
+    def _compile_patterns(self) -> InputValidationCheck:
+        object.__setattr__(self, "compiled_tool_pattern", re.compile(self.tool_definition_pattern))
+        object.__setattr__(self, "compiled_validation_pattern", re.compile(self.validation_pattern))
+        return self
 
 
 # ── Top-level config ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Pre-compile regex patterns at config load time (via Pydantic `model_validator`) instead of on every file analysis call
- Eliminates ~3,000 redundant `re.compile()` calls when scanning a 100-file codebase (10 checks × 30 patterns × 100 files → 30 compilations)
- Zero behavior change — all 1736 existing tests pass without modification

## Changes

- `config.py`: Added `compiled` field to `PatternRule`, `compiled_pattern` to `DangerousToolCheck`, `compiled_tool_pattern`/`compiled_validation_pattern` to `InputValidationCheck`
- `analyzer.py`: Updated `_run_check`, `_run_dangerous_tool_checks`, `_check_input_validation` to use pre-compiled patterns; removed `import re`
- Added 17 new tests verifying compilation behavior and no-runtime-compile guarantee

## Test plan

- [x] All 17 new pre-compilation tests pass
- [x] All 31 existing static analysis tests pass unmodified
- [x] Full test suite (1736 tests) passes
- [x] Quality gates: ruff check, ruff format, mypy strict — all pass

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)