### PR TITLE
docs: configure speckit as mandatory workflow in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,4 +31,44 @@ Python 3.11+ (CI matrix: 3.11, 3.12, 3.13): Follow standard conventions
 - 002-extract-shared-factories: Added Python 3.11+ (CI matrix: 3.11, 3.12, 3.13) + click (CLI only), PyYAML, Playwright (optional), boto3 (optional), LangChain (optional), CrewAI (optional)
 
 <!-- MANUAL ADDITIONS START -->
+
+## Speckit Workflow (MANDATORY)
+
+All non-trivial features, refactors, and bug fixes MUST follow spec-driven development using speckit. Trivial changes (typo fixes, single-line config changes, comment updates) are exempt.
+
+### Required workflow order
+
+1. `/speckit.specify` — Create feature spec (what and why)
+2. `/speckit.clarify` — Resolve ambiguities (if needed)
+3. `/speckit.plan` — Design implementation (how)
+4. `/speckit.tasks` — Generate ordered work breakdown
+5. `/speckit.implement` — Execute tasks phase by phase
+
+### Additional commands
+
+- `/speckit.analyze` — Cross-artifact consistency analysis (spec ↔ plan ↔ tasks)
+- `/speckit.checklist` — Generate quality checklists for requirements
+- `/speckit.constitution` — View or amend the project constitution
+- `/speckit.taskstoissues` — Convert tasks to GitHub issues
+
+### Constitution
+
+Read `.specify/memory/constitution.md` before starting any work. It defines architecture, type safety, test coverage, and quality gate requirements.
+
+### Spec directory structure
+
+- Active specs: `specs/NNN-feature-name/` (containing spec.md, plan.md, tasks.md)
+- Archived specs: `specs/archive/NNN-feature-name/`
+- Statuses: Draft → Active → Accepted → Superseded → Deprecated
+- Specs are never deleted; archive when superseded or deprecated
+
+### Quality gates (must pass before any PR)
+
+```bash
+uv run ruff check .              # Lint — zero violations
+uv run ruff format --check .     # Format — zero drift
+uv run mypy ziran/               # Type check — zero errors (strict)
+uv run pytest --cov=ziran        # Tests — all pass, coverage >= 85%
+```
+
 <!-- MANUAL ADDITIONS END -->


### PR DESCRIPTION
## Summary

- Adds speckit spec-driven development instructions to the `CLAUDE.md` manual additions block
- Defines the mandatory workflow order: specify → clarify → plan → tasks → implement
- Lists all speckit slash commands with descriptions
- References the constitution and spec directory structure
- Includes quality gate commands

Content is placed between the `<!-- MANUAL ADDITIONS -->` markers so it survives `update-agent-context.sh` re-generation.

## Test plan

- [ ] Verify manual additions block is populated between markers
- [ ] Verify auto-generated content above markers is untouched
- [ ] Confirm `update-agent-context.sh` still works without overwriting manual content