### PR TITLE
docs: update mkdocs pages -- explain why, remove sales tone, fix diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 
-**Find vulnerabilities in AI agents — not just LLMs, but agents with tools, memory, and multi-step reasoning.**
+**Find vulnerabilities in AI agents -- not just LLMs, but agents with tools, memory, and multi-step reasoning.**
 
 ![ZIRAN Dashboard](docs/assets/ui-dashboard.png)
 
@@ -41,34 +41,36 @@ Full results: [benchmarks/](benchmarks/) · [docs](https://taoq-ai.github.io/zir
 
 ## Why ZIRAN?
 
-Most security tools test individual prompts or tools in isolation. ZIRAN discovers how tool **combinations** create attack paths — an agent with `read_file` and `http_request` has a critical data exfiltration vulnerability, even if neither tool is dangerous alone.
+Most security tools test prompts and tools in isolation. But agent vulnerabilities emerge from how tools interact -- an agent with `read_file` and `http_request` has a data exfiltration path, even though neither tool is dangerous alone. Testing each tool individually misses this entirely.
+
+ZIRAN models your agent as a graph of capabilities and tests what happens when they combine.
 
 | Capability | ZIRAN | [Promptfoo](https://github.com/promptfoo/promptfoo) | [Invariant](https://invariantlabs.ai/) (Snyk) | [Garak](https://github.com/NVIDIA/garak) | [PyRIT](https://github.com/Azure/PyRIT) | [Inspect AI](https://github.com/UKGovernmentBEIS/inspect_ai) |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|
-| Tool chain discovery (graph-based) | **Yes** | — | Policy-based | — | — | — |
-| Side-effect detection (execution-level) | **Yes** | — | Trace-based | — | — | Sandbox |
-| Multi-phase campaigns w/ graph feedback | **Yes** | Turn-level | Flow analysis | — | Composable | Multi-turn |
-| Autonomous pentesting agent | **Yes** | — | — | — | — | — |
-| Multi-agent coordination | **Yes** | — | — | — | — | — |
-| Knowledge graph tracking | **Yes** | — | Policy lang. | — | — | — |
-| Agent-aware (tools + memory) | **Yes** | Partial | **Yes** | — | — | Partial |
-| A2A protocol support | **Yes** | — | — | — | — | — |
-| MCP protocol support | **Yes** | Partial | **Yes** | — | — | — |
-| Encoding/obfuscation attacks | **Yes** (8) | **Yes** (12+) | — | — | — | — |
-| Industry compliance plugins | — | **Yes** (46) | — | — | — | — |
-| Streaming (SSE/WebSocket) | **Yes** | — | — | — | — | — |
-| CI/CD quality gate | **Yes** | **Yes** | — | — | — | — |
+| Tool chain discovery (graph-based) | Yes | -- | Policy-based | -- | -- | -- |
+| Side-effect detection (execution-level) | Yes | -- | Trace-based | -- | -- | Sandbox |
+| Multi-phase campaigns w/ graph feedback | Yes | Turn-level | Flow analysis | -- | Composable | Multi-turn |
+| Autonomous pentesting agent | Yes | -- | -- | -- | -- | -- |
+| Multi-agent coordination | Yes | -- | -- | -- | -- | -- |
+| Knowledge graph tracking | Yes | -- | Policy lang. | -- | -- | -- |
+| Agent-aware (tools + memory) | Yes | Partial | Yes | -- | -- | Partial |
+| A2A protocol support | Yes | -- | -- | -- | -- | -- |
+| MCP protocol support | Yes | Partial | Yes | -- | -- | -- |
+| Encoding/obfuscation attacks | Yes (8) | Yes (12+) | -- | -- | -- | -- |
+| Industry compliance plugins | -- | Yes (46) | -- | -- | -- | -- |
+| Streaming (SSE/WebSocket) | Yes | -- | -- | -- | -- | -- |
+| CI/CD quality gate | Yes | Yes | -- | -- | -- | -- |
 | Open source | Apache-2.0 | MIT | Partial | Apache-2.0 | MIT | MIT |
 
-**Key differentiators:**
+**What these capabilities catch:**
 
-- **Tool Chain Discovery** — Graph-based detection of dangerous tool combinations (`read_file` → `http_request` = data exfiltration). Discovery-based, not policy-based.
-- **Side-Effect Detection** — Catches when agents refuse in text but execute dangerous tools anyway.
-- **Multi-Phase Campaigns** — 8-phase trust exploitation with live knowledge graph feedback between phases.
-- **Autonomous Pentesting Agent** — LLM-driven agent that plans, executes, and adapts attack campaigns with finding deduplication.
-- **Multi-Agent Coordination** — Discovers topologies and tests cross-agent trust boundaries.
-- **A2A + MCP Protocol Depth** — First security tool to test [Agent-to-Agent](https://google.github.io/A2A/) agents.
-- **Framework Agnostic** — LangChain, CrewAI, Bedrock, MCP, browser UIs, remote HTTPS agents, or [custom adapters](examples/08-custom-adapter/).
+- **Tool Chain Discovery** -- Individual tools pass security review, but their compositions create vulnerabilities. Graph-based analysis finds transitive attack paths (e.g., `read_file` -> `http_request` = data exfiltration) that list-based testing misses.
+- **Side-Effect Detection** -- Agents can refuse a request in their text response while still executing the dangerous tool call. Without execution-level monitoring, these silent failures go undetected.
+- **Multi-Phase Campaigns** -- Real attackers don't send a single malicious prompt. They build trust, map capabilities, then exploit. Multi-phase campaigns model this behavior to find vulnerabilities that single-turn tests miss.
+- **Knowledge Graph** -- A live graph of discovered tools, permissions, and data flows grows as the scan progresses. Each phase uses it to plan the next, catching vulnerabilities that only appear after building enough context about the agent.
+- **Multi-Agent Coordination** -- In multi-agent systems, an agent may trust messages from peers without validation. Testing cross-agent trust boundaries reveals lateral movement paths.
+- **A2A + MCP Protocols** -- Tests [Agent-to-Agent](https://google.github.io/A2A/) and [MCP](https://modelcontextprotocol.io/) agents through their native protocols, exercising the actual attack surface rather than a simplified proxy.
+- **Framework Agnostic** -- LangChain, CrewAI, Bedrock, MCP, browser UIs, remote HTTPS agents, or [custom adapters](examples/08-custom-adapter/).
 
 ### What ZIRAN Is / What ZIRAN Is Not
 
@@ -76,9 +78,9 @@ Most security tools test individual prompts or tools in isolation. ZIRAN discove
 
 **ZIRAN is not:**
 
-- An LLM safety/alignment tool — for prompt injection breadth, jailbreak templates, and compliance testing, use [Promptfoo](https://github.com/promptfoo/promptfoo) or [Garak](https://github.com/NVIDIA/garak)
-- A runtime guardrail — for real-time input/output protection, use [NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails), [Lakera Guard](https://www.lakera.ai/), or [LLM Guard](https://github.com/protectai/llm-guard)
-- A general-purpose eval framework — for model evaluation and benchmarking, use [Inspect AI](https://github.com/UKGovernmentBEIS/inspect_ai) or [Deepeval](https://github.com/confident-ai/deepeval)
+- An LLM safety/alignment tool -- for prompt injection breadth, jailbreak templates, and compliance testing, use [Promptfoo](https://github.com/promptfoo/promptfoo) or [Garak](https://github.com/NVIDIA/garak)
+- A runtime guardrail -- for real-time input/output protection, use [NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails), [Lakera Guard](https://www.lakera.ai/), or [LLM Guard](https://github.com/protectai/llm-guard)
+- A general-purpose eval framework -- for model evaluation and benchmarking, use [Inspect AI](https://github.com/UKGovernmentBEIS/inspect_ai) or [Deepeval](https://github.com/confident-ai/deepeval)
 
 ### Works With
 
@@ -125,7 +127,7 @@ docker compose up
 # Dashboard: http://localhost:8484
 ```
 
-### Attack Library — 565 vectors across 11 categories
+### Attack Library -- 565 vectors across 11 categories
 
 ![Attack Library](docs/assets/ui-library.png)
 
@@ -190,13 +192,13 @@ print(f"Vulnerabilities found: {result.total_vulnerabilities}")
 print(f"Dangerous tool chains: {len(result.dangerous_tool_chains)}")
 ```
 
-See [examples/](examples/) for 22 runnable demos — from static analysis to autonomous pentesting.
+See [examples/](examples/) for 22 runnable demos -- from static analysis to autonomous pentesting.
 
 ---
 
 ## Remote Agent Scanning
 
-ZIRAN can test any published agent over HTTPS — no source code or in-process access required. Define your target in a YAML file and ZIRAN handles the rest:
+ZIRAN can test any published agent over HTTPS -- no source code or in-process access required. Define your target in a YAML file:
 
 ```yaml
 # target.yaml
@@ -238,20 +240,20 @@ See [examples/15-remote-agent-scan/](examples/15-remote-agent-scan/) for ready-t
 
 ## What ZIRAN Finds
 
-**Prompt-level** — injection, system prompt extraction, memory poisoning, chain-of-thought manipulation.
+**Prompt-level** -- injection, system prompt extraction, memory poisoning, chain-of-thought manipulation.
 
-**Tool-level** — tool manipulation, privilege escalation, data exfiltration chains.
+**Tool-level** -- tool manipulation, privilege escalation, data exfiltration chains.
 
-**Tool chains** (unique to ZIRAN) — automatic graph analysis of dangerous tool compositions:
+**Tool chains** -- automatic graph analysis of dangerous tool compositions:
 
 ```
-┌──────────┬─────────────────────┬─────────────────────────────┬──────────────────────────────────────┐
-│ Risk     │ Type                │ Tools                       │ Description                          │
-├──────────┼─────────────────────┼─────────────────────────────┼──────────────────────────────────────┤
-│ critical │ data_exfiltration   │ read_file → http_request    │ File contents sent to external server│
-│ critical │ sql_to_rce          │ sql_query → execute_code    │ SQL results executed as code         │
-│ high     │ pii_leakage         │ get_user_info → external_api│ User PII sent to third-party API     │
-└──────────┴─────────────────────┴─────────────────────────────┴──────────────────────────────────────┘
++----------+---------------------+-----------------------------+--------------------------------------+
+| Risk     | Type                | Tools                       | Description                          |
++----------+---------------------+-----------------------------+--------------------------------------+
+| critical | data_exfiltration   | read_file -> http_request   | File contents sent to external server|
+| critical | sql_to_rce          | sql_query -> execute_code   | SQL results executed as code         |
+| high     | pii_leakage         | get_user_info -> external_api| User PII sent to third-party API    |
++----------+---------------------+-----------------------------+--------------------------------------+
 ```
 
 ---
@@ -271,11 +273,11 @@ flowchart LR
 
     subgraph ziran["⛩️ ZIRAN Pipeline"]
         direction TB
-        D["1 · DISCOVER\nProbe tools, permissions,\ndata access"]
-        MAP["2 · MAP\nBuild knowledge graph\n(NetworkX MultiDiGraph)"]
-        A["3 · ANALYZE\nWalk graph for dangerous\nchains (30+ patterns)"]
-        ATK["4 · ATTACK\nMulti-phase exploits\ninformed by the graph"]
-        R["5 · REPORT\nScored findings with\nremediation guidance"]
+        D["🔍 DISCOVER\nProbe tools, permissions,\ndata access"]
+        MAP["🗺️ MAP\nBuild knowledge graph\n(NetworkX MultiDiGraph)"]
+        A["⚡ ANALYZE\nWalk graph for dangerous\nchains (30+ patterns)"]
+        ATK["🎯 ATTACK\nMulti-phase exploits\ninformed by the graph"]
+        R["📋 REPORT\nScored findings with\nremediation guidance"]
         D --> MAP --> A --> ATK --> R
     end
 
@@ -298,7 +300,52 @@ flowchart LR
     style P fill:#2d2d44,stroke:#e94560,color:#fff
 ```
 
-**Campaigns** run 8 phases (reconnaissance → trust building → capability mapping → vulnerability discovery → exploitation setup → execution → persistence → exfiltration), each feeding a live knowledge graph. Three strategies: `fixed` (sequential), `adaptive` (rule-based reordering), `llm-adaptive` (LLM-driven planning). See [adaptive campaigns docs](https://taoq-ai.github.io/ziran/concepts/adaptive-campaigns/).
+### Campaign Phases
+
+Campaigns run 8 phases: reconnaissance, trust building, capability mapping, vulnerability discovery, exploitation setup, execution, persistence, and exfiltration. Each phase feeds its findings into a live knowledge graph, and the graph informs which phase to run next.
+
+Phases are **not linear** -- the knowledge graph drives execution order. A discovery in the exploitation phase may trigger a return to reconnaissance. An agent that reveals new tools during trust building causes capability mapping to re-run with updated context.
+
+```mermaid
+flowchart TD
+    KG["🧠 Knowledge Graph\n(live state)"]
+
+    R["🔍 Reconnaissance"] --> KG
+    TB["🤝 Trust Building"] --> KG
+    CM["🗺️ Capability Mapping"] --> KG
+    VD["⚡ Vulnerability Discovery"] --> KG
+    ES["🎯 Exploitation Setup"] --> KG
+    EX["💥 Execution"] --> KG
+    PE["🔒 Persistence"] --> KG
+    EXF["📤 Exfiltration"] --> KG
+
+    KG -->|"decides next phase"| R
+    KG -->|"decides next phase"| TB
+    KG -->|"decides next phase"| CM
+    KG -->|"decides next phase"| VD
+    KG -->|"decides next phase"| ES
+    KG -->|"decides next phase"| EX
+    KG -->|"decides next phase"| PE
+    KG -->|"decides next phase"| EXF
+
+    style KG fill:#1a1a2e,stroke:#e94560,color:#fff,stroke-width:2px
+    style R fill:#16213e,stroke:#0ea5e9,color:#fff
+    style TB fill:#16213e,stroke:#0ea5e9,color:#fff
+    style CM fill:#16213e,stroke:#0ea5e9,color:#fff
+    style VD fill:#16213e,stroke:#0ea5e9,color:#fff
+    style ES fill:#16213e,stroke:#e94560,color:#fff
+    style EX fill:#16213e,stroke:#e94560,color:#fff
+    style PE fill:#16213e,stroke:#e94560,color:#fff
+    style EXF fill:#16213e,stroke:#e94560,color:#fff
+```
+
+Three strategies control this:
+
+- **`fixed`** -- Sequential execution through all 8 phases (reproducible, good for CI)
+- **`adaptive`** -- Rule-based reordering: skips phases that won't yield results given current graph state, revisits phases when new capabilities are discovered
+- **`llm-adaptive`** -- LLM-driven planning: an LLM examines the knowledge graph after each phase and decides what to do next
+
+See [adaptive campaigns docs](https://taoq-ai.github.io/ziran/concepts/adaptive-campaigns/).
 
 ---
 
@@ -306,9 +353,9 @@ flowchart LR
 
 Three output formats, generated automatically:
 
-- **HTML** — Interactive knowledge graph with attack path highlighting
-- **Markdown** — CI/CD-friendly summary tables
-- **JSON** — Machine-parseable for programmatic consumption
+- **HTML** -- Interactive knowledge graph with attack path highlighting
+- **Markdown** -- CI/CD-friendly summary tables
+- **JSON** -- Machine-parseable for programmatic consumption
 
 <div align="center">
   <img src="docs/assets/report.png" alt="ZIRAN HTML Report" width="800">
@@ -386,7 +433,7 @@ If you use ZIRAN in academic work, please cite:
   year      = {2026},
   url       = {https://github.com/taoq-ai/ziran},
   license   = {Apache-2.0},
-  version   = {0.20.0}
+  version   = {0.25.0}
 }
 ```
 
@@ -394,7 +441,7 @@ If you use ZIRAN in academic work, please cite:
 
 ## License
 
-[Apache License 2.0](LICENSE) — See [NOTICE](NOTICE) for third-party attributions.
+[Apache License 2.0](LICENSE) -- See [NOTICE](NOTICE) for third-party attributions.
 
 <p align="center">
   Built by <a href="https://www.taoq.ai">TaoQ AI</a>

--- a/docs/concepts/adaptive-campaigns.md
+++ b/docs/concepts/adaptive-campaigns.md
@@ -1,6 +1,10 @@
 # Adaptive Campaigns
 
-ZIRAN supports three campaign execution strategies that control how scan phases are orchestrated. Choose the strategy that fits your testing scenario.
+## Why Adaptive?
+
+A fixed-order scan runs every phase regardless of what it finds. This is predictable but wasteful -- if reconnaissance reveals the agent has no file access tools, running file-based exploitation phases produces no results.
+
+Adaptive strategies use the knowledge graph to make better decisions: skip phases that won't yield findings, repeat phases where partial results suggest deeper vulnerabilities, and prioritize the most promising attack surface. This means higher coverage with fewer wasted interactions.
 
 ## Strategies
 
@@ -31,7 +35,7 @@ Best for: Thorough manual assessments, complex agents with many capabilities.
 
 ### LLM-Adaptive
 
-Uses an LLM to analyze the current knowledge graph, all previous findings, and the agent's capabilities to dynamically plan the next phase. The LLM acts as a strategy advisor — it doesn't execute attacks, it decides *which* attacks to run and in *what order*.
+Uses an LLM to analyze the current knowledge graph, all previous findings, and the agent's capabilities to dynamically plan the next phase. The LLM acts as a strategy advisor -- it doesn't execute attacks, it decides *which* attacks to run and in *what order*.
 
 ```bash
 ziran scan --target target.yaml --strategy llm-adaptive
@@ -57,28 +61,30 @@ Best for: Maximum coverage on high-value targets, red-team exercises.
 
 ## How Adaptive Strategies Work
 
+All three strategies follow the same loop -- execute a phase, update the knowledge graph, decide what to do next. The difference is how "decide" works:
+
 ```mermaid
 flowchart TD
-    S["Start Campaign"] --> P["Execute Phase"]
-    P --> A["Analyze Results"]
-    A --> D{"Strategy\nDecision"}
-    D -->|"Fixed"| N["Next Phase\n(sequential)"]
-    D -->|"Adaptive"| R["Rule Engine\n(graph analysis)"]
-    D -->|"LLM-Adaptive"| L["LLM Advisor\n(dynamic planning)"]
-    R --> P
-    L --> P
-    N --> P
-    N --> E["End"]
-    R --> E
-    L --> E
+    S["🚀 Start Campaign"] --> P["⚡ Execute Phase"]
+    P --> G["🧠 Update Knowledge Graph"]
+    G --> D{"Strategy\nDecision"}
+    D -->|"Fixed"| N["Next Phase\n(sequential order)"]
+    D -->|"Adaptive"| R["🔧 Rule Engine\n(graph-based rules)"]
+    D -->|"LLM-Adaptive"| L["🤖 LLM Advisor\n(dynamic planning)"]
+    R --> C{"Continue?"}
+    L --> C
+    N --> C
+    C -->|"Yes"| P
+    C -->|"No"| E["📋 Report"]
 
     style S fill:#16213e,stroke:#0ea5e9,color:#fff
     style P fill:#16213e,stroke:#0ea5e9,color:#fff
-    style A fill:#16213e,stroke:#0ea5e9,color:#fff
+    style G fill:#1a1a2e,stroke:#e94560,color:#fff
     style D fill:#16213e,stroke:#e94560,color:#fff
     style R fill:#0f3460,stroke:#10b981,color:#fff
     style L fill:#0f3460,stroke:#10b981,color:#fff
     style N fill:#0f3460,stroke:#10b981,color:#fff
+    style C fill:#16213e,stroke:#e94560,color:#fff
     style E fill:#1e293b,stroke:#10b981,color:#fff
 ```
 
@@ -121,6 +127,6 @@ class MyStrategy(CampaignStrategy):
 
 ## See Also
 
-- [Architecture](architecture.md) — Overall system design
-- [Trust Exploitation](romance-scan.md) — The 8-phase methodology
-- [CLI Reference](../reference/cli.md) — `--strategy` option documentation
+- [Architecture](architecture.md) -- Overall system design
+- [Trust Exploitation](romance-scan.md) -- The 8-phase methodology
+- [CLI Reference](../reference/cli.md) -- `--strategy` option documentation

--- a/docs/concepts/knowledge-graph.md
+++ b/docs/concepts/knowledge-graph.md
@@ -1,17 +1,27 @@
 # Knowledge Graph
 
+## Why a Graph?
+
+During a scan, ZIRAN discovers tools, permissions, data sources, and their relationships. A flat list of findings loses the connections between them -- you see that `read_file` exists and `http_request` exists, but not that they can chain together into a data exfiltration path.
+
+A directed graph preserves these relationships. Each discovery becomes a node, each relationship an edge. As the scan progresses, the graph grows and reveals attack paths that only become visible after enough context is gathered -- a tool discovered in phase 1 might combine with a permission found in phase 4 to create a vulnerability neither phase would catch alone.
+
+The graph also drives adaptive campaigns: after each phase, the strategy examines the graph to decide which phase to run next.
+
+## Implementation
+
 ZIRAN uses a **NetworkX-based directed multigraph** to track all discoveries, relationships, and attack paths during a scan campaign.
 
 ## Node Types
 
-| Type | Shape | Description |
-|------|-------|-------------|
-| `capability` | Circle | A discovered agent capability |
-| `tool` | Diamond | An invokable tool the agent has access to |
-| `vulnerability` | Triangle | A discovered vulnerability |
-| `data_source` | Square | A data source the agent can access |
-| `phase` | Hexagon | A scan phase execution |
-| `agent_state` | Ellipse | A snapshot of agent state |
+| Type | Icon | Description |
+|------|------|-------------|
+| `capability` | :gear: | A discovered agent capability |
+| `tool` | :wrench: | An invokable tool the agent has access to |
+| `vulnerability` | :warning: | A discovered vulnerability |
+| `data_source` | :file_folder: | A data source the agent can access |
+| `phase` | :repeat: | A scan phase execution |
+| `agent_state` | :robot: | A snapshot of agent state |
 
 ## Edge Types
 

--- a/docs/concepts/romance-scan.md
+++ b/docs/concepts/romance-scan.md
@@ -1,6 +1,6 @@
 # Multi-Phase Trust Exploitation
 
-ZIRAN's core methodology is a **multi-phase trust exploitation campaign** inspired by social engineering. Instead of throwing attacks at an agent randomly, ZIRAN builds trust incrementally — exactly like a real attacker would.
+ZIRAN's core methodology is a **multi-phase trust exploitation campaign** inspired by social engineering. Instead of throwing attacks at an agent randomly, ZIRAN builds trust incrementally -- exactly like a real attacker would.
 
 !!! danger "Why this matters"
 
@@ -20,33 +20,52 @@ A multi-phase approach overcomes these defences by establishing trust first, the
 
 | Approach | Typical Detection Rate | Against Hardened Agents |
 |----------|----------------------|------------------------|
-| Single-shot injection | 40–60% | 10–20% |
-| **Multi-phase campaign** | **80–95%** | **60–80%** |
+| Single-shot injection | 40--60% | 10--20% |
+| **Multi-phase campaign** | **80--95%** | **60--80%** |
 
 ## The Eight Phases
 
-```mermaid
-graph LR
-    P1[1. Reconnaissance] --> P2[2. Trust Building]
-    P2 --> P3[3. Capability Mapping]
-    P3 --> P4[4. Vulnerability Discovery]
-    P4 --> P5[5. Exploitation Setup]
-    P5 --> P6[6. Execution]
-    P6 --> P7[7. Persistence]
-    P7 --> P8[8. Exfiltration]
+Phases are **not linear**. Each phase feeds its findings into the knowledge graph, and the graph drives what happens next. A discovery during execution may trigger a return to reconnaissance. New tools revealed during trust building cause capability mapping to re-run with updated context.
 
-    style P1 fill:#4051B5,color:#fff
-    style P2 fill:#4051B5,color:#fff
-    style P3 fill:#4051B5,color:#fff
-    style P4 fill:#E53935,color:#fff
-    style P5 fill:#E53935,color:#fff
-    style P6 fill:#E53935,color:#fff
-    style P7 fill:#FF9800,color:#000
-    style P8 fill:#FF9800,color:#000
+The diagram below shows how the knowledge graph sits at the center, receiving findings from each phase and informing which phase runs next:
+
+```mermaid
+flowchart TD
+    KG["🧠 Knowledge Graph\n(live state)"]
+
+    R["🔍 1. Reconnaissance"] --> KG
+    TB["🤝 2. Trust Building"] --> KG
+    CM["🗺️ 3. Capability Mapping"] --> KG
+    VD["⚡ 4. Vulnerability Discovery"] --> KG
+    ES["🎯 5. Exploitation Setup"] --> KG
+    EX["💥 6. Execution"] --> KG
+    PE["🔒 7. Persistence"] --> KG
+    EXF["📤 8. Exfiltration"] --> KG
+
+    KG -->|"decides next phase"| R
+    KG -->|"decides next phase"| TB
+    KG -->|"decides next phase"| CM
+    KG -->|"decides next phase"| VD
+    KG -->|"decides next phase"| ES
+    KG -->|"decides next phase"| EX
+    KG -->|"decides next phase"| PE
+    KG -->|"decides next phase"| EXF
+
+    style KG fill:#1a1a2e,stroke:#e94560,color:#fff,stroke-width:2px
+    style R fill:#4051B5,color:#fff
+    style TB fill:#4051B5,color:#fff
+    style CM fill:#4051B5,color:#fff
+    style VD fill:#E53935,color:#fff
+    style ES fill:#E53935,color:#fff
+    style EX fill:#E53935,color:#fff
+    style PE fill:#FF9800,color:#000
+    style EXF fill:#FF9800,color:#000
 ```
 
+With the `fixed` strategy, phases run sequentially (1 through 8) for reproducibility. With `adaptive` or `llm-adaptive`, the knowledge graph drives phase selection -- phases can be skipped, reordered, or revisited. See [Adaptive Campaigns](adaptive-campaigns.md).
+
 ### Phase 1: Reconnaissance
-Discover what the agent can do — tools, skills, permissions, and data access. This is passive; no attacks are sent. For remote agents, ZIRAN reads endpoint metadata, OpenAPI specs, or A2A Agent Cards.
+Discover what the agent can do -- tools, skills, permissions, and data access. This is passive; no attacks are sent. For remote agents, ZIRAN reads endpoint metadata, OpenAPI specs, or A2A Agent Cards.
 
 ### Phase 2: Trust Building
 Establish conversational rapport. Ask legitimate questions, use the agent as intended. This builds a conversation history that makes later attacks more likely to succeed.
@@ -75,9 +94,9 @@ The `--coverage` flag controls how many phases ZIRAN runs:
 
 | Level | Phases Included | Use Case |
 |-------|----------------|----------|
-| `essential` | 1–4 (Recon → Vulnerability Discovery) | Quick feedback during development |
-| `standard` | 1–6 (Recon → Execution) | Pre-deployment gate (**default**) |
-| `comprehensive` | 1–8 (All phases) | Full security audit |
+| `essential` | 1--4 (Recon -> Vulnerability Discovery) | Quick feedback during development |
+| `standard` | 1--6 (Recon -> Execution) | Pre-deployment gate (**default**) |
+| `comprehensive` | 1--8 (All phases) | Full security audit |
 
 ```bash
 # Quick check
@@ -89,19 +108,9 @@ ziran scan --target target.yaml --coverage comprehensive
 
 ## Knowledge Graph Integration
 
-Each phase updates the **attack knowledge graph** — a directed graph that tracks:
+Each phase updates the **attack knowledge graph** -- a directed graph that tracks:
 
 - **Nodes**: Agent capabilities, tools, data sources, vulnerabilities
 - **Edges**: Relationships (`uses_tool`, `accesses_data`, `enables`, `can_chain_to`)
 
 The graph enables ZIRAN to discover attack paths that span multiple phases and tool invocations. See [Knowledge Graph](knowledge-graph.md) for details.
-
-## How It Compares
-
-| Feature | ZIRAN | Single-Shot Tools |
-|---------|-------|------------------|
-| Phase-aware campaigns | :white_check_mark: 8 phases | :x: 1 phase |
-| Trust escalation | :white_check_mark: Automatic | :x: None |
-| Knowledge graph | :white_check_mark: Builds per-phase | :x: N/A |
-| Tool chain reasoning | :white_check_mark: Graph-based | :x: None |
-| Coverage control | :white_check_mark: 3 levels | :x: All or nothing |

--- a/docs/concepts/tool-chains.md
+++ b/docs/concepts/tool-chains.md
@@ -1,45 +1,45 @@
 # Tool Chain Analysis
 
-**Tool Chain Analysis is ZIRAN's unique differentiator.** No other AI security testing tool automatically detects dangerous tool combinations.
-
 ## The Problem
 
-An agent with `read_file` is not inherently dangerous. An agent with `http_request` is not inherently dangerous. But an agent with **both** has a critical data exfiltration vulnerability — an attacker can read local files and send their contents to an external server.
+An agent with `read_file` is not inherently dangerous. An agent with `http_request` is not inherently dangerous. But an agent with **both** has a critical data exfiltration vulnerability -- an attacker can read local files and send their contents to an external server.
 
-Traditional tools test individual prompts. ZIRAN reasons about **tool composition**.
+Security reviews that examine tools individually will approve both. The vulnerability only exists in their **composition** -- and that's what tool chain analysis detects.
 
-## How It Works
+## Why Graph-Based Detection Matters
 
-After a scan campaign completes, ZIRAN's `ToolChainAnalyzer` examines the knowledge graph:
+List-based testing checks each tool against a blocklist. Policy-based approaches define rules for known-bad combinations. Both miss transitive chains -- when tool A connects to tool B through an intermediate tool C that is not itself dangerous.
 
-1. **Direct chains** — Tool A has a direct edge to Tool B, and (A, B) matches a known dangerous pattern
-2. **Indirect chains** — Tools A and B are connected through intermediate nodes (A → X → B)
-3. **Cycles** — Circular chains (A → B → C → A) that enable repeated exploitation
+Graph-based analysis builds a directed graph of all tool relationships and walks it for dangerous paths. This catches:
 
-### Dangerous Pattern Database
+- **Direct chains** -- Tool A has a direct edge to Tool B, and (A, B) matches a known dangerous pattern
+- **Indirect chains** -- Tools A and B are connected through intermediate nodes (A -> X -> B)
+- **Cycles** -- Circular chains (A -> B -> C -> A) that enable repeated exploitation
+
+## Dangerous Pattern Database
 
 ZIRAN ships with 30+ dangerous tool chain patterns:
 
 | Category | Example | Risk |
 |----------|---------|------|
-| Data Exfiltration | `read_file` → `http_request` | Critical |
-| SQL to RCE | `sql_query` → `execute_code` | Critical |
-| PII Leakage | `get_user_info` → `external_api` | High |
-| Privilege Escalation | `search_database` → `update_permissions` | Critical |
-| File Manipulation | `read_file` → `write_file` | High |
-| Remote Code Execution | `http_request` → `shell_execute` | Critical |
-| Authentication Bypass | `read_config` → `generate_token` | Critical |
-| Data Poisoning | `http_request` → `write_file` | High |
-| Session Hijacking | `get_session` → `http_request` | Critical |
-| MCP Exploitation | `mcp_list_servers` → `mcp_invoke` | High |
+| Data Exfiltration | `read_file` -> `http_request` | Critical |
+| SQL to RCE | `sql_query` -> `execute_code` | Critical |
+| PII Leakage | `get_user_info` -> `external_api` | High |
+| Privilege Escalation | `search_database` -> `update_permissions` | Critical |
+| File Manipulation | `read_file` -> `write_file` | High |
+| Remote Code Execution | `http_request` -> `shell_execute` | Critical |
+| Authentication Bypass | `read_config` -> `generate_token` | Critical |
+| Data Poisoning | `http_request` -> `write_file` | High |
+| Session Hijacking | `get_session` -> `http_request` | Critical |
+| MCP Exploitation | `mcp_list_servers` -> `mcp_invoke` | High |
 
-### Risk Scoring
+## Risk Scoring
 
-Each chain receives a 0.0–1.0 risk score based on:
+Each chain receives a 0.0--1.0 risk score based on:
 
-- **Base severity** — Critical (1.0), High (0.75), Medium (0.5), Low (0.25)
-- **Chain type** — Direct (1.0×), Cycle (0.9×), Indirect (0.8×)
-- **Graph centrality** — Bonus for tools that are central to many paths
+- **Base severity** -- Critical (1.0), High (0.75), Medium (0.5), Low (0.25)
+- **Chain type** -- Direct (1.0x), Cycle (0.9x), Indirect (0.8x)
+- **Graph centrality** -- Bonus for tools that are central to many paths
 
 ## Using Chain Analysis
 
@@ -52,7 +52,7 @@ analyzer = ToolChainAnalyzer(scanner.graph)
 chains = analyzer.analyze()
 
 for chain in chains:
-    print(f"{chain.risk_level}: {' → '.join(chain.tools)}")
+    print(f"{chain.risk_level}: {' -> '.join(chain.tools)}")
     print(f"  Type: {chain.vulnerability_type}")
     print(f"  Score: {chain.risk_score}")
     print(f"  Fix: {chain.remediation}")
@@ -60,7 +60,7 @@ for chain in chains:
 
 ### In Reports
 
-Tool chains appear prominently in all report formats — HTML, Markdown, and JSON.
+Tool chains appear prominently in all report formats -- HTML, Markdown, and JSON.
 
 ## Adding Custom Patterns
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,14 @@
-# ZIRAN — AI Agent Security Testing
+# ZIRAN -- AI Agent Security Testing
 
-**Find vulnerabilities in AI agents — not just LLMs, but agents with tools, memory, and multi-step reasoning.**
+**Find vulnerabilities in AI agents -- not just LLMs, but agents with tools, memory, and multi-step reasoning.**
 
 ---
 
 ## The Problem
 
-Most security tools test individual prompts or tools in isolation. But AI agents have a fundamentally different attack surface — **tool combinations**:
+Most security tools test individual prompts or tools in isolation. But AI agents have a fundamentally different attack surface -- **tool combinations**:
 
-- An agent with `read_file` and `http_request` has a **critical data exfiltration vulnerability** — even if neither tool is dangerous alone
+- An agent with `read_file` and `http_request` has a **critical data exfiltration vulnerability** -- even if neither tool is dangerous alone
 - An agent that says "I can't do that" but **executes the tool anyway** will pass text-based evaluation but fail in production
 - Vulnerabilities that only emerge after **building trust across multiple interactions** are invisible to single-pass testing
 
@@ -16,19 +16,17 @@ ZIRAN discovers these composition-level risks through knowledge graph analysis, 
 
 ## What ZIRAN Does
 
-ZIRAN is the first open-source framework designed specifically for **agent security testing**:
-
 !!! success "Core Capabilities"
 
-    - :link: **Tool Chain Analysis** — Automatically detects dangerous tool combinations across 30+ known patterns
-    - :shield: **Multi-Phase Trust Exploitation** — Progressive campaigns that build trust before testing boundaries
-    - :people_holding_hands: **Multi-Agent Coordination** — Discover topologies and test cross-agent trust boundaries in supervisor, router, and peer-to-peer systems
-    - :brain: **Adaptive Campaigns** — Three execution strategies (fixed, rule-based adaptive, LLM-driven) that adjust attack plans based on findings
-    - :zap: **Streaming Support** — Real-time attack monitoring via SSE and WebSocket protocols
-    - :globe_with_meridians: **Remote Agent Scanning** — Test any published agent over HTTPS (REST, OpenAI, MCP, A2A)
-    - :world_map: **Knowledge Graph** — Every capability, relationship, and attack path tracked in a live graph
-    - :bar_chart: **CI/CD Quality Gate** — Block deployments that fail security thresholds, with SARIF output
-    - :mag: **Static Analysis** — Scan agent source code for vulnerabilities without running the agent
+    - :link: **Tool Chain Analysis** -- Automatically detects dangerous tool combinations across 30+ known patterns
+    - :shield: **Multi-Phase Trust Exploitation** -- Progressive campaigns that build trust before testing boundaries
+    - :people_holding_hands: **Multi-Agent Coordination** -- Discover topologies and test cross-agent trust boundaries in supervisor, router, and peer-to-peer systems
+    - :brain: **Adaptive Campaigns** -- Three execution strategies (fixed, rule-based adaptive, LLM-driven) that adjust attack plans based on findings
+    - :zap: **Streaming Support** -- Real-time attack monitoring via SSE and WebSocket protocols
+    - :globe_with_meridians: **Remote Agent Scanning** -- Test any published agent over HTTPS (REST, OpenAI, MCP, A2A)
+    - :world_map: **Knowledge Graph** -- Every capability, relationship, and attack path tracked in a live graph
+    - :bar_chart: **CI/CD Quality Gate** -- Block deployments that fail security thresholds, with SARIF output
+    - :mag: **Static Analysis** -- Scan agent source code for vulnerabilities without running the agent
 
 ## Quick Demo
 
@@ -45,16 +43,16 @@ uv run python examples/10-vulnerable-agent/main.py
 
 | Capability | ZIRAN | Promptfoo | Invariant (Snyk) | Garak | PyRIT | Inspect AI |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|
-| Tool chain discovery (graph-based) | **Yes** | — | Policy-based | — | — | — |
-| Side-effect detection (execution-level) | **Yes** | — | Trace-based | — | — | Sandbox |
-| Multi-phase campaigns w/ graph feedback | **Yes** | Turn-level | Flow analysis | — | Composable | Multi-turn |
-| Autonomous pentesting agent | **Yes** | — | — | — | — | — |
-| Multi-agent coordination | **Yes** | — | — | — | — | — |
-| Agent-aware (tools + memory) | **Yes** | Partial | **Yes** | — | — | Partial |
-| A2A + MCP protocol support | **Yes** | MCP only | MCP only | — | — | — |
-| Encoding/obfuscation attacks | — | **Yes** (12+) | — | — | — | — |
-| Industry compliance plugins | — | **Yes** (46) | — | — | — | — |
-| CI/CD quality gate | **Yes** | **Yes** | — | — | — | — |
+| Tool chain discovery (graph-based) | Yes | -- | Policy-based | -- | -- | -- |
+| Side-effect detection (execution-level) | Yes | -- | Trace-based | -- | -- | Sandbox |
+| Multi-phase campaigns w/ graph feedback | Yes | Turn-level | Flow analysis | -- | Composable | Multi-turn |
+| Autonomous pentesting agent | Yes | -- | -- | -- | -- | -- |
+| Multi-agent coordination | Yes | -- | -- | -- | -- | -- |
+| Agent-aware (tools + memory) | Yes | Partial | Yes | -- | -- | Partial |
+| A2A + MCP protocol support | Yes | MCP only | MCP only | -- | -- | -- |
+| Encoding/obfuscation attacks | -- | Yes (12+) | -- | -- | -- | -- |
+| Industry compliance plugins | -- | Yes (46) | -- | -- | -- | -- |
+| CI/CD quality gate | Yes | Yes | -- | -- | -- | -- |
 
 !!! info "What ZIRAN Is Not"
 
@@ -62,10 +60,10 @@ uv run python examples/10-vulnerable-agent/main.py
 
 ## Next Steps
 
-- :rocket: [Getting Started](getting-started.md) — Your first scan in 5 minutes
-- :brain: [Concepts](concepts/architecture.md) — Understand how ZIRAN works
-- :people_holding_hands: [Multi-Agent Scanning](concepts/multi-agent.md) — Test coordinated agent systems
-- :zap: [Streaming](concepts/streaming.md) — Real-time attack monitoring
-- :dart: [Adaptive Campaigns](concepts/adaptive-campaigns.md) — Intelligent attack strategies
-- :books: [Scanning Agents](guides/scanning-agents.md) — Scan your own agents
-- :test_tube: [Examples](https://github.com/taoq-ai/ziran/tree/main/examples) — 18 runnable examples from basic to advanced
+- :rocket: [Getting Started](getting-started.md) -- Your first scan in 5 minutes
+- :brain: [Concepts](concepts/architecture.md) -- Understand how ZIRAN works
+- :people_holding_hands: [Multi-Agent Scanning](concepts/multi-agent.md) -- Test coordinated agent systems
+- :zap: [Streaming](concepts/streaming.md) -- Real-time attack monitoring
+- :dart: [Adaptive Campaigns](concepts/adaptive-campaigns.md) -- Intelligent attack strategies
+- :books: [Scanning Agents](guides/scanning-agents.md) -- Scan your own agents
+- :test_tube: [Examples](https://github.com/taoq-ai/ziran/tree/main/examples) -- 18 runnable examples from basic to advanced


### PR DESCRIPTION
## Summary
Follow-up to #251 (README improvements). Applies the same changes to the mkdocs documentation pages:

- **index.md** -- Remove "first open-source framework" claim, remove bold Yes from comparison table
- **tool-chains.md** -- Replace "unique differentiator" opener with explanation of why graph-based detection catches what list-based misses
- **knowledge-graph.md** -- Add "Why a Graph?" section explaining security impact; replace geometric shape icons with relatable emoji
- **romance-scan.md** -- Replace linear phase diagram with knowledge-graph-centered diagram showing non-linear execution; remove comparison table with checkmark/x positioning
- **adaptive-campaigns.md** -- Add "Why Adaptive?" section; add knowledge graph update step to flowchart

## Test plan
- [ ] Verify mkdocs builds successfully
- [ ] Check Mermaid diagrams render on GitHub Pages after merge