### PR TITLE
fix: trigger release workflow on release event from release-please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,14 @@
 name: Release
 
 on:
+  # Trigger on GitHub releases created by release-please.
+  # release-please uses GITHUB_TOKEN which doesn't trigger tag-push events,
+  # but the 'release' event IS dispatched for API-created releases.
+  release:
+    types: [published]
+  # Also support manual tag pushes (e.g., pre-releases pushed via git)
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"       # stable:  v1.2.3
       - "v[0-9]+.[0-9]+.[0-9]+a[0-9]+" # alpha:   v1.2.3a1
       - "v[0-9]+.[0-9]+.[0-9]+b[0-9]+" # beta:    v1.2.3b1
       - "v[0-9]+.[0-9]+.[0-9]+rc[0-9]+" # rc:     v1.2.3rc1
@@ -167,7 +172,10 @@ jobs:
         with:
           repository-url: https://test.pypi.org/legacy/
 
-  # ── Create GitHub Release with artifacts ───────────────────────────
+  # ── Upload artifacts to GitHub Release ─────────────────────────────
+  # When triggered by release-please (release event), the release already
+  # exists — softprops/action-gh-release updates it with build artifacts.
+  # When triggered by tag push (pre-releases), it creates a new release.
   github-release:
     needs: [publish-pypi]
     runs-on: ubuntu-latest
@@ -191,7 +199,7 @@ jobs:
             echo "flag=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Create GitHub Release
+      - name: Upload artifacts to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

- Switch release workflow trigger from `push: tags` to `release: published`
- release-please uses GITHUB_TOKEN which doesn't trigger tag-push events (GitHub security policy)
- The `release: published` event IS dispatched for API-created releases
- Keep tag-push trigger for manual pre-releases (alpha/beta/rc)

## Root cause

Since v0.15.0, all releases were created by release-please but the release workflow never fired, so no packages were published to PyPI.

## Test plan

- [x] Workflow syntax valid
- [ ] After merge, manually re-trigger releases for v0.15.0-v0.18.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)