### PR TITLE
perf: reduce test suite runtime from 7min to 1.5min (4.7x speedup)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,10 +6,26 @@ from typing import Any
 
 import pytest
 
+from ziran.application.attacks.library import AttackLibrary
 from ziran.domain.entities.attack import AttackCategory, AttackPrompt, AttackResult, AttackVector
 from ziran.domain.entities.capability import AgentCapability, CapabilityType
 from ziran.domain.entities.phase import ScanPhase
 from ziran.domain.interfaces.adapter import AgentResponse, AgentState, BaseAgentAdapter
+
+# ──────────────────────────────────────────────────────────────────────
+# Session-scoped fixtures (expensive objects loaded once per test run)
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="session")
+def shared_attack_library() -> AttackLibrary:
+    """Session-scoped AttackLibrary — YAML parsing happens once per test run.
+
+    Tests that only read from the library (filtering, counting, etc.)
+    should use this fixture instead of constructing AttackLibrary().
+    """
+    return AttackLibrary()
+
 
 # ──────────────────────────────────────────────────────────────────────
 # Mock Agent Adapter

--- a/tests/unit/test_attack_library.py
+++ b/tests/unit/test_attack_library.py
@@ -15,9 +15,9 @@ class TestAttackLibrary:
     """Tests for AttackLibrary YAML loading and filtering."""
 
     @pytest.fixture
-    def library(self) -> AttackLibrary:
-        """Library loaded with built-in vectors."""
-        return AttackLibrary()
+    def library(self, shared_attack_library: AttackLibrary) -> AttackLibrary:
+        """Library loaded with built-in vectors (session-cached)."""
+        return shared_attack_library
 
     def test_loads_builtin_vectors(self, library: AttackLibrary) -> None:
         assert library.vector_count > 0

--- a/tests/unit/test_authorization_detector.py
+++ b/tests/unit/test_authorization_detector.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from ziran.application.detectors.authorization import AuthorizationDetector
+
+if TYPE_CHECKING:
+    from ziran.application.attacks.library import AttackLibrary
 from ziran.domain.entities.attack import AttackCategory, AttackPrompt, AttackVector
 from ziran.domain.entities.phase import ScanPhase
 from ziran.domain.interfaces.adapter import AgentResponse
@@ -169,44 +172,34 @@ class TestAuthorizationDetector:
 
 
 class TestAuthorizationVectorsYAML:
-    def test_vectors_load(self) -> None:
+    def test_vectors_load(self, shared_attack_library: AttackLibrary) -> None:
         """Authorization vectors should load without errors."""
-        from ziran.application.attacks.library import AttackLibrary
-
-        library = AttackLibrary()
+        library = shared_attack_library
         authz_vectors = library.get_attacks_by_category(AttackCategory.AUTHORIZATION_BYPASS)
         assert len(authz_vectors) >= 15
 
-    def test_vectors_have_authorization_tag(self) -> None:
-        from ziran.application.attacks.library import AttackLibrary
-
-        library = AttackLibrary()
+    def test_vectors_have_authorization_tag(self, shared_attack_library: AttackLibrary) -> None:
+        library = shared_attack_library
         authz_vectors = library.get_attacks_by_category(AttackCategory.AUTHORIZATION_BYPASS)
         for v in authz_vectors:
             assert "authorization" in v.tags, f"Vector {v.id} missing 'authorization' tag"
 
-    def test_vectors_have_bola_or_bfla_tag(self) -> None:
-        from ziran.application.attacks.library import AttackLibrary
-
-        library = AttackLibrary()
+    def test_vectors_have_bola_or_bfla_tag(self, shared_attack_library: AttackLibrary) -> None:
+        library = shared_attack_library
         authz_vectors = library.get_attacks_by_category(AttackCategory.AUTHORIZATION_BYPASS)
         for v in authz_vectors:
             tags = set(v.tags)
             has_type = bool(tags & {"bola", "bfla", "impersonation", "privilege_escalation"})
             assert has_type, f"Vector {v.id} missing BOLA/BFLA/related tag"
 
-    def test_vectors_have_prompts(self) -> None:
-        from ziran.application.attacks.library import AttackLibrary
-
-        library = AttackLibrary()
+    def test_vectors_have_prompts(self, shared_attack_library: AttackLibrary) -> None:
+        library = shared_attack_library
         authz_vectors = library.get_attacks_by_category(AttackCategory.AUTHORIZATION_BYPASS)
         for v in authz_vectors:
             assert len(v.prompts) >= 1, f"Vector {v.id} has no prompts"
 
-    def test_multi_turn_vectors_have_tactic(self) -> None:
-        from ziran.application.attacks.library import AttackLibrary
-
-        library = AttackLibrary()
+    def test_multi_turn_vectors_have_tactic(self, shared_attack_library: AttackLibrary) -> None:
+        library = shared_attack_library
         authz_vectors = library.get_attacks_by_category(AttackCategory.AUTHORIZATION_BYPASS)
         multi_turn = [v for v in authz_vectors if "multi_turn" in v.tags]
         assert len(multi_turn) >= 3

--- a/tests/unit/test_benchmark_scripts.py
+++ b/tests/unit/test_benchmark_scripts.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from benchmarks.benchmark_comparison import collect_benchmark_comparison
 from benchmarks.gap_status import collect_gap_status
 from benchmarks.inventory import collect_inventory
 from benchmarks.owasp_coverage import collect_owasp_coverage
-from ziran.application.attacks.library import AttackLibrary
+
+if TYPE_CHECKING:
+    from ziran.application.attacks.library import AttackLibrary
 
 
 class TestInventory:
@@ -22,9 +26,9 @@ class TestInventory:
         assert "multi_turn_vectors" in data
         assert "business_impact_coverage" in data
 
-    def test_total_matches_library(self) -> None:
+    def test_total_matches_library(self, shared_attack_library: AttackLibrary) -> None:
         data = collect_inventory()
-        library = AttackLibrary()
+        library = shared_attack_library
         assert data["total_vectors"] == len(library.vectors)
 
     def test_categories_sum_to_total(self) -> None:

--- a/tests/unit/test_expanded_tactics.py
+++ b/tests/unit/test_expanded_tactics.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 from ziran.application.attacks.encoding import (
@@ -12,7 +14,9 @@ from ziran.application.attacks.encoding import (
     _encode_token_boundary,
     _encode_word_shuffle,
 )
-from ziran.application.attacks.library import AttackLibrary
+
+if TYPE_CHECKING:
+    from ziran.application.attacks.library import AttackLibrary
 from ziran.application.attacks.tactics import TacticType
 
 # ── New TacticType values ────────────────────────────────────────────
@@ -50,8 +54,8 @@ class TestNewTacticTypes:
 
 class TestExpandedTacticsVectors:
     @pytest.fixture
-    def library(self) -> AttackLibrary:
-        return AttackLibrary()
+    def library(self, shared_attack_library: AttackLibrary) -> AttackLibrary:
+        return shared_attack_library
 
     def test_expanded_vectors_load(self, library: AttackLibrary) -> None:
         """All expanded tactic vectors should load without validation errors."""

--- a/tests/unit/test_harmful_tasks.py
+++ b/tests/unit/test_harmful_tasks.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
-from ziran.application.attacks.library import AttackLibrary
+if TYPE_CHECKING:
+    from ziran.application.attacks.library import AttackLibrary
 from ziran.domain.entities.attack import (
     HARM_CATEGORY_DESCRIPTIONS,
     AttackResult,
@@ -42,8 +45,8 @@ class TestHarmCategory:
 
 class TestHarmfulTaskVectors:
     @pytest.fixture
-    def library(self) -> AttackLibrary:
-        return AttackLibrary()
+    def library(self, shared_attack_library: AttackLibrary) -> AttackLibrary:
+        return shared_attack_library
 
     def test_harmful_task_vectors_load(self, library: AttackLibrary) -> None:
         """All harmful task vectors should load without validation errors."""
@@ -179,8 +182,8 @@ class TestAlertCoverage:
     """GAP-21: Verify 100% coverage of ALERT's 32 micro categories."""
 
     @pytest.fixture
-    def library(self) -> AttackLibrary:
-        return AttackLibrary()
+    def library(self, shared_attack_library: AttackLibrary) -> AttackLibrary:
+        return shared_attack_library
 
     def test_alert_has_32_micro_categories(self) -> None:
         assert len(ALERT_MICRO_CATEGORIES) == 32

--- a/tests/unit/test_historical_tracking.py
+++ b/tests/unit/test_historical_tracking.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from benchmarks.historical_tracking import (
@@ -11,12 +13,17 @@ from benchmarks.historical_tracking import (
 )
 
 
+@pytest.fixture(scope="module")
+def snapshot() -> dict[str, Any]:
+    """Module-scoped snapshot to avoid repeated AttackLibrary init."""
+    return take_snapshot()
+
+
 @pytest.mark.unit
 class TestHistoricalTracking:
     """Tests for historical tracking and trend analysis."""
 
-    def test_take_snapshot_has_required_fields(self) -> None:
-        snapshot = take_snapshot()
+    def test_take_snapshot_has_required_fields(self, snapshot: dict) -> None:
         assert "timestamp" in snapshot
         assert "metrics" in snapshot
         metrics = snapshot["metrics"]
@@ -24,8 +31,7 @@ class TestHistoricalTracking:
         assert "owasp_coverage_pct" in metrics
         assert "categories" in metrics
 
-    def test_snapshot_metrics_positive(self) -> None:
-        snapshot = take_snapshot()
+    def test_snapshot_metrics_positive(self, snapshot: dict) -> None:
         metrics = snapshot["metrics"]
         assert metrics["total_vectors"] > 0
         assert metrics["categories"] > 0
@@ -36,28 +42,29 @@ class TestHistoricalTracking:
         assert result["trend_count"] == 0
         assert result["history_points"] == 0
 
-    def test_compute_trends_single_snapshot(self) -> None:
-        snapshot = take_snapshot()
+    def test_compute_trends_single_snapshot(self, snapshot: dict) -> None:
         result = compute_trends([snapshot])
         assert result["history_points"] == 1
-        # All deltas should be 0 (comparing against self)
         for trend in result["trends"].values():
             assert trend["delta"] == 0
             assert trend["direction"] == "stable"
 
-    def test_compute_trends_two_snapshots(self) -> None:
-        s1 = take_snapshot()
-        s2 = take_snapshot()
-        # Modify s2 to simulate growth
+    def test_compute_trends_two_snapshots(self, snapshot: dict) -> None:
+        import copy
+
+        s1 = copy.deepcopy(snapshot)
+        s2 = copy.deepcopy(snapshot)
         s2["metrics"]["total_vectors"] = s1["metrics"]["total_vectors"] + 10
         result = compute_trends([s1, s2])
         assert result["history_points"] == 2
         assert result["trends"]["total_vectors"]["delta"] == 10
         assert result["trends"]["total_vectors"]["direction"] == "up"
 
-    def test_compute_trends_regression(self) -> None:
-        s1 = take_snapshot()
-        s2 = take_snapshot()
+    def test_compute_trends_regression(self, snapshot: dict) -> None:
+        import copy
+
+        s1 = copy.deepcopy(snapshot)
+        s2 = copy.deepcopy(snapshot)
         s2["metrics"]["total_vectors"] = s1["metrics"]["total_vectors"] - 5
         result = compute_trends([s1, s2])
         assert result["trends"]["total_vectors"]["delta"] == -5

--- a/tests/unit/test_http_adapter.py
+++ b/tests/unit/test_http_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -14,6 +15,9 @@ from ziran.domain.entities.target import (
     TargetConfig,
 )
 from ziran.infrastructure.adapters.protocols import ProtocolError
+
+if TYPE_CHECKING:
+    from ziran.application.attacks.library import AttackLibrary
 
 # ──────────────────────────────────────────────────────────────────────
 # ProtocolError
@@ -488,29 +492,23 @@ class TestAttackLibraryProtocolFilter:
         )
         assert vector.protocol_filter == []
 
-    def test_library_loads_a2a_vectors(self) -> None:
-        from ziran.application.attacks.library import AttackLibrary
-
-        library = AttackLibrary()
+    def test_library_loads_a2a_vectors(self, shared_attack_library: AttackLibrary) -> None:
+        library = shared_attack_library
         a2a_vectors = library.get_attacks_by_protocol("a2a")
         # Should include both generic vectors and A2A-specific ones
         a2a_specific = [v for v in a2a_vectors if v.protocol_filter == ["a2a"]]
         assert len(a2a_specific) > 0
 
-    def test_library_protocol_filter_excludes(self) -> None:
-        from ziran.application.attacks.library import AttackLibrary
-
-        library = AttackLibrary()
+    def test_library_protocol_filter_excludes(self, shared_attack_library: AttackLibrary) -> None:
+        library = shared_attack_library
         rest_vectors = library.get_attacks_by_protocol("rest")
         # A2A-only vectors should not appear for REST
         for v in rest_vectors:
             if v.protocol_filter:
                 assert "rest" in v.protocol_filter
 
-    def test_search_with_protocol(self) -> None:
-        from ziran.application.attacks.library import AttackLibrary
-
-        library = AttackLibrary()
+    def test_search_with_protocol(self, shared_attack_library: AttackLibrary) -> None:
+        library = shared_attack_library
         results = library.search(protocol="a2a")
         # Should include generic + A2A-specific vectors
         assert len(results) > 0

--- a/tests/unit/test_jailbreakbench.py
+++ b/tests/unit/test_jailbreakbench.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
-from ziran.application.attacks.library import AttackLibrary
+if TYPE_CHECKING:
+    from ziran.application.attacks.library import AttackLibrary
 from ziran.domain.entities.attack import AttackCategory
 
 # JailbreakBench's 10 categories aligned with OpenAI usage policies.
@@ -26,8 +29,8 @@ class TestJailbreakBenchCoverage:
     """GAP-15: Verify JailbreakBench 10 category coverage."""
 
     @pytest.fixture
-    def library(self) -> AttackLibrary:
-        return AttackLibrary()
+    def library(self, shared_attack_library: AttackLibrary) -> AttackLibrary:
+        return shared_attack_library
 
     def test_jbb_has_10_categories(self) -> None:
         assert len(JBB_CATEGORIES) == 10

--- a/tests/unit/test_model_dos.py
+++ b/tests/unit/test_model_dos.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
-from ziran.application.attacks.library import AttackLibrary
+if TYPE_CHECKING:
+    from ziran.application.attacks.library import AttackLibrary
 from ziran.domain.entities.attack import AttackCategory, OwaspLlmCategory
 
 
@@ -15,8 +18,8 @@ class TestModelDosCategory:
 
 class TestModelDosVectors:
     @pytest.fixture
-    def library(self) -> AttackLibrary:
-        return AttackLibrary()
+    def library(self, shared_attack_library: AttackLibrary) -> AttackLibrary:
+        return shared_attack_library
 
     def test_dos_vectors_load(self, library: AttackLibrary) -> None:
         """All model_dos vectors should load without validation errors."""

--- a/tests/unit/test_multi_agent.py
+++ b/tests/unit/test_multi_agent.py
@@ -7,11 +7,13 @@ knowledge graph extensions, and multi-agent scanner.
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
+if TYPE_CHECKING:
+    from ziran.application.attacks.library import AttackLibrary
 from ziran.domain.entities.multi_agent import (
     AgentEdge,
     AgentNode,
@@ -230,18 +232,15 @@ class TestKnowledgeGraphMultiAgent:
 class TestMultiAgentAttackVectors:
     """Tests that multi-agent YAML vectors load correctly."""
 
-    def test_vectors_load(self) -> None:
-        from ziran.application.attacks.library import AttackLibrary
+    def test_vectors_load(self, shared_attack_library: AttackLibrary) -> None:
         from ziran.domain.entities.attack import AttackCategory
 
-        library = AttackLibrary()
+        library = shared_attack_library
         # Should have multi_agent category
         assert AttackCategory.MULTI_AGENT in library.categories
 
-    def test_vector_ids_unique(self) -> None:
-        from ziran.application.attacks.library import AttackLibrary
-
-        library = AttackLibrary()
+    def test_vector_ids_unique(self, shared_attack_library: AttackLibrary) -> None:
+        library = shared_attack_library
         ids = [v.id for v in library.vectors]
         assert len(ids) == len(set(ids)), "Duplicate vector IDs found"
 

--- a/tests/unit/test_owasp_mapping.py
+++ b/tests/unit/test_owasp_mapping.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
-from ziran.application.attacks.library import AttackLibrary
+if TYPE_CHECKING:
+    from ziran.application.attacks.library import AttackLibrary
 from ziran.domain.entities.attack import (
     OWASP_LLM_DESCRIPTIONS,
     AttackCategory,
@@ -133,8 +136,8 @@ class TestAttackLibraryOwasp:
     """Tests for OWASP filtering in AttackLibrary."""
 
     @pytest.fixture
-    def library(self) -> AttackLibrary:
-        return AttackLibrary()
+    def library(self, shared_attack_library: AttackLibrary) -> AttackLibrary:
+        return shared_attack_library
 
     def test_all_builtin_vectors_have_owasp_mapping(self, library: AttackLibrary) -> None:
         """Every built-in vector should have at least one OWASP mapping."""

--- a/tests/unit/test_performance_metrics.py
+++ b/tests/unit/test_performance_metrics.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from benchmarks.performance_metrics import (
@@ -11,28 +13,31 @@ from benchmarks.performance_metrics import (
 )
 
 
+@pytest.fixture(scope="module")
+def perf_data() -> dict[str, Any]:
+    """Run collect_performance_metrics once for all tests in this module."""
+    return collect_performance_metrics()
+
+
 @pytest.mark.unit
 class TestPerformanceMetrics:
     """Tests for performance benchmark infrastructure."""
 
-    def test_collect_returns_all_sections(self) -> None:
+    def test_collect_returns_all_sections(self, perf_data: dict) -> None:
         """Collected metrics should have all required top-level keys."""
-        data = collect_performance_metrics()
-        assert "benchmarks" in data
-        assert "summary" in data
-        assert "targets" in data
-        assert "regressions" in data
-        assert "regression_detected" in data
+        assert "benchmarks" in perf_data
+        assert "summary" in perf_data
+        assert "targets" in perf_data
+        assert "regressions" in perf_data
+        assert "regression_detected" in perf_data
 
-    def test_benchmarks_list_nonempty(self) -> None:
+    def test_benchmarks_list_nonempty(self, perf_data: dict) -> None:
         """Should have at least one benchmark result."""
-        data = collect_performance_metrics()
-        assert len(data["benchmarks"]) >= 5
+        assert len(perf_data["benchmarks"]) >= 5
 
-    def test_benchmark_structure(self) -> None:
+    def test_benchmark_structure(self, perf_data: dict) -> None:
         """Each benchmark should have timing and memory data."""
-        data = collect_performance_metrics()
-        for bench in data["benchmarks"]:
+        for bench in perf_data["benchmarks"]:
             assert "name" in bench
             assert "timing_seconds" in bench
             assert "memory_bytes" in bench
@@ -42,24 +47,23 @@ class TestPerformanceMetrics:
             assert "mean" in t
             assert t["min"] <= t["mean"] <= t["max"]
 
-    def test_summary_has_throughput(self) -> None:
+    def test_summary_has_throughput(self, perf_data: dict) -> None:
         """Summary should include vector throughput."""
-        data = collect_performance_metrics()
-        s = data["summary"]
+        s = perf_data["summary"]
         assert "vectors_per_second" in s
         assert s["vectors_per_second"] > 0
 
-    def test_targets_defined(self) -> None:
+    def test_targets_defined(self, perf_data: dict) -> None:
         """Performance targets should be defined."""
-        data = collect_performance_metrics()
-        targets = data["targets"]
+        targets = perf_data["targets"]
         assert "library_init_max_seconds" in targets
         assert all(v > 0 for v in targets.values())
 
-    def test_no_regressions_on_clean_run(self) -> None:
+    def test_no_regressions_on_clean_run(self, perf_data: dict) -> None:
         """A clean run should not detect regressions (generous targets)."""
-        data = collect_performance_metrics()
-        assert not data["regression_detected"], f"Unexpected regressions: {data['regressions']}"
+        assert not perf_data["regression_detected"], (
+            f"Unexpected regressions: {perf_data['regressions']}"
+        )
 
     def test_measure_operation_basic(self) -> None:
         """Measure operation should return valid timing data."""

--- a/tests/unit/test_rjudge.py
+++ b/tests/unit/test_rjudge.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
-from ziran.application.attacks.library import AttackLibrary
+if TYPE_CHECKING:
+    from ziran.application.attacks.library import AttackLibrary
 
 # R-Judge's 10 risk types across 5 application categories.
 RJUDGE_RISK_TYPES = [
@@ -25,8 +28,8 @@ class TestRJudgeCoverage:
     """GAP-20: Verify R-Judge 10 risk type coverage."""
 
     @pytest.fixture
-    def library(self) -> AttackLibrary:
-        return AttackLibrary()
+    def library(self, shared_attack_library: AttackLibrary) -> AttackLibrary:
+        return shared_attack_library
 
     def test_rjudge_has_10_risk_types(self) -> None:
         assert len(RJUDGE_RISK_TYPES) == 10

--- a/tests/unit/test_scanner.py
+++ b/tests/unit/test_scanner.py
@@ -25,17 +25,21 @@ class TestAgentScanner:
     """Tests for the AgentScanner."""
 
     @pytest.fixture
-    def scanner(self, mock_adapter: MockAgentAdapter) -> AgentScanner:
+    def scanner(
+        self, mock_adapter: MockAgentAdapter, shared_attack_library: AttackLibrary
+    ) -> AgentScanner:
         return AgentScanner(
             adapter=mock_adapter,
-            attack_library=AttackLibrary(),
+            attack_library=shared_attack_library,
         )
 
     @pytest.fixture
-    def vulnerable_scanner(self, vulnerable_adapter: MockAgentAdapter) -> AgentScanner:
+    def vulnerable_scanner(
+        self, vulnerable_adapter: MockAgentAdapter, shared_attack_library: AttackLibrary
+    ) -> AgentScanner:
         return AgentScanner(
             adapter=vulnerable_adapter,
-            attack_library=AttackLibrary(),
+            attack_library=shared_attack_library,
         )
 
     async def test_run_empty_campaign(self, mock_adapter: MockAgentAdapter) -> None:
@@ -161,12 +165,14 @@ class TestAgentScannerPromptRendering:
 class TestProgressCallback:
     """Tests for the on_progress callback mechanism."""
 
-    async def test_callback_receives_campaign_events(self, mock_adapter: MockAgentAdapter) -> None:
+    async def test_callback_receives_campaign_events(
+        self, mock_adapter: MockAgentAdapter, shared_attack_library: AttackLibrary
+    ) -> None:
         """Callback should receive CAMPAIGN_START and CAMPAIGN_COMPLETE."""
         events: list[ProgressEvent] = []
         scanner = AgentScanner(
             adapter=mock_adapter,
-            attack_library=AttackLibrary(),
+            attack_library=shared_attack_library,
         )
         await scanner.run_campaign(
             phases=[ScanPhase.RECONNAISSANCE],
@@ -176,12 +182,14 @@ class TestProgressCallback:
         assert ProgressEventType.CAMPAIGN_START in event_types
         assert ProgressEventType.CAMPAIGN_COMPLETE in event_types
 
-    async def test_callback_receives_phase_events(self, mock_adapter: MockAgentAdapter) -> None:
+    async def test_callback_receives_phase_events(
+        self, mock_adapter: MockAgentAdapter, shared_attack_library: AttackLibrary
+    ) -> None:
         """Callback should receive PHASE_START and PHASE_COMPLETE for each phase."""
         events: list[ProgressEvent] = []
         scanner = AgentScanner(
             adapter=mock_adapter,
-            attack_library=AttackLibrary(),
+            attack_library=shared_attack_library,
         )
         await scanner.run_campaign(
             phases=[ScanPhase.RECONNAISSANCE, ScanPhase.TRUST_BUILDING],
@@ -195,13 +203,13 @@ class TestProgressCallback:
         assert phase_starts[1].phase == "trust_building"
 
     async def test_callback_receives_attack_events(
-        self, vulnerable_adapter: MockAgentAdapter
+        self, vulnerable_adapter: MockAgentAdapter, shared_attack_library: AttackLibrary
     ) -> None:
         """Callback should receive ATTACK_START and ATTACK_COMPLETE for each attack."""
         events: list[ProgressEvent] = []
         scanner = AgentScanner(
             adapter=vulnerable_adapter,
-            attack_library=AttackLibrary(),
+            attack_library=shared_attack_library,
         )
         await scanner.run_campaign(
             phases=[ScanPhase.VULNERABILITY_DISCOVERY],
@@ -217,7 +225,9 @@ class TestProgressCallback:
             assert evt.attack_name != ""
             assert evt.total_attacks > 0
 
-    async def test_callback_phase_index_tracking(self, mock_adapter: MockAgentAdapter) -> None:
+    async def test_callback_phase_index_tracking(
+        self, mock_adapter: MockAgentAdapter, shared_attack_library: AttackLibrary
+    ) -> None:
         """Phase events should track correct indices."""
         events: list[ProgressEvent] = []
         phases = [
@@ -227,7 +237,7 @@ class TestProgressCallback:
         ]
         scanner = AgentScanner(
             adapter=mock_adapter,
-            attack_library=AttackLibrary(),
+            attack_library=shared_attack_library,
         )
         await scanner.run_campaign(phases=phases, on_progress=events.append)
 
@@ -237,11 +247,13 @@ class TestProgressCallback:
             assert evt.phase_index == idx
             assert evt.total_phases == 3
 
-    async def test_no_callback_still_works(self, mock_adapter: MockAgentAdapter) -> None:
+    async def test_no_callback_still_works(
+        self, mock_adapter: MockAgentAdapter, shared_attack_library: AttackLibrary
+    ) -> None:
         """Campaign should work fine when on_progress is None (default)."""
         scanner = AgentScanner(
             adapter=mock_adapter,
-            attack_library=AttackLibrary(),
+            attack_library=shared_attack_library,
         )
         result = await scanner.run_campaign(
             phases=[ScanPhase.RECONNAISSANCE],
@@ -249,13 +261,13 @@ class TestProgressCallback:
         assert result.campaign_id.startswith("campaign_")
 
     async def test_campaign_complete_has_metadata(
-        self, vulnerable_adapter: MockAgentAdapter
+        self, vulnerable_adapter: MockAgentAdapter, shared_attack_library: AttackLibrary
     ) -> None:
         """CAMPAIGN_COMPLETE event should include total_vulnerabilities in extra."""
         events: list[ProgressEvent] = []
         scanner = AgentScanner(
             adapter=vulnerable_adapter,
-            attack_library=AttackLibrary(),
+            attack_library=shared_attack_library,
         )
         await scanner.run_campaign(
             phases=[ScanPhase.VULNERABILITY_DISCOVERY],
@@ -300,12 +312,12 @@ class TestConcurrentAttackExecution:
     """Tests for concurrent attack execution and race conditions in _execute_phase."""
 
     async def test_concurrent_attacks_aggregate_tokens_correctly(
-        self, vulnerable_adapter: MockAgentAdapter
+        self, vulnerable_adapter: MockAgentAdapter, shared_attack_library: AttackLibrary
     ) -> None:
         """Token usage must be correct even when attacks run concurrently."""
         scanner = AgentScanner(
             adapter=vulnerable_adapter,
-            attack_library=AttackLibrary(),
+            attack_library=shared_attack_library,
             config={"attack_timeout": 10.0, "phase_timeout": 30.0},
         )
         result = await scanner.run_campaign(
@@ -322,12 +334,12 @@ class TestConcurrentAttackExecution:
         assert tokens["total_tokens"] == tokens["prompt_tokens"] + tokens["completion_tokens"]
 
     async def test_concurrent_attacks_no_duplicate_results(
-        self, vulnerable_adapter: MockAgentAdapter
+        self, vulnerable_adapter: MockAgentAdapter, shared_attack_library: AttackLibrary
     ) -> None:
         """Each attack vector should produce exactly one result, no duplicates."""
         scanner = AgentScanner(
             adapter=vulnerable_adapter,
-            attack_library=AttackLibrary(),
+            attack_library=shared_attack_library,
         )
         await scanner.run_campaign(
             phases=[ScanPhase.VULNERABILITY_DISCOVERY],
@@ -341,12 +353,12 @@ class TestConcurrentAttackExecution:
         )
 
     async def test_concurrent_attacks_all_results_recorded(
-        self, vulnerable_adapter: MockAgentAdapter
+        self, vulnerable_adapter: MockAgentAdapter, shared_attack_library: AttackLibrary
     ) -> None:
         """All attacks that run should have their results recorded."""
         scanner = AgentScanner(
             adapter=vulnerable_adapter,
-            attack_library=AttackLibrary(),
+            attack_library=shared_attack_library,
         )
         attacks = scanner.attack_library.get_attacks_for_phase(
             ScanPhase.VULNERABILITY_DISCOVERY, coverage=CoverageLevel.COMPREHENSIVE
@@ -361,7 +373,9 @@ class TestConcurrentAttackExecution:
         # Every attack vector should produce a result (success or failure)
         assert len(scanner._attack_results) == expected_count
 
-    async def test_concurrent_attacks_with_slow_adapter(self) -> None:
+    async def test_concurrent_attacks_with_slow_adapter(
+        self, shared_attack_library: AttackLibrary
+    ) -> None:
         """Attacks should truly run concurrently - total time < sum of individual times."""
         import asyncio
         import time
@@ -382,7 +396,7 @@ class TestConcurrentAttackExecution:
         )
         scanner = AgentScanner(
             adapter=adapter,
-            attack_library=AttackLibrary(),
+            attack_library=shared_attack_library,
         )
 
         t0 = time.monotonic()
@@ -401,12 +415,12 @@ class TestConcurrentAttackExecution:
             )
 
     async def test_concurrent_attacks_vulnerability_list_consistent(
-        self, vulnerable_adapter: MockAgentAdapter
+        self, vulnerable_adapter: MockAgentAdapter, shared_attack_library: AttackLibrary
     ) -> None:
         """Vulnerabilities found in phase result must match successful attack results."""
         scanner = AgentScanner(
             adapter=vulnerable_adapter,
-            attack_library=AttackLibrary(),
+            attack_library=shared_attack_library,
         )
         result = await scanner.run_campaign(
             phases=[ScanPhase.VULNERABILITY_DISCOVERY],
@@ -417,7 +431,9 @@ class TestConcurrentAttackExecution:
         successful_ids = {r.vector_id for r in scanner._attack_results if r.successful}
         assert set(phase_result.vulnerabilities_found) == successful_ids
 
-    async def test_concurrent_attacks_with_mixed_failures(self) -> None:
+    async def test_concurrent_attacks_with_mixed_failures(
+        self, shared_attack_library: AttackLibrary
+    ) -> None:
         """Some attacks failing should not corrupt results of successful ones."""
         import asyncio
 
@@ -439,7 +455,7 @@ class TestConcurrentAttackExecution:
         )
         scanner = AgentScanner(
             adapter=adapter,
-            attack_library=AttackLibrary(),
+            attack_library=shared_attack_library,
         )
         # Should not raise even when some attacks fail
         result = await scanner.run_campaign(
@@ -450,7 +466,9 @@ class TestConcurrentAttackExecution:
         # Campaign should complete without error
         assert result.campaign_id.startswith("campaign_")
 
-    async def test_concurrent_phase_timeout_does_not_lose_results(self) -> None:
+    async def test_concurrent_phase_timeout_does_not_lose_results(
+        self, shared_attack_library: AttackLibrary
+    ) -> None:
         """When phase times out, results gathered before timeout should be preserved."""
         import asyncio
 
@@ -465,7 +483,7 @@ class TestConcurrentAttackExecution:
         )
         scanner = AgentScanner(
             adapter=adapter,
-            attack_library=AttackLibrary(),
+            attack_library=shared_attack_library,
             config={"phase_timeout": 60.0, "attack_timeout": 5.0},
         )
         result = await scanner.run_campaign(
@@ -479,13 +497,13 @@ class TestConcurrentAttackExecution:
         assert len(scanner._attack_results) >= 0
 
     async def test_progress_events_under_concurrency(
-        self, vulnerable_adapter: MockAgentAdapter
+        self, vulnerable_adapter: MockAgentAdapter, shared_attack_library: AttackLibrary
     ) -> None:
         """Progress events should be emitted correctly even with concurrent attacks."""
         events: list[ProgressEvent] = []
         scanner = AgentScanner(
             adapter=vulnerable_adapter,
-            attack_library=AttackLibrary(),
+            attack_library=shared_attack_library,
         )
         await scanner.run_campaign(
             phases=[ScanPhase.VULNERABILITY_DISCOVERY],
@@ -506,11 +524,15 @@ class TestConcurrentAttackExecution:
 class TestScannerLLMClientWiring:
     """Tests that AgentScanner passes llm_client to DetectorPipeline."""
 
-    def test_scanner_without_llm(self, mock_adapter: MockAgentAdapter) -> None:
-        scanner = AgentScanner(adapter=mock_adapter, attack_library=AttackLibrary())
+    def test_scanner_without_llm(
+        self, mock_adapter: MockAgentAdapter, shared_attack_library: AttackLibrary
+    ) -> None:
+        scanner = AgentScanner(adapter=mock_adapter, attack_library=shared_attack_library)
         assert scanner._detector_pipeline._llm_judge is None
 
-    def test_scanner_with_llm_client_in_config(self, mock_adapter: MockAgentAdapter) -> None:
+    def test_scanner_with_llm_client_in_config(
+        self, mock_adapter: MockAgentAdapter, shared_attack_library: AttackLibrary
+    ) -> None:
         from ziran.infrastructure.llm.base import BaseLLMClient, LLMConfig
 
         mock_client = AsyncMock(spec=BaseLLMClient)
@@ -518,23 +540,27 @@ class TestScannerLLMClientWiring:
 
         scanner = AgentScanner(
             adapter=mock_adapter,
-            attack_library=AttackLibrary(),
+            attack_library=shared_attack_library,
             config={"llm_client": mock_client},
         )
         assert scanner._detector_pipeline._llm_judge is not None
 
-    def test_scanner_with_none_llm_client(self, mock_adapter: MockAgentAdapter) -> None:
+    def test_scanner_with_none_llm_client(
+        self, mock_adapter: MockAgentAdapter, shared_attack_library: AttackLibrary
+    ) -> None:
         scanner = AgentScanner(
             adapter=mock_adapter,
-            attack_library=AttackLibrary(),
+            attack_library=shared_attack_library,
             config={"llm_client": None},
         )
         assert scanner._detector_pipeline._llm_judge is None
 
-    def test_scanner_with_empty_config(self, mock_adapter: MockAgentAdapter) -> None:
+    def test_scanner_with_empty_config(
+        self, mock_adapter: MockAgentAdapter, shared_attack_library: AttackLibrary
+    ) -> None:
         scanner = AgentScanner(
             adapter=mock_adapter,
-            attack_library=AttackLibrary(),
+            attack_library=shared_attack_library,
             config={},
         )
         assert scanner._detector_pipeline._llm_judge is None

--- a/tests/unit/test_tactics.py
+++ b/tests/unit/test_tactics.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock
 
 import pytest
 
 from ziran.application.attacks.tactics import TacticExecutor, TacticType
+
+if TYPE_CHECKING:
+    from ziran.application.attacks.library import AttackLibrary
 from ziran.application.detectors.pipeline import DetectorPipeline
 from ziran.domain.entities.attack import (
     AttackCategory,
@@ -253,40 +256,34 @@ class TestTacticExecutor:
 
 
 class TestMultiTurnVectorsYAML:
-    def test_vectors_load(self) -> None:
+    def test_vectors_load(self, shared_attack_library: AttackLibrary) -> None:
         """Multi-turn tactic vectors should load without errors."""
-        from ziran.application.attacks.library import AttackLibrary
-
-        library = AttackLibrary()
+        library = shared_attack_library
         all_vectors = library.vectors
 
         multi_turn = [v for v in all_vectors if v.tactic != "single"]
         assert len(multi_turn) >= 10
 
-    def test_vectors_have_multi_turn_tag(self) -> None:
-        from ziran.application.attacks.library import AttackLibrary
-
-        library = AttackLibrary()
+    def test_vectors_have_multi_turn_tag(self, shared_attack_library: AttackLibrary) -> None:
+        library = shared_attack_library
         all_vectors = library.vectors
 
         multi_turn = [v for v in all_vectors if v.tactic != "single"]
         for v in multi_turn:
             assert "multi_turn" in v.tags, f"Vector {v.id} missing 'multi_turn' tag"
 
-    def test_vectors_have_multiple_prompts(self) -> None:
-        from ziran.application.attacks.library import AttackLibrary
-
-        library = AttackLibrary()
+    def test_vectors_have_multiple_prompts(self, shared_attack_library: AttackLibrary) -> None:
+        library = shared_attack_library
         all_vectors = library.vectors
 
         multi_turn = [v for v in all_vectors if v.tactic != "single"]
         for v in multi_turn:
             assert len(v.prompts) >= 2, f"Vector {v.id} has only {len(v.prompts)} prompt(s)"
 
-    def test_vectors_have_success_indicators_on_later_prompts(self) -> None:
-        from ziran.application.attacks.library import AttackLibrary
-
-        library = AttackLibrary()
+    def test_vectors_have_success_indicators_on_later_prompts(
+        self, shared_attack_library: AttackLibrary
+    ) -> None:
+        library = shared_attack_library
         all_vectors = library.vectors
 
         multi_turn = [v for v in all_vectors if v.tactic != "single"]


### PR DESCRIPTION
## Summary

Test suite was taking **7+ minutes** locally and **30-40 minutes on CI**. Root cause: `AttackLibrary()` was instantiated 49 times across 14 test files, each time parsing 682KB of YAML (24 files, 565 vectors).

## Changes

- Add `shared_attack_library` session-scoped fixture in `tests/conftest.py` — YAML parsed once per test run
- Convert 14 test files (49 instantiations → 1)
- Use module-scoped fixture for `test_performance_metrics.py` (was calling `collect_performance_metrics()` 6 times)
- Use module-scoped snapshot for `test_historical_tracking.py`

## Results

| Metric | Before | After | Speedup |
|--------|--------|-------|---------|
| Local runtime | 439s (7:18) | 93s (1:32) | **4.7x** |
| Perf metrics tests | 340s | 58s | 5.9x |
| Historical tracking | 10s | 1.1s | 9x |
| CI estimate | 30-40min | ~8-10min | ~4x |

## Test plan

- [x] All 1796 tests pass
- [x] Ruff lint and format clean
- [x] No behavioral changes — all tests read-only on the library

🤖 Generated with [Claude Code](https://claude.com/claude-code)