### PR TITLE
feat: make detector pipeline configurable and extensible

### DIFF
--- a/specs/003-configurable-detector-pipeline/spec.md
+++ b/specs/003-configurable-detector-pipeline/spec.md
@@ -1,0 +1,68 @@
+# Feature Specification: Configurable Detector Pipeline
+
+**Feature Branch**: `feat/003-configurable-detector-pipeline`
+**Created**: 2026-03-20
+**Status**: Active
+**Input**: User description: "Make detector pipeline configurable and extensible (issue #121)."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Disable Specific Detectors (Priority: P1)
+
+As a security engineer running a targeted scan, I need to disable specific detectors (e.g., the LLM judge or authorization detector) so that I can control which detection methods are active for my specific use case.
+
+**Why this priority**: This is the most requested capability — users need to customize which detectors run.
+
+**Independent Test**: Create a pipeline with a specific detector disabled and verify it doesn't run.
+
+**Acceptance Scenarios**:
+
+1. **Given** a detector configuration that disables the side_effect detector, **When** I run a scan, **Then** the side_effect detector does not execute
+2. **Given** a default configuration with no overrides, **When** I run a scan, **Then** all detectors run as before (backward compatible)
+
+---
+
+### User Story 2 - Register Custom Detectors (Priority: P2)
+
+As a developer building a custom security tool, I need to register my own detector implementation so that I can extend the pipeline without modifying source code.
+
+**Why this priority**: Extensibility is the second most important capability.
+
+**Independent Test**: Register a custom detector and verify it runs during evaluation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a custom detector implementing the BaseDetector interface, **When** I register it with the pipeline, **Then** it runs during evaluation and its results contribute to the verdict
+2. **Given** a custom detector with a duplicate name, **When** I register it, **Then** it replaces the existing detector
+
+---
+
+### Edge Cases
+
+- What happens when all detectors are disabled? (Should return conservative default: attack failed)
+- What happens when a custom detector raises an exception? (Should be caught and logged, not crash the pipeline)
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Pipeline MUST accept an optional detector configuration that enables/disables detectors by name
+- **FR-002**: Pipeline MUST provide a `register_detector()` method for adding custom detectors
+- **FR-003**: Default behavior (no configuration) MUST be identical to current behavior
+- **FR-004**: Custom detectors MUST participate in the resolution strategy
+- **FR-005**: All existing tests MUST pass without modification
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Detectors can be individually disabled via configuration
+- **SC-002**: Custom detectors can be registered and participate in verdicts
+- **SC-003**: All existing tests pass without modification
+- **SC-004**: All quality gates pass
+
+## Assumptions
+
+- The resolution strategy remains the same — only the set of active detectors changes
+- Custom detectors participate in the "ambiguous → LLM judge" step but don't override the priority chain (refusal → side-effect → authorization → indicator → LLM judge)
+- Configuration is a simple dict mapping detector names to enabled/disabled status

--- a/tests/unit/application/test_detector_config.py
+++ b/tests/unit/application/test_detector_config.py
@@ -1,0 +1,172 @@
+"""Tests for configurable detector pipeline."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ziran.application.detectors.pipeline import DetectorConfig, DetectorPipeline
+from ziran.domain.entities.detection import DetectorResult
+from ziran.domain.interfaces.detector import BaseDetector
+
+
+class _MockDetector(BaseDetector):
+    """A minimal custom detector for testing."""
+
+    def __init__(self, detector_name: str = "custom", score: float = 0.8) -> None:
+        self._name = detector_name
+        self._score = score
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def detect(self, prompt, response, prompt_spec, vector=None):  # type: ignore[override]
+        return DetectorResult(
+            detector_name=self._name,
+            score=self._score,
+            confidence=0.9,
+            matched_indicators=[],
+            reasoning=f"Custom detector {self._name} result",
+        )
+
+
+class _FailingDetector(BaseDetector):
+    """A detector that always raises an exception."""
+
+    @property
+    def name(self) -> str:
+        return "failing"
+
+    def detect(self, prompt, response, prompt_spec, vector=None):  # type: ignore[override]
+        msg = "Detector crashed!"
+        raise RuntimeError(msg)
+
+
+def _make_response(text: str = "test response") -> MagicMock:
+    response = MagicMock()
+    response.content = text
+    response.tool_calls = []
+    response.raw = {"choices": [{"message": {"content": text}}]}
+    return response
+
+
+def _make_prompt_spec() -> MagicMock:
+    spec = MagicMock()
+    spec.success_indicators = []
+    spec.failure_indicators = []
+    return spec
+
+
+@pytest.mark.unit
+class TestDetectorConfig:
+    """Test DetectorConfig dataclass."""
+
+    def test_default_config_has_no_disabled(self) -> None:
+        config = DetectorConfig()
+        assert config.disabled == set()
+
+    def test_config_with_disabled_detectors(self) -> None:
+        config = DetectorConfig(disabled={"side_effect", "authorization"})
+        assert "side_effect" in config.disabled
+        assert "authorization" in config.disabled
+
+    def test_default_matchtypes(self) -> None:
+        config = DetectorConfig()
+        assert config.refusal_matchtype == "str"
+        assert config.indicator_matchtype == "str"
+
+    def test_custom_matchtypes(self) -> None:
+        config = DetectorConfig(refusal_matchtype="word", indicator_matchtype="word")
+        assert config.refusal_matchtype == "word"
+
+
+@pytest.mark.unit
+class TestDisabledDetectors:
+    """Test disabling built-in detectors."""
+
+    @pytest.mark.asyncio
+    async def test_disabled_refusal_not_in_results(self) -> None:
+        config = DetectorConfig(disabled={"refusal"})
+        pipeline = DetectorPipeline(detector_config=config)
+        verdict = await pipeline.evaluate("test prompt", _make_response(), _make_prompt_spec())
+        detector_names = {r.detector_name for r in verdict.detector_results}
+        assert "refusal" not in detector_names
+
+    @pytest.mark.asyncio
+    async def test_disabled_side_effect_not_in_results(self) -> None:
+        config = DetectorConfig(disabled={"side_effect"})
+        pipeline = DetectorPipeline(detector_config=config)
+        verdict = await pipeline.evaluate("test prompt", _make_response(), _make_prompt_spec())
+        detector_names = {r.detector_name for r in verdict.detector_results}
+        assert "side_effect" not in detector_names
+
+    @pytest.mark.asyncio
+    async def test_default_config_runs_all_core_detectors(self) -> None:
+        pipeline = DetectorPipeline()
+        verdict = await pipeline.evaluate("test prompt", _make_response(), _make_prompt_spec())
+        detector_names = {r.detector_name for r in verdict.detector_results}
+        assert "refusal" in detector_names
+        assert "indicator" in detector_names
+        assert "side_effect" in detector_names
+
+    @pytest.mark.asyncio
+    async def test_all_disabled_returns_safe_default(self) -> None:
+        config = DetectorConfig(
+            disabled={"refusal", "indicator", "side_effect", "authorization", "llm_judge"}
+        )
+        pipeline = DetectorPipeline(detector_config=config)
+        verdict = await pipeline.evaluate("test prompt", _make_response(), _make_prompt_spec())
+        assert not verdict.successful
+        assert verdict.score == 0.0
+
+
+@pytest.mark.unit
+class TestCustomDetectors:
+    """Test registering and running custom detectors."""
+
+    @pytest.mark.asyncio
+    async def test_custom_detector_runs(self) -> None:
+        pipeline = DetectorPipeline()
+        pipeline.register_detector(_MockDetector("custom_test", score=0.9))
+        verdict = await pipeline.evaluate("test prompt", _make_response(), _make_prompt_spec())
+        detector_names = {r.detector_name for r in verdict.detector_results}
+        assert "custom_test" in detector_names
+
+    @pytest.mark.asyncio
+    async def test_custom_detector_replaces_same_name(self) -> None:
+        pipeline = DetectorPipeline()
+        pipeline.register_detector(_MockDetector("my_det", score=0.5))
+        pipeline.register_detector(_MockDetector("my_det", score=0.9))
+        # Should only have one custom detector
+        assert len(pipeline._custom_detectors) == 1
+        assert pipeline._custom_detectors[0]._score == 0.9  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_custom_detector_can_be_disabled(self) -> None:
+        config = DetectorConfig(disabled={"custom_test"})
+        pipeline = DetectorPipeline(detector_config=config)
+        pipeline.register_detector(_MockDetector("custom_test"))
+        verdict = await pipeline.evaluate("test prompt", _make_response(), _make_prompt_spec())
+        detector_names = {r.detector_name for r in verdict.detector_results}
+        assert "custom_test" not in detector_names
+
+    @pytest.mark.asyncio
+    async def test_failing_custom_detector_does_not_crash(self) -> None:
+        pipeline = DetectorPipeline()
+        pipeline.register_detector(_FailingDetector())
+        # Should not raise — the failing detector is caught
+        verdict = await pipeline.evaluate("test prompt", _make_response(), _make_prompt_spec())
+        detector_names = {r.detector_name for r in verdict.detector_results}
+        assert "failing" not in detector_names  # result not added since it crashed
+
+    @pytest.mark.asyncio
+    async def test_multiple_custom_detectors(self) -> None:
+        pipeline = DetectorPipeline()
+        pipeline.register_detector(_MockDetector("custom_a", score=0.6))
+        pipeline.register_detector(_MockDetector("custom_b", score=0.8))
+        verdict = await pipeline.evaluate("test prompt", _make_response(), _make_prompt_spec())
+        detector_names = {r.detector_name for r in verdict.detector_results}
+        assert "custom_a" in detector_names
+        assert "custom_b" in detector_names

--- a/ziran/application/detectors/pipeline.py
+++ b/ziran/application/detectors/pipeline.py
@@ -21,7 +21,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
 
 from ziran.application.detectors.authorization import AuthorizationDetector
 from ziran.application.detectors.indicator import IndicatorDetector
@@ -33,6 +34,7 @@ from ziran.infrastructure.telemetry.tracing import get_tracer
 if TYPE_CHECKING:
     from ziran.domain.entities.attack import AttackPrompt, AttackVector
     from ziran.domain.interfaces.adapter import AgentResponse
+    from ziran.domain.interfaces.detector import BaseDetector
     from ziran.infrastructure.llm.base import BaseLLMClient
 
 logger = logging.getLogger(__name__)
@@ -45,6 +47,29 @@ _SAFE_THRESHOLD = 0.3
 
 #: Timeout for the LLM judge call in seconds.
 _LLM_JUDGE_TIMEOUT: float = 30.0
+
+
+@dataclass
+class DetectorConfig:
+    """Configuration for the detector pipeline.
+
+    Controls which detectors are enabled and their settings.
+    All detectors are enabled by default.
+
+    Example::
+
+        config = DetectorConfig(disabled={"side_effect", "authorization"})
+        pipeline = DetectorPipeline(detector_config=config)
+    """
+
+    disabled: set[str] = field(default_factory=set)
+    """Set of detector names to disable (e.g. ``{"side_effect", "llm_judge"}``)."""
+
+    refusal_matchtype: Literal["str", "word", "startswith"] = "str"
+    """Match type for the refusal detector (``"str"``, ``"word"``, ``"startswith"``)."""
+
+    indicator_matchtype: Literal["str", "word"] = "str"
+    """Match type for the indicator detector."""
 
 
 class DetectorPipeline:
@@ -66,14 +91,19 @@ class DetectorPipeline:
         *,
         llm_client: BaseLLMClient | None = None,
         quality_scoring: bool = False,
+        detector_config: DetectorConfig | None = None,
     ) -> None:
-        self._refusal = RefusalDetector(matchtype="str")
-        self._indicator = IndicatorDetector(matchtype="str")
+        config = detector_config or DetectorConfig()
+        self._disabled = config.disabled
+        self._custom_detectors: list[BaseDetector] = []
+
+        self._refusal = RefusalDetector(matchtype=config.refusal_matchtype)
+        self._indicator = IndicatorDetector(matchtype=config.indicator_matchtype)
         self._side_effect = SideEffectDetector()
         self._authorization = AuthorizationDetector()
         self._llm_judge = None
 
-        if llm_client is not None:
+        if llm_client is not None and "llm_judge" not in self._disabled:
             from ziran.application.detectors.llm_judge import LLMJudgeDetector
 
             self._llm_judge = LLMJudgeDetector(llm_client, quality_scoring=quality_scoring)
@@ -81,6 +111,24 @@ class DetectorPipeline:
                 "LLM judge detector enabled (quality_scoring=%s)",
                 quality_scoring,
             )
+
+    def register_detector(self, detector: BaseDetector) -> None:
+        """Register a custom detector to participate in the pipeline.
+
+        Custom detectors run after the built-in detectors. If a custom
+        detector has the same name as an existing one, it replaces it.
+
+        Args:
+            detector: A detector implementing :class:`BaseDetector`.
+        """
+        # Replace existing custom detector with the same name
+        self._custom_detectors = [d for d in self._custom_detectors if d.name != detector.name]
+        self._custom_detectors.append(detector)
+        logger.info("Registered custom detector: %s", detector.name)
+
+    def _is_enabled(self, name: str) -> bool:
+        """Check if a detector is enabled."""
+        return name not in self._disabled
 
     async def evaluate(
         self,
@@ -104,25 +152,37 @@ class DetectorPipeline:
         _det_span = _tracer.start_span("ziran.detection")
 
         # ── 1. Refusal detector (highest priority) ───────────────
-        refusal_result = self._refusal.detect(prompt, response, prompt_spec, vector)
-        results.append(refusal_result)
+        if self._is_enabled("refusal"):
+            refusal_result = self._refusal.detect(prompt, response, prompt_spec, vector)
+            results.append(refusal_result)
 
         # ── 2. Indicator detector ────────────────────────────────
-        indicator_result = self._indicator.detect(prompt, response, prompt_spec, vector)
-        results.append(indicator_result)
+        if self._is_enabled("indicator"):
+            indicator_result = self._indicator.detect(prompt, response, prompt_spec, vector)
+            results.append(indicator_result)
 
         # ── 3. Side-effect detector (tool call analysis) ─────────
-        side_effect_result = self._side_effect.detect(prompt, response, prompt_spec, vector)
-        results.append(side_effect_result)
+        if self._is_enabled("side_effect"):
+            side_effect_result = self._side_effect.detect(prompt, response, prompt_spec, vector)
+            results.append(side_effect_result)
 
         # ── 4. Authorization detector (for BOLA/BFLA vectors) ─────
-        if self._is_authz_vector(vector):
+        if self._is_enabled("authorization") and self._is_authz_vector(vector):
             authz_result = self._authorization.detect(prompt, response, prompt_spec, vector)
             results.append(authz_result)
 
-        # ── 5. LLM judge (optional, only for ambiguous cases) ────
+        # ── 5. Custom detectors ──────────────────────────────────
+        for custom in self._custom_detectors:
+            if self._is_enabled(custom.name):
+                try:
+                    custom_result = custom.detect(prompt, response, prompt_spec, vector)
+                    results.append(custom_result)
+                except Exception as exc:
+                    logger.warning("Custom detector '%s' failed: %s", custom.name, exc)
+
+        # ── 6. LLM judge (optional, only for ambiguous cases) ────
         llm_judge_result = None
-        if self._llm_judge is not None:
+        if self._llm_judge is not None and self._is_enabled("llm_judge"):
             try:
                 async with asyncio.timeout(_LLM_JUDGE_TIMEOUT):
                     llm_judge_result = await self._llm_judge.detect(


### PR DESCRIPTION
## Summary

- Add `DetectorConfig` dataclass to enable/disable detectors by name and configure matchtypes
- Add `register_detector()` method for runtime registration of custom `BaseDetector` implementations
- Custom detector exceptions are caught and logged (graceful degradation)
- Default behavior unchanged — all detectors enabled, same resolution strategy

## API

```python
from ziran.application.detectors.pipeline import DetectorConfig, DetectorPipeline

# Disable specific detectors
config = DetectorConfig(disabled={"side_effect", "authorization"})
pipeline = DetectorPipeline(detector_config=config)

# Register a custom detector
pipeline.register_detector(MyCustomDetector())
```

## Test plan

- [x] 13 new tests for config, disabled detectors, custom detectors, error handling
- [x] All 31 existing detector tests pass unmodified
- [x] Full test suite (1749 tests) passes
- [x] Quality gates: ruff, mypy strict — all pass

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)