### PR TITLE
ci: fix npm E401 in release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,11 +125,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "npm"
-          cache-dependency-path: ui/package-lock.json
 
       - name: Build frontend
-        run: cd ui && npm ci && npm run build
+        run: |
+          echo "registry=https://registry.npmjs.org/" > ui/.npmrc
+          cd ui && npm ci && npm run build
 
       - name: Build package
         run: uv build


### PR DESCRIPTION
## Summary

- Set explicit `registry=https://registry.npmjs.org/` in `.npmrc` before `npm ci`
- Remove `cache: "npm"` from `setup-node` to avoid stale auth token conflicts
- The E401 error during v0.22.0 release was caused by npm auth configuration on the GitHub Actions runner

## Test plan

- [ ] After merge, manually trigger: `gh workflow run release.yml --repo taoq-ai/ziran -f tag=v0.22.0`
- [ ] Verify frontend builds and wheel is published to PyPI