### PR TITLE
ci: use PAT in release-please to trigger release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
-        id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-      # No need to dispatch release.yml — release-please creates a tag,
-      # and release.yml triggers on push:tags. Tag pushes are NOT blocked
-      # by GitHub's anti-cascade rule (only release/workflow_run events are).
+          # MUST use a PAT, not GITHUB_TOKEN. Tags created by GITHUB_TOKEN
+          # do not trigger other workflows (GitHub's anti-cascade rule).
+          # The RELEASE_PAT needs repo scope so the tag push triggers
+          # the Release workflow (release.yml).
+          token: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,9 @@ name: Release
 
 on:
   # Tag push is the primary trigger. release-please creates tags via
-  # GITHUB_TOKEN, and tag pushes ARE NOT blocked by the anti-cascade rule
-  # (only release/workflow_run events are). This works without a PAT.
+  # a PAT (RELEASE_PAT), so the push event triggers this workflow.
+  # Tags created by GITHUB_TOKEN would NOT trigger this due to
+  # GitHub's anti-cascade rule — that's why a PAT is required.
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"        # stable:  v1.2.3
@@ -43,6 +44,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Verify tag is ancestor of main
         run: |


### PR DESCRIPTION
## Summary
- Switch release-please from `GITHUB_TOKEN` to `RELEASE_PAT` so tag pushes trigger the Release workflow
- Add `verify-tag` gate to prevent publishing from orphaned/detached commits

## Root cause
`GITHUB_TOKEN` tag pushes do not trigger other workflows (GitHub anti-cascade rule). This caused v0.22.0 and v0.25.0 to never publish to PyPI — the tag was created but the release workflow never ran.

v0.23.0 worked because it was manually tagged (personal credentials), not by release-please.

## Required setup
Create a **fine-grained PAT** (`RELEASE_PAT`) with `contents: write` scope and add it as a repository secret.

## Test plan
- [ ] Create `RELEASE_PAT` secret in repo settings
- [ ] Merge this PR
- [ ] Manually trigger release for v0.22.0 and v0.25.0 via `workflow_dispatch`
- [ ] Verify next release-please tag push triggers the Release workflow