### PR TITLE
ci: fix verify-tag to fetch all tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          fetch-tags: true
+
+      - name: Fetch all tags
+        run: git fetch --tags --force
 
       - name: Verify tag is ancestor of main
         run: |


### PR DESCRIPTION
## Summary
- Replace `fetch-tags: true` with explicit `git fetch --tags --force` in verify-tag step
- `actions/checkout@v4` `fetch-tags` doesn't fetch tags not reachable from the checked-out ref, causing `workflow_dispatch` re-releases of older tags to fail

## Test plan
- [ ] Merge and re-trigger `workflow_dispatch` for v0.22.0