### PR TITLE
feat: add MCP and multi-agent delegation patterns

### DIFF
--- a/specs/003-mcp-delegation-patterns/spec.md
+++ b/specs/003-mcp-delegation-patterns/spec.md
@@ -1,0 +1,72 @@
+# Feature Specification: Add MCP and Multi-Agent Delegation Patterns
+
+**Feature Branch**: `feat/003-mcp-delegation-patterns`
+**Created**: 2026-03-20
+**Status**: Active
+**Input**: User description: "Add MCP and multi-agent delegation patterns to tool classifier and chain analyzer (issue #163)."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Detect MCP Write and Git Operations (Priority: P1)
+
+As a security engineer scanning an agent with MCP tools, I need the tool classifier to correctly identify MCP write operations as critical risk and MCP git operations at the appropriate risk level, so that dangerous MCP tools are flagged in scan reports.
+
+**Why this priority**: MCP write operations (mcp_write_file) can modify the filesystem and should be classified as critical risk, matching the existing classification of write_file.
+
+**Independent Test**: Classify MCP tool names and verify correct risk levels.
+
+**Acceptance Scenarios**:
+
+1. **Given** a tool named `mcp_write_file`, **When** classified, **Then** it is rated critical risk
+2. **Given** a tool named `mcp_git_diff`, **When** classified, **Then** it is rated medium risk
+3. **Given** a tool named `send_task`, **When** classified, **Then** it is rated high risk (A2A delegation)
+4. **Given** tools named `payment` or `transaction`, **When** classified, **Then** they are rated critical risk
+
+---
+
+### User Story 2 - Detect MCP-Specific Exfiltration Chains (Priority: P2)
+
+As a security engineer, I need the chain analyzer to detect MCP-specific exfiltration patterns (e.g., mcp_read_file → mcp_fetch) so that data exfiltration through MCP tool combinations is flagged.
+
+**Why this priority**: Exfiltration through MCP tool chains is a documented attack vector (CVE-2025-53109 and related).
+
+**Independent Test**: Create a tool graph with MCP read and fetch tools, run chain analysis, verify the exfiltration chain is detected.
+
+**Acceptance Scenarios**:
+
+1. **Given** tools `mcp_read_file` and `mcp_fetch` in a graph, **When** chain analysis runs, **Then** it detects a data_exfiltration chain
+2. **Given** tools `mcp_git_diff` and `mcp_fetch` in a graph, **When** chain analysis runs, **Then** it detects a code exfiltration chain
+
+---
+
+### Edge Cases
+
+- What happens when `mcp_write` matches but `mcp_write_file` also has a specific pattern? (More specific pattern should win via first-match ordering)
+- How does `send_task` interact with existing `delegate_task` patterns?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Tool classifier MUST classify `mcp_write_file` and `mcp_write` as critical risk
+- **FR-002**: Tool classifier MUST classify `mcp_git_diff` as medium risk
+- **FR-003**: Tool classifier MUST classify `payment` and `transaction` broadly as critical risk
+- **FR-004**: Tool classifier MUST classify `send_task` as high risk (A2A protocol)
+- **FR-005**: Chain patterns MUST include `mcp_read_file → mcp_fetch` as data exfiltration
+- **FR-006**: Chain patterns MUST include `mcp_git_diff → mcp_fetch` as code exfiltration
+- **FR-007**: All existing tests MUST pass without modification
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All new tool names are classified at the correct risk tier
+- **SC-002**: New chain patterns are detected during graph analysis
+- **SC-003**: All existing tests pass, all quality gates pass
+- **SC-004**: Ground truth benchmark reflects improved coverage
+
+## Assumptions
+
+- New patterns are additive — no existing patterns are changed or removed
+- MCP write operations carry the same risk as regular file write operations
+- The A2A `send_task` pattern follows Google's A2A protocol naming convention

--- a/tests/unit/test_tool_classifier.py
+++ b/tests/unit/test_tool_classifier.py
@@ -62,6 +62,11 @@ class TestClassifyTool:
             # Financial
             "process_payment",
             "transfer_funds",
+            "payment",
+            "transaction",
+            # MCP write operations
+            "mcp_write_file",
+            "mcp_write",
         ],
     )
     def test_critical_tools(self, tool_name: str) -> None:
@@ -123,6 +128,8 @@ class TestClassifyTool:
             "mcp_read_file",
             "mcp_fetch",
             "mcp_read_resource",
+            # A2A protocol
+            "send_task",
             # File read (may expose secrets/PII)
             "read_file",
             "get_file",
@@ -143,6 +150,9 @@ class TestClassifyTool:
             "api_call",
             "external_api",
             "browser_open",
+            # MCP git operations
+            "mcp_git_diff",
+            "mcp_git_log",
         ],
     )
     def test_medium_tools(self, tool_name: str) -> None:

--- a/ziran/application/knowledge_graph/chain_patterns.yaml
+++ b/ziran/application/knowledge_graph/chain_patterns.yaml
@@ -645,6 +645,38 @@ patterns:
     description: MCP tool on one server triggers tool on another server
     remediation: Restrict cross-server MCP tool invocation chains
 
+  - source: mcp_read_file
+    target: mcp_fetch
+    type: mcp_file_exfiltration
+    risk: critical
+    category: mcp_specific
+    description: File content read via MCP exfiltrated through MCP fetch
+    remediation: Block MCP fetch after MCP file reads without user approval
+
+  - source: mcp_git_diff
+    target: mcp_fetch
+    type: mcp_code_exfiltration
+    risk: critical
+    category: mcp_specific
+    description: Git diff content exfiltrated through MCP fetch
+    remediation: Block MCP fetch after MCP git operations
+
+  - source: mcp_write_file
+    target: execute_code
+    type: mcp_write_to_rce
+    risk: critical
+    category: mcp_specific
+    description: MCP writes file that is then executed as code
+    remediation: Validate file content and restrict execution after MCP writes
+
+  - source: mcp_read_file
+    target: send_email
+    type: mcp_file_to_email
+    risk: critical
+    category: mcp_specific
+    description: File content read via MCP sent via email
+    remediation: Block email sending after MCP file reads without approval
+
   # ── A2A / Multi-Agent Delegation ──────────────────────────────────
   - source: delegate_task
     target: execute_code
@@ -847,6 +879,14 @@ patterns:
     category: cicd_pipeline
     description: Dockerfile contents used to craft malicious file writes
     remediation: Validate Dockerfile processing; restrict write targets
+
+  - source: read_env
+    target: deploy
+    type: env_secret_injection
+    risk: critical
+    category: cicd_pipeline
+    description: Environment secrets injected into deployment
+    remediation: Never pass raw env vars to deployment tools; use secret managers
 
   - source: read_env
     target: write_file

--- a/ziran/domain/tool_classifier.py
+++ b/ziran/domain/tool_classifier.py
@@ -97,6 +97,11 @@ CRITICAL_PATTERNS: dict[str, str] = {
     # Financial
     r"\bprocess[\s_-]?payment\b": "Payment processing",
     r"\btransfer[\s_-]?funds?\b": "Fund transfer",
+    r"\bpayment\b": "Payment operation",
+    r"\btransaction\b": "Financial transaction",
+    # MCP write operations (filesystem mutation via MCP)
+    r"\bmcp[\s_-]?write[\s_-]?file\b": "MCP filesystem write",
+    r"\bmcp[\s_-]?write\b": "MCP write operation",
 }
 
 # ── High: email, permissions, DB writes ──────────────────────────────
@@ -153,6 +158,8 @@ HIGH_PATTERNS: dict[str, str] = {
     r"\bmcp[\s_-]?read[\s_-]?file\b": "MCP filesystem read",
     r"\bmcp[\s_-]?fetch\b": "MCP outbound fetch",
     r"\bmcp[\s_-]?read[\s_-]?resource\b": "MCP resource read",
+    # A2A / multi-agent protocol
+    r"\bsend[\s_-]?task\b": "A2A task delegation",
     # File read (promoted from medium — can expose secrets/PII)
     r"\bread[\s_-]?file\b": "File read (may expose secrets)",
     r"\bget[\s_-]?file\b": "File read",
@@ -170,6 +177,9 @@ MEDIUM_PATTERNS: dict[str, str] = {
     # External API
     r"\bapi[\s_-]?call\b": "External API call",
     r"\bexternal[\s_-]?api\b": "External API call",
+    # MCP git operations (read-only but may expose code/secrets)
+    r"\bmcp[\s_-]?git[\s_-]?diff\b": "MCP git diff (code exposure)",
+    r"\bmcp[\s_-]?git[\s_-]?log\b": "MCP git log",
     # Browser
     r"\bbrowser\b": "Browser access",
     r"\bscrape\b": "Web scraping",


### PR DESCRIPTION
## Summary

- Add missing MCP write/git patterns and broader financial patterns to tool classifier
- Add 5 new chain patterns for MCP-specific exfiltration and CI/CD injection
- Update existing tests with new tool name classifications

## New Patterns

### Tool Classifier
| Tool | Risk | Category |
|------|------|----------|
| `mcp_write_file` | critical | MCP filesystem write |
| `mcp_write` | critical | MCP write operation |
| `payment` | critical | Payment operation |
| `transaction` | critical | Financial transaction |
| `send_task` | high | A2A task delegation |
| `mcp_git_diff` | medium | MCP git diff |
| `mcp_git_log` | medium | MCP git log |

### Chain Patterns (5 new)
- `mcp_read_file → mcp_fetch` — file exfiltration via MCP
- `mcp_git_diff → mcp_fetch` — code exfiltration via MCP
- `mcp_write_file → execute_code` — write-to-RCE via MCP
- `mcp_read_file → send_email` — file-to-email via MCP
- `read_env → deploy` — secret injection into deployment

## Test plan

- [x] All 128 tool classifier + chain analyzer tests pass (7 new parametrized cases)
- [x] Ground truth benchmark passes
- [x] Quality gates: ruff, mypy — all pass

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)