### PR TITLE
ci: fix release-please dispatch with --repo flag

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,4 +26,5 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh workflow run release.yml \
+            --repo "${{ github.repository }}" \
             -f tag="${{ steps.release.outputs.tag_name }}"


### PR DESCRIPTION
## Summary

- Add `--repo` flag to `gh workflow run` in release-please.yml
- `gh` CLI needs git context to resolve the repository, but release-please-action doesn't checkout the repo — causing `fatal: not a git repository`

## Test plan

- [x] Next release-please run should successfully dispatch the release workflow