### PR TITLE
ci: regenerate npm lockfile in release build for older tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,12 @@ jobs:
           node-version: "20"
 
       - name: Build frontend
-        run: cd ui && npm ci && npm run build
+        run: |
+          cd ui
+          echo "registry=https://registry.npmjs.org/" > .npmrc
+          npm install --package-lock-only --registry=https://registry.npmjs.org/
+          npm ci
+          npm run build
 
       - name: Build package
         run: uv build


### PR DESCRIPTION
## Summary
- Regenerate `package-lock.json` from public npm registry during release build
- Ensures older tags (v0.22.0, v0.23.0) with private JFrog URLs can still build
- Future tags already have the correct lockfile, but this acts as a safety net

## Test plan
- [ ] Manually dispatch release for v0.22.0 after merge
- [ ] Manually dispatch release for v0.23.0 after merge
- [ ] Verify both publish to PyPI successfully