### PR TITLE
feat(domain): MITRE ATLAS taxonomy + atlas_mapping field (012 foundation)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # ziran Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-04-09
+Auto-generated from all feature plans. Last updated: 2026-04-21
 
 ## Active Technologies
 - Python 3.11+ (CI matrix: 3.11, 3.12, 3.13) + asyncio, dataclasses, logging, OpenTelemetry (tracing) (003-split-agent-scanner)
@@ -15,6 +15,8 @@ Auto-generated from all feature plans. Last updated: 2026-04-09
 - Python 3.11+ (backend), TypeScript 5.x (frontend) + FastAPI, SQLAlchemy 2.0 (async), Pydantic v2 (backend); React 18, Vite, TanStack Query/Table, shadcn/ui, Tailwind CSS, vis-network (frontend) (010-ui-polish-pages)
 - Python 3.11+ (CI matrix: 3.11, 3.12, 3.13) + click (CLI), httpx (async HTTP), pydantic (models), networkx (graph), pyyaml (config), rich (output), mdutils (reports). New optional: `langfuse` (trace pull). (011-runtime-bridge-v0-8)
 - Local JSON files for registry snapshots (`.ziran/snapshots/`); no database. (011-runtime-bridge-v0-8)
+- Python 3.11+ (CI matrix: 3.11, 3.12, 3.13) + pydantic (models), PyYAML (vector loader), click (CLI), rich (reports), networkx (graph — unchanged). No new dependencies. (012-benchmark-maturity)
+- YAML vector files under `ziran/application/attacks/vectors/`; benchmark result JSON under `benchmarks/results/`; docs under `docs/reference/benchmarks/`. (012-benchmark-maturity)
 
 - Python 3.11+ (CI matrix: 3.11, 3.12, 3.13) + click (CLI only), PyYAML, Playwright (optional), boto3 (optional), LangChain (optional), CrewAI (optional) (002-extract-shared-factories)
 
@@ -34,9 +36,9 @@ cd src [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECHNOLO
 Python 3.11+ (CI matrix: 3.11, 3.12, 3.13): Follow standard conventions
 
 ## Recent Changes
+- 012-benchmark-maturity: Added Python 3.11+ (CI matrix: 3.11, 3.12, 3.13) + pydantic (models), PyYAML (vector loader), click (CLI), rich (reports), networkx (graph — unchanged). No new dependencies.
 - 011-runtime-bridge-v0-8: Added Python 3.11+ (CI matrix: 3.11, 3.12, 3.13) + click (CLI), httpx (async HTTP), pydantic (models), networkx (graph), pyyaml (config), rich (output), mdutils (reports). New optional: `langfuse` (trace pull).
 - 010-ui-polish-pages: Added Python 3.11+ (backend), TypeScript 5.x (frontend) + FastAPI, SQLAlchemy 2.0 (async), Pydantic v2 (backend); React 18, Vite, TanStack Query/Table, shadcn/ui, Tailwind CSS, vis-network (frontend)
-- 009-ui-findings-compliance: Added Python 3.11+ (backend), TypeScript 5.x (frontend) + FastAPI, SQLAlchemy 2.0 (async), Alembic, Pydantic v2 (backend); React 18, Vite, TanStack Query, TanStack Table, shadcn/ui, Tailwind CSS (frontend)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/012-benchmark-maturity/checklists/requirements.md
+++ b/specs/012-benchmark-maturity/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Benchmark Maturity
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-21
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The spec references existing infrastructure (`ziran/domain/entities/attack.py`, `benchmarks/*.py`, `docs/reference/benchmarks/coverage-comparison.md`) in **Dependencies** and **Assumptions**, not in Requirements — this is informational context for the planner, not leaked implementation detail.
+- Success criteria such as "at least 60 distinct ATLAS techniques" and "all 14 agent-specific techniques" are quantitative and framework-specific but technology-agnostic (they don't dictate how the mapping is stored or generated).
+- Five user stories (P1×2, P2×2, P3×1) are each independently testable — MITRE ATLAS (US1) and OWASP gap closure (US2) can each land as standalone releases without the others.
+- No [NEEDS CLARIFICATION] markers were introduced. Reasonable defaults were chosen and recorded in the **Assumptions** section — notably ATLAS granularity (technique-level), ATLAS as a static snapshot, defence-evasion as schema + metric only, no UI work in scope.
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`.

--- a/specs/012-benchmark-maturity/contracts/atlas-taxonomy.md
+++ b/specs/012-benchmark-maturity/contracts/atlas-taxonomy.md
@@ -1,0 +1,89 @@
+# Contract: ATLAS Taxonomy
+
+**Applies to**: Python import surface of `ziran.domain.entities.attack`.
+
+## Public exports (new)
+
+```python
+from ziran.domain.entities.attack import (
+    AtlasTactic,
+    AtlasTechnique,
+    ATLAS_TECHNIQUE_DESCRIPTIONS,
+    ATLAS_TECHNIQUE_TO_TACTIC,
+    AGENT_SPECIFIC_TECHNIQUES,
+)
+```
+
+All five are module-level names in `ziran/domain/entities/attack.py` alongside the existing `OwaspLlmCategory` / `OWASP_LLM_DESCRIPTIONS` pair.
+
+## `AtlasTactic`
+
+```python
+class AtlasTactic(StrEnum):
+    RECONNAISSANCE = "AML.TA0002"
+    RESOURCE_DEVELOPMENT = "AML.TA0003"
+    # ... 15 entries matching the October 2025 ATLAS snapshot ...
+```
+
+- Value format: `AML.TA\d{4}`.
+- Enum count: 15.
+- Stable: values MUST NOT be renamed between releases (this is a public contract).
+
+## `AtlasTechnique`
+
+```python
+class AtlasTechnique(StrEnum):
+    LLM_PROMPT_INJECTION = "AML.T0051"
+    # ... ≥ 60 entries ...
+```
+
+- Value format: `AML.T\d{4}(\.\d{3})?` (optional `.NNN` sub-technique).
+- Enum count: ≥ 60 after Phase 3; grows additively.
+- Stable: once added, values MUST NOT be renamed. Deprecations are handled by keeping the old enum value and marking it as deprecated in the description.
+
+## `ATLAS_TECHNIQUE_DESCRIPTIONS`
+
+```python
+ATLAS_TECHNIQUE_DESCRIPTIONS: dict[AtlasTechnique, str] = {
+    AtlasTechnique.LLM_PROMPT_INJECTION: "LLM Prompt Injection",
+    # ...
+}
+```
+
+- Keys: exactly the members of `AtlasTechnique` (enforced by unit test).
+- Values: short human-readable name as published by MITRE at the snapshot date.
+
+## `ATLAS_TECHNIQUE_TO_TACTIC`
+
+```python
+ATLAS_TECHNIQUE_TO_TACTIC: dict[AtlasTechnique, AtlasTactic] = {
+    AtlasTechnique.LLM_PROMPT_INJECTION: AtlasTactic.INITIAL_ACCESS,
+    # ...
+}
+```
+
+- Keys: exactly the members of `AtlasTechnique` (enforced by unit test).
+- Values: canonical parent tactic per ATLAS.
+
+## `AGENT_SPECIFIC_TECHNIQUES`
+
+```python
+AGENT_SPECIFIC_TECHNIQUES: frozenset[AtlasTechnique] = frozenset({
+    # the 14 October-2025 AI-agent-specific techniques
+})
+```
+
+- Cardinality: exactly 14 (enforced by unit test).
+- `AGENT_SPECIFIC_TECHNIQUES` ⊂ `set(AtlasTechnique)` (enforced by unit test).
+
+## Contract tests
+
+Tests in `tests/unit/test_atlas_enum.py`:
+
+1. `set(ATLAS_TECHNIQUE_DESCRIPTIONS) == set(AtlasTechnique)`
+2. `set(ATLAS_TECHNIQUE_TO_TACTIC) == set(AtlasTechnique)`
+3. `len(AGENT_SPECIFIC_TECHNIQUES) == 14`
+4. `AGENT_SPECIFIC_TECHNIQUES.issubset(set(AtlasTechnique))`
+5. Every `AtlasTactic` referenced in `ATLAS_TECHNIQUE_TO_TACTIC.values()` is a valid `AtlasTactic` member.
+6. Every `AtlasTechnique` value matches the expected `AML.T\d{4}(\.\d{3})?` format.
+7. Every `AtlasTactic` value matches `AML.TA\d{4}`.

--- a/specs/012-benchmark-maturity/contracts/attack-vector-yaml.md
+++ b/specs/012-benchmark-maturity/contracts/attack-vector-yaml.md
@@ -1,0 +1,45 @@
+# Contract: Attack Vector YAML Schema
+
+**Applies to**: Every file under `ziran/application/attacks/vectors/*.yaml`.
+
+## Change summary
+
+One additive field: `atlas_mapping`. All existing fields retain their current shape, defaults, and semantics.
+
+## Schema (additions only)
+
+```yaml
+- id: example_vector_id
+  name: Example Vector
+  category: indirect_injection
+  target_phase: execution
+  description: …
+  severity: high
+  prompts: […]
+  tags: [rag-poisoning]
+
+  # Existing mapping — unchanged:
+  owasp_mapping: [LLM01]
+
+  # NEW — list of MITRE ATLAS technique IDs (strings matching AtlasTechnique enum values).
+  # Empty list is accepted until Phase 3 completes; after Phase 3 the CI lint flags
+  # any empty list.
+  atlas_mapping:
+    - AML.T0051   # LLM Prompt Injection
+    - AML.T0070   # Retrieval Content Crafting
+```
+
+## Rules
+
+| Rule | Enforcement |
+|---|---|
+| `atlas_mapping` values must match `AtlasTechnique` enum | Pydantic validation when library loads YAML |
+| Unknown technique IDs fail fast with a clear error | Pydantic `ValueError` surfacing the bad value |
+| Duplicate technique IDs within the same vector are deduplicated silently (but a warning is logged) | Library loader post-processing |
+| The field is optional at the YAML layer (defaults to `[]`) | Pydantic `default_factory=list` |
+| CI gate after Phase 3: no vector may have empty `atlas_mapping` on `main` | `benchmarks/atlas_coverage.py` non-zero exit |
+
+## Backwards compatibility
+
+- YAML files without `atlas_mapping` load as they do today (empty list). No migration needed for downstream consumers of the YAML format.
+- All existing vectors retain their existing `owasp_mapping`; neither taxonomy affects the other.

--- a/specs/012-benchmark-maturity/contracts/benchmark-reports.md
+++ b/specs/012-benchmark-maturity/contracts/benchmark-reports.md
@@ -1,0 +1,93 @@
+# Contract: Benchmark Coverage Reports
+
+**Applies to**: `benchmarks/atlas_coverage.py` (new) and the extensions to `benchmarks/benchmark_comparison.py`, `benchmarks/owasp_coverage.py`, `benchmarks/generate_all.py`, `benchmarks/inventory.py`.
+
+## `benchmarks/atlas_coverage.py`
+
+New script paralleling `owasp_coverage.py`.
+
+### CLI
+
+```text
+$ uv run python benchmarks/atlas_coverage.py
+$ uv run python benchmarks/atlas_coverage.py --json benchmarks/results/atlas_coverage.json
+```
+
+### JSON output schema
+
+```json
+{
+  "generated_at": "2026-04-21T10:30:00Z",
+  "snapshot_date": "2025-10-01",
+  "totals": {
+    "vectors_total": 612,
+    "vectors_with_atlas_mapping": 612,
+    "vectors_without_atlas_mapping": 0,
+    "techniques_covered": 63,
+    "techniques_total_in_enum": 66,
+    "agent_specific_covered": 14,
+    "agent_specific_total": 14
+  },
+  "per_tactic": {
+    "AML.TA0002": {
+      "tactic_name": "Reconnaissance",
+      "techniques_covered": 3,
+      "techniques_total": 5,
+      "vector_count": 28
+    }
+  },
+  "per_technique": {
+    "AML.T0051": {
+      "name": "LLM Prompt Injection",
+      "tactic": "AML.TA0008",
+      "agent_specific": false,
+      "vector_count": 175
+    }
+  },
+  "uncovered_techniques": ["AML.T0040", "AML.T0041", "AML.T0042"],
+  "uncovered_agent_specific": []
+}
+```
+
+### Exit code
+
+| Condition | Exit code |
+|---|---|
+| All validation passes (every vector mapped, all 14 agent-specific techniques covered, ≥ 60 techniques total) | 0 |
+| Any vector has empty `atlas_mapping` | 1 (with list of offending vector IDs) |
+| < 14 agent-specific techniques covered | 1 (with list of missing) |
+| < 60 techniques covered overall | 1 (warning, not strict error — behind `--strict` flag the same condition fails) |
+
+### Determinism
+
+- Running the script twice without library changes produces byte-identical JSON (sorted keys, sorted arrays).
+- Stdout table uses the same sorted order.
+
+## Changes to `owasp_coverage.py`
+
+- Remove `_PLANNED_ISSUES` entries for `"LLM05"` and `"LLM10"` once coverage is achieved.
+- Add a strict assertion: every category has `_STRONG` or `_COMPREHENSIVE` status, otherwise exit 1. Behind a `--strict` flag if existing consumers rely on non-strict behaviour; otherwise default to strict since all gaps are intended to be closed in this release.
+
+## Changes to `benchmark_comparison.py`
+
+- Add a MITRE ATLAS row summarising technique coverage (denominator = `len(AtlasTechnique)`, numerator = covered in library).
+- Update TensorTrust, WildJailbreak, ToolEmu, CyberSecEval rows to reflect new vector counts after Phase 5.
+- Add a RAG injection row pointing to the new `rag_poisoning.yaml` (replaces the "Not yet implemented" LLMail-Inject row).
+
+## Changes to `generate_all.py`
+
+- Invoke `atlas_coverage.py` in the regeneration list alongside `owasp_coverage.py`.
+- Regeneration MUST be idempotent: running twice produces byte-identical outputs.
+
+## Changes to `docs/reference/benchmarks/coverage-comparison.md`
+
+- Regenerated — no manual edits. The regeneration script must produce this file in one pass from the library state.
+
+## Contract tests
+
+Tests in `tests/integration/test_atlas_coverage_script.py`:
+
+1. Running the script with `--json /tmp/out.json` writes a file matching the schema above.
+2. Running the script twice produces byte-identical JSON.
+3. When a vector has empty `atlas_mapping`, the script exits non-zero and names the vector in stdout.
+4. When a library snapshot has all coverage, the script exits zero.

--- a/specs/012-benchmark-maturity/contracts/cli-library-atlas.md
+++ b/specs/012-benchmark-maturity/contracts/cli-library-atlas.md
@@ -1,0 +1,44 @@
+# Contract: CLI `--atlas` Filter
+
+**Applies to**: `ziran library` subcommand in `ziran/interfaces/cli/main.py`.
+
+## Behaviour
+
+```text
+$ ziran library --atlas AML.T0051
+```
+
+Lists all attack vectors whose `atlas_mapping` contains the supplied technique ID.
+
+## Flag
+
+| Attribute | Value |
+|---|---|
+| Flag | `--atlas` |
+| Short | (none) |
+| Accepts | Single ATLAS technique ID string matching an `AtlasTechnique` enum value |
+| Case | Sensitive (canonical ATLAS casing) |
+| Invalid input | Click error with "did-you-mean" hint via `difflib.get_close_matches` |
+| Combinable | Yes — can be combined with `--owasp`, `--category`, `--tag`, `--severity`; filters compose as AND |
+
+## Output
+
+The existing library table gains an ATLAS column (analogous to the existing OWASP column):
+
+```text
+  ID                  Name                        Severity  Category        OWASP    ATLAS
+  ──────────────────────────────────────────────────────────────────────────────────────────────
+  pi_basic_override   Basic system prompt override  high    prompt_inj…     LLM01    AML.T0051
+```
+
+When filtered by `--atlas`, only vectors matching the supplied technique are shown. The column stays visible in unfiltered listings too.
+
+## Contract tests
+
+Tests in `tests/integration/test_cli_atlas_filter.py`:
+
+1. Valid technique ID → non-empty list of vectors, all containing that technique.
+2. Valid technique ID with no matches → empty list + informational message.
+3. Invalid technique ID → Click exit code 2, error message listing close matches.
+4. Combined `--atlas X --owasp LLM01` → AND semantics (vectors matching both).
+5. Invalid combination (`--atlas X --category Y` where no vector satisfies both) → empty result, no error.

--- a/specs/012-benchmark-maturity/contracts/defence-profile-yaml.md
+++ b/specs/012-benchmark-maturity/contracts/defence-profile-yaml.md
@@ -1,0 +1,63 @@
+# Contract: Defence Profile YAML Schema
+
+**Applies to**: Files supplied via `ziran scan --defence-profile <file>` or inlined under a `defence_profile:` key in the main scan config.
+
+## Schema
+
+```yaml
+# profile.yaml — standalone profile file
+name: prod-ingress-v1
+defences:
+  - kind: input_filter
+    identifier: nemo-guardrails@v0.8
+    evaluable: false
+  - kind: output_guard
+    identifier: lakera-guard@2025-09
+    evaluable: false
+  - kind: hybrid
+    identifier: custom-internal-regex
+    evaluable: false
+```
+
+Or inlined under the scan config:
+
+```yaml
+# scan-config.yaml (existing file — new key added)
+target: …
+phases: [discovery, execution, escalation]
+defence_profile:
+  name: prod-ingress-v1
+  defences:
+    - kind: input_filter
+      identifier: nemo-guardrails@v0.8
+      evaluable: false
+```
+
+## Rules
+
+| Rule | Enforcement |
+|---|---|
+| `name` required, non-empty string | Pydantic validation |
+| `defences` is a list (possibly empty) | Pydantic validation |
+| Each `kind` is one of `input_filter`, `output_guard`, `hybrid` | Pydantic `Literal` type |
+| Each `identifier` is a non-empty string | Pydantic validation |
+| Each `evaluable` is a boolean, default `False` | Pydantic default |
+| Empty `defences` list produces no `evasion_rate` in the campaign report | Application-layer invariant (FR-017) |
+| Profile with no `evaluable: true` entries produces no `evasion_rate` | Application-layer invariant |
+
+## CLI UX
+
+```text
+ziran scan --target <agent> --defence-profile ./profiles/prod-ingress.yaml
+```
+
+If both `--defence-profile` and a `defence_profile:` key in scan config are provided, the flag wins and a warning is logged.
+
+## Report surface
+
+When a profile is declared, the campaign report (JSON, Markdown, HTML) includes:
+
+1. A "Declared defences" section listing each declaration (kind, identifier, evaluable flag).
+2. An `evasion_rate` value — or, if no declaration was `evaluable`, the string `"not computable"` alongside the declared defences (rather than a numeric field) in Markdown/HTML. The JSON omits `evasion_rate` entirely in the not-computable case (FR-017, determinism).
+
+When no profile is declared (or the profile is empty), the report contains **zero** defence or evasion content — byte-identical to a pre-release report.

--- a/specs/012-benchmark-maturity/data-model.md
+++ b/specs/012-benchmark-maturity/data-model.md
@@ -1,0 +1,155 @@
+# Phase 1 Data Model: Benchmark Maturity
+
+**Feature**: 012-benchmark-maturity
+**Date**: 2026-04-21
+**Depends on**: [research.md](./research.md)
+
+## Scope
+
+This release adds one new threat-framework taxonomy (MITRE ATLAS), one new campaign-config entity (DefenceProfile), one new campaign-level metric (EvasionRate), and extends two existing entities (AttackVector and AttackResult) with a new mapping field. It does not introduce any new database schemas or persistent storage — all data is in-memory, YAML-loaded, or emitted in report artefacts.
+
+## Entities
+
+### AtlasTactic *(new enum)*
+
+| Field | Type | Notes |
+|---|---|---|
+| value | `str` | Canonical ATLAS tactic ID (e.g., `"AML.TA0002"`). |
+
+- **Shape**: `StrEnum` in `ziran/domain/entities/attack.py`.
+- **Cardinality**: 15 values at the October 2025 snapshot date.
+- **Invariants**:
+  - Value format matches `^AML\.TA\d{4}$`.
+  - Every tactic listed in the library's `ATLAS_TECHNIQUE_TO_TACTIC` codomain exists in this enum.
+
+### AtlasTechnique *(new enum)*
+
+| Field | Type | Notes |
+|---|---|---|
+| value | `str` | Canonical ATLAS technique ID (e.g., `"AML.T0051"` or sub-technique like `"AML.T0051.001"`). |
+
+- **Shape**: `StrEnum` in `ziran/domain/entities/attack.py`.
+- **Cardinality**: Initially populated with every technique referenced by at least one vector in the library. Target ≥ 60 distinct techniques after Phase 3. All 14 October-2025 AI-agent-specific techniques are included regardless of whether a vector references them (enables coverage-gap reporting).
+- **Invariants**:
+  - Value format matches `^AML\.T\d{4}(\.\d{3})?$`.
+  - Every technique value is a key in `ATLAS_TECHNIQUE_DESCRIPTIONS` and `ATLAS_TECHNIQUE_TO_TACTIC`.
+
+### Module-level ATLAS constants *(new)*
+
+- `ATLAS_TECHNIQUE_DESCRIPTIONS: dict[AtlasTechnique, str]` — human-readable technique name.
+- `ATLAS_TECHNIQUE_TO_TACTIC: dict[AtlasTechnique, AtlasTactic]` — canonical parent tactic for each technique.
+- `AGENT_SPECIFIC_TECHNIQUES: frozenset[AtlasTechnique]` — the 14 AI-agent-specific techniques added in the October 2025 ATLAS release. Used by the benchmark dashboard to highlight agent-focused coverage.
+
+All three constants live next to `OWASP_LLM_DESCRIPTIONS` for discoverability.
+
+### AttackVector *(extended)*
+
+New field only. Existing fields unchanged.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `atlas_mapping` | `list[AtlasTechnique]` | `[]` | Zero or more ATLAS techniques this vector exercises. Populated via YAML. After Phase 3, enforced non-empty by CI lint. |
+
+- **YAML contract**: see [contracts/attack-vector-yaml.md](./contracts/attack-vector-yaml.md).
+- **Backwards compatibility**: default-empty list ensures existing YAML files load without modification. Existing consumers of `AttackVector` see the new field via `model_dump`; it's omitted from JSON when empty if `exclude_none=True` is not set (current reports include empty lists; after Phase 3 no vector should have an empty list in `main`).
+
+### AttackResult *(extended)*
+
+New field only. Mirrors `AttackVector`.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `atlas_mapping` | `list[AtlasTechnique]` | `[]` | Copied from the executing vector at attack-dispatch time. |
+
+- **Population**: the existing dispatch path that copies `owasp_mapping` from vector to result is extended to copy `atlas_mapping` too.
+
+### DefenceProfile *(new entity)*
+
+New Pydantic model. Used at campaign-config time and echoed into `CampaignResult`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | `str` | Free-form profile label (e.g., `"prod-ingress-v1"`). |
+| `defences` | `list[DefenceDeclaration]` | Zero or more defence declarations. Empty list semantically equivalent to no profile (FR-017). |
+
+**Module location**: `ziran/domain/entities/campaign.py` (or a new sibling module `defence.py` if the file grows).
+
+### DefenceDeclaration *(new entity)*
+
+| Field | Type | Notes |
+|---|---|---|
+| `kind` | `Literal["input_filter", "output_guard", "hybrid"]` | What family of defence this is. |
+| `identifier` | `str` | Free-form; typically `<product>@<version>` (e.g., `"nemo-guardrails@v0.8"`). |
+| `evaluable` | `bool` | `True` only when ZIRAN knows how to test whether an attack bypasses this defence. Always `False` in this release (future integrations flip this per supported product). |
+
+- **Invariants**: `kind` is one of the three literals; `identifier` non-empty; `evaluable` defaults to `False`.
+
+### CampaignResult *(extended)*
+
+Two new optional fields. Existing fields unchanged.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `defence_profile` | `DefenceProfile \| None` | `None` | Echo of the profile supplied at campaign config; omitted from JSON when `None`. |
+| `evasion_rate` | `float \| None` | `None` | Proportion [0.0, 1.0] of attacks that succeeded despite evaluable declared defences. `None` when no profile, empty profile, or no evaluable defences. Omitted from JSON when `None`. |
+
+- **Serialisation**: `model_dump(exclude_none=True)` preserves byte-identity with pre-release outputs whenever no profile is declared. Mandatory for deterministic-output guarantee (FR-020) and downstream signing.
+
+### EvasionMetric *(computation, not a persisted entity)*
+
+- **Location**: `ziran/application/campaign/evasion.py`.
+- **Signature**:
+
+  ```python
+  def compute_evasion_rate(
+      findings: Sequence[AttackResult],
+      profile: DefenceProfile | None,
+  ) -> float | None
+  ```
+
+- **Behaviour**:
+  - `profile is None` → `None`.
+  - `profile.defences == []` → `None` (empty = absent per FR-017).
+  - No defence in the profile has `evaluable=True` → `None` (report surfaces "declared but not computable").
+  - Otherwise → `bypassed / total_attempted`, where `bypassed` counts findings that succeeded AND bypassed evaluable defences. In this release that's structurally always zero; future evaluator integrations populate a per-finding bypass flag from which this is computed.
+- **Pure function**: no I/O, no mutation.
+
+## Relationships
+
+```text
+AttackVector  ──(has-many)──▶  AtlasTechnique
+AttackVector  ──(has-many)──▶  OwaspLlmCategory         (existing)
+
+AttackResult  ──(has-many)──▶  AtlasTechnique           (copied from vector at dispatch)
+AttackResult  ──(has-many)──▶  OwaspLlmCategory         (existing)
+
+AtlasTechnique  ──(belongs-to-1)──▶  AtlasTactic        (via ATLAS_TECHNIQUE_TO_TACTIC)
+
+CampaignResult  ──(has-optional-1)──▶  DefenceProfile
+DefenceProfile  ──(has-many)──▶  DefenceDeclaration
+
+CampaignResult  ──(has-optional-scalar)──▶  evasion_rate (float | None)
+```
+
+## State transitions
+
+None of the new entities have lifecycle states. `CampaignResult` transitions are unchanged; the new fields are populated once at campaign finalisation and never mutated thereafter.
+
+## Validation rules summary
+
+| Rule | Where enforced |
+|---|---|
+| `atlas_mapping` members must all be valid `AtlasTechnique` | Pydantic validation on model load |
+| Every vector in `main` has non-empty `atlas_mapping` | CI lint (after Phase 3) — `lint_atlas_coverage()` returns empty list |
+| Every `AtlasTechnique` enum value appears in `ATLAS_TECHNIQUE_DESCRIPTIONS` and `ATLAS_TECHNIQUE_TO_TACTIC` | Unit test on enum completeness |
+| `AGENT_SPECIFIC_TECHNIQUES` has exactly 14 entries | Unit test |
+| `DefenceProfile.defences == []` ⇒ `evasion_rate is None` | Unit test + application-layer assertion |
+| `CampaignResult` JSON output omits `evasion_rate` and `defence_profile` when `None` | Integration test asserting byte-identity |
+
+## Migration
+
+None. All changes are additive:
+- New fields default to empty / None.
+- Existing YAML files load unchanged until Phase 3 annotates them.
+- Existing JSON campaign results round-trip through the extended model without modification.
+- No database migrations (no database involved).

--- a/specs/012-benchmark-maturity/plan.md
+++ b/specs/012-benchmark-maturity/plan.md
@@ -1,0 +1,316 @@
+# Implementation Plan: Benchmark Maturity
+
+**Branch**: `012-benchmark-maturity` | **Date**: 2026-04-21 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/012-benchmark-maturity/spec.md`
+
+## Summary
+
+Close out the v0.13.0 "Benchmark Maturity" milestone by (a) adding MITRE ATLAS as a second threat-framework mapping alongside OWASP, (b) closing OWASP LLM05 and LLM10 coverage gaps, (c) expanding representative coverage of TensorTrust, WildJailbreak, ToolEmu, and CyberSecEval, (d) adding a retrieval-aware RAG-poisoning attack category, and (e) introducing a defence-profile configuration and evasion-rate metric. The work mirrors the existing `OwaspLlmCategory` pattern for ATLAS, adds attack vectors purely as YAML data, and extends the existing benchmark scripts under `benchmarks/`. No new runtime dependencies; no detection-pipeline changes.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+ (CI matrix: 3.11, 3.12, 3.13)
+**Primary Dependencies**: pydantic (models), PyYAML (vector loader), click (CLI), rich (reports), networkx (graph — unchanged). No new dependencies.
+**Storage**: YAML vector files under `ziran/application/attacks/vectors/`; benchmark result JSON under `benchmarks/results/`; docs under `docs/reference/benchmarks/`.
+**Testing**: pytest with `@pytest.mark.unit` and `@pytest.mark.integration`; existing fixtures for library and reports.
+**Target Platform**: Linux/macOS CLI; Python library.
+**Project Type**: CLI tool + Python library (single project, hexagonal architecture).
+**Performance Goals**: Library load ≤ 2s with ~600 vectors; ATLAS coverage script ≤ 5s; benchmark comparison regeneration ≤ 10s.
+**Constraints**: Deterministic report output (stable key/array order); backwards-compatible additions to attack vector YAML schema; no changes to detector pipeline or adapter interfaces.
+**Scale/Scope**: ~565 existing vectors to retro-map; target ~650 vectors post-release; ~60+ ATLAS techniques; all 14 October-2025 AI-agent-specific ATLAS techniques covered.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Hexagonal Architecture | ✅ Pass | `AtlasTactic` / `AtlasTechnique` enums and `atlas_mapping` field live in `domain/entities/attack.py` alongside existing `OwaspLlmCategory`. `DefenceProfile` entity lives in domain. `EvasionMetric` computation is an application-layer pure function. No new ports or adapters (ATLAS is an embedded taxonomy, not an external system). Benchmark scripts live under `benchmarks/` as tooling (outside `ziran/`). |
+| II. Type Safety | ✅ Pass | All new models are Pydantic; all enums are `StrEnum`; all functions typed; mypy strict. |
+| III. Test Coverage | ✅ Pass | Unit tests: ATLAS enum completeness, `get_attacks_by_atlas`, `atlas_mapping` non-empty lint, evasion-rate computation, defence-profile validation, RAG poisoning YAML load. Integration tests: CLI `--atlas` filter, `benchmarks/atlas_coverage.py` JSON output, report ATLAS sections, campaign with and without defence profile. Target ≥ 85%. |
+| IV. Async-First | ✅ Pass | No new I/O introduced. Defence-profile consumption and evasion-rate computation are pure functions on campaign data already in memory. |
+| V. Extensibility via Adapters | ✅ Pass | All new attack vectors added as YAML under `ziran/application/attacks/vectors/`, not as code. No new adapter interfaces are modified. |
+| VI. Simplicity | ✅ Pass | ATLAS mapping mirrors the existing OWASP pattern exactly — same list-of-enum field shape, same library-filter signature, same report-surface approach. Defence profile is a thin Pydantic model; evasion rate is one function. No new abstractions. |
+
+No violations. No complexity justifications needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/012-benchmark-maturity/
+├── spec.md
+├── plan.md                # This file
+├── research.md            # Phase 0 output
+├── data-model.md          # Phase 1 output
+├── quickstart.md          # Phase 1 output
+├── contracts/             # Phase 1 output
+│   ├── attack-vector-yaml.md     # YAML schema additions
+│   ├── atlas-taxonomy.md         # Enum and mapping contracts
+│   ├── defence-profile-yaml.md   # Campaign-config schema additions
+│   ├── cli-library-atlas.md      # CLI --atlas flag contract
+│   └── benchmark-reports.md      # atlas_coverage.py JSON schema
+├── checklists/
+│   └── requirements.md    # Quality checklist (already written)
+└── tasks.md               # Phase 2 output (/speckit.tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+ziran/
+├── domain/
+│   └── entities/
+│       ├── attack.py                   # MODIFIED: AtlasTactic, AtlasTechnique, ATLAS_TECHNIQUE_DESCRIPTIONS,
+│       │                                # atlas_mapping field on AttackVector and AttackResult.
+│       └── campaign.py                 # MODIFIED: DefenceProfile, EvasionMetric; CampaignResult gains
+│                                       # optional evasion_rate and defence_profile fields.
+├── application/
+│   ├── attacks/
+│   │   ├── library.py                  # MODIFIED: get_attacks_by_atlas(), lint helper that reports
+│   │   │                               # vectors without atlas_mapping.
+│   │   └── vectors/
+│   │       ├── *.yaml                  # MODIFIED: every existing YAML file gains atlas_mapping entries
+│   │       │                           # on each vector (retro-mapping).
+│   │       ├── supply_chain.yaml           # NEW: ≥10 LLM05 vectors.
+│   │       ├── model_theft.yaml            # NEW: ≥10 LLM10 vectors.
+│   │       ├── tensortrust_patterns.yaml   # NEW: representative patterns.
+│   │       ├── wildjailbreak_tactics.yaml  # NEW: new multi-turn tactics.
+│   │       ├── toolemu_sandbox.yaml        # NEW: sandbox-evasion vectors.
+│   │       ├── cyberseceval_codegen.yaml   # NEW: code-gen safety + cybersec knowledge.
+│   │       └── rag_poisoning.yaml          # NEW: retrieval-targeted indirect injection.
+│   └── campaign/
+│       └── evasion.py                  # NEW: compute_evasion_rate(findings, defence_profile) → float | None.
+├── interfaces/
+│   └── cli/
+│       ├── main.py                     # MODIFIED: add --atlas filter, add --defence-profile config flag
+│       │                               # on scan subcommand.
+│       └── reports.py                  # MODIFIED: MD/HTML templates gain ATLAS sections and
+│                                       # conditional evasion-rate row.
+└── infrastructure/
+    └── reports/                        # (existing) templates extended; no new files.
+
+benchmarks/
+├── atlas_coverage.py                   # NEW: generate ATLAS technique coverage JSON report.
+├── benchmark_comparison.py             # MODIFIED: add ATLAS row, bump TensorTrust/WildJailbreak/
+│                                       # ToolEmu/CyberSecEval counts, and include RAG benchmark row.
+├── owasp_coverage.py                   # MODIFIED: LLM05 threshold check, LLM10 row added; planned-issues
+│                                       # map trimmed.
+├── generate_all.py                     # MODIFIED: invoke atlas_coverage.py alongside others.
+├── inventory.py                        # MODIFIED: include atlas_mapping coverage in inventory.
+└── results/                            # (existing) generated artefacts — atlas_coverage.json new.
+
+docs/
+└── reference/
+    └── benchmarks/
+        ├── coverage-comparison.md      # MODIFIED: regenerated with ATLAS section + bumped benchmark rows.
+        └── atlas-mapping.md            # NEW: how ATLAS mapping is structured, snapshot date, links to ATLAS.
+
+tests/
+├── unit/
+│   ├── test_atlas_enum.py              # NEW: enum completeness, description coverage, agent-specific list.
+│   ├── test_library_atlas_filter.py    # NEW: get_attacks_by_atlas + lint helper.
+│   ├── test_evasion_metric.py          # NEW: compute_evasion_rate edge cases.
+│   ├── test_defence_profile.py         # NEW: Pydantic validation, empty-profile handling.
+│   └── test_owasp_coverage.py          # EXTENDED: LLM05/LLM10 thresholds; existing file.
+└── integration/
+    ├── test_cli_atlas_filter.py        # NEW: `ziran library --atlas AML.T0051` end-to-end.
+    ├── test_atlas_coverage_script.py   # NEW: benchmarks/atlas_coverage.py JSON output shape.
+    ├── test_report_atlas_section.py    # NEW: MD/HTML reports contain ATLAS tables.
+    ├── test_campaign_with_defence.py   # NEW: campaign with declared profile yields evasion_rate.
+    └── test_campaign_without_defence.py # NEW: campaign with no profile has no evasion_rate field.
+```
+
+**Structure Decision**: Single-project hexagonal layout (unchanged). All new code extends the established `ziran/` package across the four layers. No new top-level packages. Attack vectors remain YAML-first. ATLAS taxonomy is embedded in domain, mirroring the existing OWASP pattern.
+
+## Architecture
+
+### A. ATLAS threat-framework mapping
+
+```
+domain/entities/attack.py
+    AtlasTactic (StrEnum, ~15 values: AML.TA0002 … AML.TA0043)
+    AtlasTechnique (StrEnum, enumerates technique IDs used in the library)
+    ATLAS_TECHNIQUE_DESCRIPTIONS: dict[AtlasTechnique, str]
+    ATLAS_TECHNIQUE_TO_TACTIC: dict[AtlasTechnique, AtlasTactic]
+    AGENT_SPECIFIC_TECHNIQUES: frozenset[AtlasTechnique]   # the Oct-2025 14
+
+    AttackVector:
+        atlas_mapping: list[AtlasTechnique] = Field(default_factory=list, ...)
+
+    AttackResult:
+        atlas_mapping: list[AtlasTechnique] = Field(default_factory=list, ...)
+
+application/attacks/library.py
+    def get_attacks_by_atlas(technique: AtlasTechnique) -> list[AttackVector]
+    def lint_atlas_coverage() -> list[str]   # returns vector IDs with empty atlas_mapping
+```
+
+**Key Design Decisions**:
+- **Static snapshot** of ATLAS pinned to the October 2025 release. Matches how OWASP is already embedded. No runtime fetch.
+- **Technique-level** granularity. Sub-technique optional and encoded as separate enum values only when a vector clearly targets one specific sub-technique.
+- **AGENT_SPECIFIC_TECHNIQUES** is a frozenset for fast membership checks in reports and dashboards.
+- Backwards compatibility: `atlas_mapping` defaults to empty list, so existing campaign-result JSON round-trips unchanged. The lint helper is advisory — the library still loads vectors with empty mappings, but the coverage script fails the gate if any vector remains empty in `main`.
+
+### B. OWASP gap closure (LLM05, LLM10)
+
+Pure YAML additions. No code changes other than extending existing unit tests to assert the new vector counts.
+
+- `supply_chain.yaml` (≥10 vectors): malicious plugin manifests; typosquatted tool names piggybacking on known tools; compromised dependency simulation (fake `pip install` payloads surfaced as tool descriptions); data pipeline poisoning via RAG connectors; fine-tuning-data exfiltration prompts.
+- `model_theft.yaml` (≥10 vectors): systematic API querying for model extraction; weight approximation probes (temperature-0 deterministic queries); fine-tuning-data extraction (memorisation probes); model fingerprinting (version / RLHF-marker queries); fine-tuning inversion prompts.
+
+Each file uses the established YAML structure: `id`, `name`, `category`, `target_phase`, `description`, `severity`, `prompts`, `tags`, `references`, `owasp_mapping`, and (new in this release) `atlas_mapping`.
+
+### C. Benchmark expansion (TensorTrust, WildJailbreak, ToolEmu, CyberSecEval)
+
+All four are YAML additions. Goal is diversity across unique pattern families, not parity.
+
+- `tensortrust_patterns.yaml` (target ~25 vectors): representative families — explicit system-prompt override, credential-extraction framings, tool-output-substitution, fake-rulebook framings, multi-language injection.
+- `wildjailbreak_tactics.yaml` (target ~10 new tactics): tactics not already in `multi_turn_tactics.yaml`. Candidates: progressive hypothetical escalation, persona-rewind, compliance-weaponisation, moral-inversion, Socratic-induction. Each tactic gets at least one representative vector.
+- `toolemu_sandbox.yaml` (target ~15 vectors): sandbox-escape probes distinct from the existing tool_manipulation vectors — filesystem-path tricks, process-spawn requests, network egress probes, sandbox-fingerprinting (detect if in emulator and behave benignly vs aggressively).
+- `cyberseceval_codegen.yaml` (target ~20 vectors): code-generation safety (unsafe code requests, insecure-pattern solicitation) and cybersecurity knowledge (CVE discussion prompts, exploit-detail elicitation).
+
+### D. RAG-specific poisoning
+
+New `rag_poisoning.yaml` (target ~12 vectors) in the existing `AttackCategory.INDIRECT_INJECTION` family, with a distinguishing tag `tag: rag-poisoning`.
+
+Each vector's `prompts[*].template` contains content designed to rank highly in similarity search: keyword-dense phrasing, trust markers, and variants framed as email, web page, and database record. The prompt renderer doesn't need to change — RAG exercise mode is a test-harness concern; the vectors themselves are already usable via existing indirect-injection flows.
+
+### E. Defence-profile and evasion-rate
+
+```
+domain/entities/campaign.py (MODIFIED)
+    DefenceProfile:
+        name: str
+        defences: list[DefenceDeclaration]
+
+    DefenceDeclaration:
+        kind: Literal["input_filter", "output_guard", "hybrid"]
+        identifier: str           # free-form, e.g., "nemo-guardrails@v0.8" or "custom-regex"
+        evaluable: bool = False   # True if ZIRAN knows how to evaluate this defence;
+                                  # for now always False — integration work is follow-up.
+
+    CampaignResult: (existing, EXTENDED)
+        defence_profile: DefenceProfile | None = None
+        evasion_rate: float | None = None   # omitted entirely when None via model_dump(exclude_none=True)
+
+application/campaign/evasion.py (NEW)
+    def compute_evasion_rate(
+        findings: Sequence[AttackResult],
+        profile: DefenceProfile,
+    ) -> float | None:
+        # If profile is None or has no declared defences → return None.
+        # If no declared defence is evaluable → return None (report marks "not computable").
+        # Otherwise: proportion of successful attacks that ALSO bypassed evaluable defences.
+        # First release has no evaluable defences, so evasion_rate will default to None and reports
+        # surface "declared but not computable" metadata. Wire-up is in place for future integrations.
+```
+
+**Key Design Decisions**:
+- Keep the first-release bar low: declare-only profile, metadata carried through, metric omitted rather than faked. This unblocks downstream report consumers (UI, asqav signing) without committing to specific guardrail integrations.
+- `evasion_rate` is `float | None` — when None, `exclude_none=True` on `model_dump` prevents it from appearing in JSON output at all. Deterministic-output requirement (FR-020) preserved.
+- Individual `AttackResult` does not need a new bypass-flag field for this release; the per-finding bypass indication is derived from the defence profile and the finding's success state via an application-layer helper. When evaluable defences exist (future release), per-finding flags can be populated by that logic without schema change.
+
+### F. CLI and report surface
+
+- **CLI library filter**: `ziran library --atlas AML.T0051` — mirrors `--owasp LLM01`. Implementation: `click.Choice([t.value for t in AtlasTechnique])` or a free-form validator that checks membership in the enum with a helpful error listing the top candidates.
+- **CLI scan defence-profile**: `ziran scan --defence-profile path/to/profile.yaml` — YAML loaded via Pydantic's `DefenceProfile`. Existing scan config schema gains an optional `defence_profile` key so users can keep it in their main config instead of a separate flag.
+- **Markdown report**: an "ATLAS Coverage" section listing tactics and the count of findings per tactic, with agent-specific techniques called out. Conditional "Evasion" row appears only when `evasion_rate` is not None or a profile was declared.
+- **HTML report**: identical structure to MD; existing template system supports conditional sections.
+- **JSON report**: fields added natively via Pydantic `model_dump` — no template changes.
+
+### G. Benchmark scripts
+
+- `benchmarks/atlas_coverage.py` — new script. Walks the attack library, groups by `AtlasTactic`, counts unique techniques represented, asserts all 14 agent-specific techniques are present. Emits JSON to `benchmarks/results/atlas_coverage.json` and a Markdown table to stdout (matching the style of `owasp_coverage.py`).
+- `benchmarks/benchmark_comparison.py` — update the target rows for TensorTrust, WildJailbreak, ToolEmu, CyberSecEval to reflect the new vector counts. Add an ATLAS row summarising technique coverage.
+- `benchmarks/owasp_coverage.py` — remove `_PLANNED_ISSUES` entries for LLM05 and LLM10 once coverage is achieved. Assert `_STRONG` floor across all categories.
+- `benchmarks/generate_all.py` — register `atlas_coverage.py` in the regeneration list.
+- `docs/reference/benchmarks/coverage-comparison.md` — regenerate; no manual edits.
+
+## Implementation Phases
+
+Mapped to user stories so each phase is independently reviewable and shippable.
+
+### Phase 1: Domain Foundation
+
+- Add `AtlasTactic`, `AtlasTechnique`, `ATLAS_TECHNIQUE_DESCRIPTIONS`, `ATLAS_TECHNIQUE_TO_TACTIC`, `AGENT_SPECIFIC_TECHNIQUES` to `ziran/domain/entities/attack.py`.
+- Add `atlas_mapping: list[AtlasTechnique]` to `AttackVector` and `AttackResult` (default empty).
+- Add `DefenceProfile` / `DefenceDeclaration` to domain (`campaign.py` or a new small module if it grows).
+- Extend `CampaignResult` with optional `defence_profile` and `evasion_rate` fields, using `exclude_none=True` semantics in serialisation.
+- **Gate**: mypy passes; existing tests unchanged pass (backwards compatibility).
+
+### Phase 2: Library + Lint
+
+- Add `AttackLibrary.get_attacks_by_atlas(technique)` and `lint_atlas_coverage()` helper.
+- Add compute helper `ziran/application/campaign/evasion.py::compute_evasion_rate`.
+- Unit tests for both helpers and enum completeness.
+- **Gate**: `ziran library --atlas <value>` works against whatever vectors are already annotated (empty list acceptable at this phase).
+
+### Phase 3: ATLAS retro-mapping (US1 / #61)
+
+- Annotate every YAML file under `ziran/application/attacks/vectors/` with `atlas_mapping` per vector.
+- Update `benchmarks/atlas_coverage.py` (new script) to iterate library and produce the JSON + MD output.
+- Update `benchmarks/benchmark_comparison.py` to include the ATLAS row.
+- Regenerate `docs/reference/benchmarks/coverage-comparison.md`.
+- **Gate**: `lint_atlas_coverage()` returns empty list; `atlas_coverage.py` shows ≥ 60 techniques; all 14 agent-specific techniques are present.
+
+### Phase 4: OWASP gap closure (US2 / #42, #43)
+
+- Create `supply_chain.yaml` (≥10 LLM05 vectors) and `model_theft.yaml` (≥10 LLM10 vectors).
+- Each new vector carries both `owasp_mapping` and `atlas_mapping`.
+- Update existing `owasp_coverage.py` to assert `_STRONG` floor; remove the planned-issues mapping for LLM05/LLM10.
+- Regenerate coverage dashboards.
+- **Gate**: OWASP coverage script emits `_STRONG` or `_COMPREHENSIVE` for every category.
+
+### Phase 5: Benchmark expansion (US3 / #55, #56, #58, #57)
+
+- Create the four new YAML files (TensorTrust, WildJailbreak, ToolEmu, CyberSecEval).
+- Bump corresponding rows in `benchmark_comparison.py`.
+- Regenerate coverage-comparison.md.
+- **Gate**: benchmark comparison table shows increased vector counts on all four rows.
+
+### Phase 6: RAG-specific poisoning (US4 / #44)
+
+- Create `rag_poisoning.yaml` with ~12 vectors across multiple document framings.
+- Each vector uses `category: indirect_injection` and `tag: rag-poisoning`.
+- Add integration test that the tag-filter surfaces these vectors and that each carries an ATLAS indirect-injection technique.
+- **Gate**: `ziran library --tag rag-poisoning` returns the new vectors; all carry correct OWASP LLM01 + ATLAS mappings.
+
+### Phase 7: Defence profile + evasion rate (US5 / #45)
+
+- Wire `DefenceProfile` into scan config schema (`--defence-profile path.yaml` and a top-level `defence_profile:` key).
+- Wire `compute_evasion_rate` into the campaign finalisation step.
+- Extend MD/HTML report templates with conditional evasion-rate row and "declared defences" metadata section.
+- Unit + integration tests for both "profile present" and "no profile" paths.
+- **Gate**: running a campaign with a sample profile produces a report containing the declared defences; without a profile the report has no evasion fields at all.
+
+### Phase 8: CLI + Report surface
+
+- Add `--atlas` filter to `ziran library`.
+- Add ATLAS sections to MD/HTML report templates.
+- Add `--atlas` column to library listing output (like the existing OWASP column).
+- Integration tests for CLI and report content.
+- **Gate**: CLI filter and report surfacing work end-to-end.
+
+### Phase 9: Release readiness
+
+- All quality gates: `ruff check .`, `ruff format --check .`, `mypy ziran/`, `pytest --cov=ziran` (≥ 85%).
+- Release notes entry noting: ATLAS mapping available, OWASP coverage 10/10, benchmark coverage bumps, new RAG poisoning category, defence-profile schema (guardrail integrations follow-up).
+- Validate deterministic output (run report generation twice; diff should be empty).
+- **Gate**: CI green on the final PR.
+
+## Packaging / PR strategy
+
+Internally land as 5 focused PRs under the same branch family, each independently reviewable:
+1. **Foundation** — Phases 1+2 (enum, entities, helpers, library filter, ATLAS retro-mapping seed).
+2. **ATLAS retro-map** — Phase 3 (the large YAML annotation pass + new benchmark script).
+3. **OWASP + benchmark expansion** — Phases 4+5+6 (new YAML files for LLM05, LLM10, TensorTrust, WildJailbreak, ToolEmu, CyberSecEval, RAG).
+4. **Defence profile + evasion metric** — Phase 7.
+5. **Surface + release** — Phases 8+9 (CLI filter, report sections, regenerate dashboards, release notes).
+
+Each PR closes the issues it fully addresses; the final PR closes the milestone. release-please handles the version bump at the end.
+
+## Complexity Tracking
+
+No constitution violations. No complexity justifications needed.

--- a/specs/012-benchmark-maturity/quickstart.md
+++ b/specs/012-benchmark-maturity/quickstart.md
@@ -1,0 +1,173 @@
+# Quickstart: Benchmark Maturity
+
+**Feature**: 012-benchmark-maturity
+
+Short end-user walkthroughs that validate each acceptance signal in `spec.md` using only commands that exist after this release.
+
+## 1. Find the ATLAS technique for an existing vector
+
+```text
+$ ziran library --filter pi_basic_override
+  ID                  Name                        Severity  OWASP    ATLAS
+  ─────────────────────────────────────────────────────────────────────────
+  pi_basic_override   Basic system prompt override  high    LLM01    AML.T0051
+```
+
+One line, one ATLAS technique, one OWASP category — matches Acceptance Scenario 1.1.
+
+## 2. List all vectors for a specific ATLAS technique
+
+```text
+$ ziran library --atlas AML.T0051
+```
+
+Matches US1 Scenario 1.2.
+
+## 3. Confirm OWASP 10/10
+
+```text
+$ uv run python benchmarks/owasp_coverage.py
+Category     Vectors   Status
+LLM01        434       comprehensive
+LLM02        194       comprehensive
+LLM03        15        strong
+LLM04        12        strong
+LLM05        11        strong           ← was: moderate
+LLM06        95        comprehensive
+LLM07        136       comprehensive
+LLM08        139       comprehensive
+LLM09        15        strong
+LLM10        12        strong           ← was: not covered
+```
+
+Matches US2 Scenario 2.1.
+
+## 4. Generate the ATLAS coverage report
+
+```text
+$ uv run python benchmarks/atlas_coverage.py
+Techniques covered: 63/66
+Agent-specific techniques covered: 14/14  ✓
+Uncovered techniques: AML.T0040, AML.T0041, AML.T0042
+
+$ uv run python benchmarks/atlas_coverage.py --json benchmarks/results/atlas_coverage.json
+Written benchmarks/results/atlas_coverage.json
+```
+
+Matches US1 Scenario 1.3.
+
+## 5. Run a campaign and inspect the ATLAS section in the report
+
+```text
+$ ziran scan --target examples/01-langchain-agent/agent.py --report-format markdown
+Report written to reports/latest.md
+
+$ head -40 reports/latest.md
+# Campaign Report
+…
+## Findings (12)
+
+### Finding 1: pi_basic_override
+- OWASP: LLM01 (Prompt Injection)
+- ATLAS: AML.T0051 (LLM Prompt Injection) — Tactic: Initial Access
+- Severity: high
+- Evidence: …
+
+…
+
+## ATLAS Coverage Summary
+| Tactic              | Findings | Techniques   |
+|---------------------|----------|--------------|
+| Initial Access      | 8        | AML.T0051, AML.T0052 |
+| Persistence         | 2        | AML.T0070    |
+| …                   | …        | …            |
+```
+
+Matches US1 Scenario 1.1 and SC-004.
+
+## 6. Run a RAG-poisoning focused campaign
+
+```text
+$ ziran library --tag rag-poisoning
+  ID                         Name                             OWASP    ATLAS
+  ─────────────────────────────────────────────────────────────────────────────
+  rag_credential_doc         Credential-leak doc framing      LLM01    AML.T0070
+  rag_policy_override_email  Email-framed policy override     LLM01    AML.T0051
+  …
+
+$ ziran scan --target <rag-agent> --include-tag rag-poisoning
+```
+
+Matches US4 Scenario 4.1 and 4.2.
+
+## 7. Run a campaign with a defence profile
+
+Create `profiles/prod-ingress.yaml`:
+
+```yaml
+name: prod-ingress-v1
+defences:
+  - kind: input_filter
+    identifier: nemo-guardrails@v0.8
+    evaluable: false
+  - kind: output_guard
+    identifier: lakera-guard@2025-09
+    evaluable: false
+```
+
+Run:
+
+```text
+$ ziran scan --target <agent> --defence-profile profiles/prod-ingress.yaml
+```
+
+Report contains:
+
+```markdown
+## Declared Defences
+
+| Kind          | Identifier                    | Evaluable |
+|---------------|-------------------------------|-----------|
+| input_filter  | nemo-guardrails@v0.8          | no        |
+| output_guard  | lakera-guard@2025-09          | no        |
+
+Evasion rate: not computable (no declared defence is evaluable in this release).
+```
+
+And a campaign run without `--defence-profile`:
+
+```text
+$ ziran scan --target <agent>
+```
+
+Produces a report that contains **zero** defence or evasion content — byte-identical to pre-release reports for the same target. Matches US5 Scenarios 5.1 and 5.2.
+
+## 8. Validate determinism
+
+Run the benchmark regeneration twice:
+
+```text
+$ uv run python benchmarks/generate_all.py
+$ sha256sum benchmarks/results/*.json > /tmp/hashes_a
+$ uv run python benchmarks/generate_all.py
+$ sha256sum benchmarks/results/*.json > /tmp/hashes_b
+$ diff /tmp/hashes_a /tmp/hashes_b
+# empty — byte-identical
+```
+
+Matches SC-006.
+
+## 9. Quality gates
+
+Standard constitution gates on the final PR:
+
+```text
+$ uv run ruff check .
+$ uv run ruff format --check .
+$ uv run mypy ziran/
+$ uv run pytest --cov=ziran
+  …
+  TOTAL    90%   PASSED
+```
+
+All clean — required to close the milestone.

--- a/specs/012-benchmark-maturity/research.md
+++ b/specs/012-benchmark-maturity/research.md
@@ -1,0 +1,131 @@
+# Phase 0 Research: Benchmark Maturity
+
+**Feature**: 012-benchmark-maturity
+**Date**: 2026-04-21
+
+The spec did not introduce any `[NEEDS CLARIFICATION]` markers — the questions that could have required clarification are resolved in the Assumptions section with informed defaults. This research document records the decisions behind those defaults plus the external-data research needed to execute the plan.
+
+## 1. ATLAS snapshot source & granularity
+
+**Decision**: Pin to the MITRE ATLAS October 2025 release (covers 15 tactics, 66 techniques + 46 sub-techniques, 14 new agent-specific techniques). Embed technique IDs and human-readable names as a `StrEnum` + `dict[Enum, str]` pair inside `ziran/domain/entities/attack.py`, mirroring the existing `OwaspLlmCategory` and `OWASP_LLM_DESCRIPTIONS` pattern.
+
+**Rationale**:
+- The OWASP pattern is already understood by the codebase, by downstream consumers (web UI, reports, asqav signing), and by existing tests. Reusing it is cheapest and most predictable.
+- ATLAS evolves on a release cadence. A static snapshot pinned to a named release date is easier to reason about than a live fetch, and matches how OWASP is already embedded.
+- Technique level is the sweet spot for this release: sub-technique detail is finer than what most downstream consumers can display, and some existing vectors span multiple sub-techniques of the same technique. When a vector clearly targets one sub-technique, we encode that sub-technique as its own enum value alongside the parent — but we don't require it universally.
+
+**Alternatives considered**:
+- **Live fetch from the MITRE ATLAS GitHub repo at library-load time.** Rejected: introduces a network dependency on the CLI hot path, violates determinism, and the snapshot approach is already proven for OWASP.
+- **Sub-technique-level mapping for every vector.** Rejected: doubles the annotation work for little downstream benefit in this release; can be tightened in a follow-up if UI or compliance workflows need it.
+- **Use MITRE ATT&CK for Enterprise instead.** Rejected: ATT&CK is enterprise-system focused; ATLAS is the AI-specific taxonomy the spec targets.
+
+## 2. ATLAS taxonomy data layout
+
+**Decision**: Three module-level constants in `ziran/domain/entities/attack.py`:
+- `AtlasTactic` — `StrEnum` listing the 15 ATLAS tactics (values like `"AML.TA0002"`).
+- `AtlasTechnique` — `StrEnum` listing every technique ID used by at least one vector in the library (values like `"AML.T0051"`). Not every published ATLAS technique is represented — only those that match something ZIRAN actually tests.
+- `ATLAS_TECHNIQUE_DESCRIPTIONS: dict[AtlasTechnique, str]` — human-readable names.
+- `ATLAS_TECHNIQUE_TO_TACTIC: dict[AtlasTechnique, AtlasTactic]` — the canonical technique→tactic link used by coverage reports.
+- `AGENT_SPECIFIC_TECHNIQUES: frozenset[AtlasTechnique]` — the 14 October-2025 agent-specific techniques, used by the benchmark dashboard to highlight those.
+
+**Rationale**: Pydantic's `StrEnum` is already the idiom used for `OwaspLlmCategory`. A `list[AtlasTechnique]` field round-trips cleanly to YAML (as strings) and to JSON reports. Keeping only referenced techniques in the enum avoids surfacing a long empty list of "techniques we don't touch" on the coverage dashboard — the dashboard uses `ATLAS_TECHNIQUE_TO_TACTIC` for the denominator.
+
+**Alternatives considered**:
+- **Enumerate every published ATLAS technique**, even unreferenced ones. Rejected: the dashboard is clearer when it shows only techniques the library actually targets; unreferenced techniques are visible as "gaps" in `ATLAS_TECHNIQUE_TO_TACTIC` vs `AtlasTechnique` if we need that later.
+- **String IDs with a separate registry JSON file.** Rejected: breaks the consistency with OWASP and loses mypy-checked enum safety.
+
+## 3. Defence-profile scope for the first release
+
+**Decision**: Ship the schema, the metric field, and the report plumbing. Real evaluators for specific guardrail products (NeMo Guardrails, Lakera Guard, others) are out of scope.
+
+**Rationale**:
+- The user-facing value of the first release is the data model and report surface. Downstream consumers (web UI, asqav signing, compliance audits) can proceed knowing the field exists even if it's always "declared but not computable" for now.
+- Building evaluators requires integration work per guardrail product, with different authentication, different APIs, and different correctness models. That's multiple releases of work. Shipping an empty `evaluable=False` declaration now and wiring it later via the existing `DefenceDeclaration.evaluable` flag is additive and safe.
+- The LLMail-Inject and PINT benchmarks describe the evasion-rate metric shape but do not mandate a specific guardrail-product integration. Either benchmark could be measured against a profile once we have an evaluator.
+
+**Alternatives considered**:
+- **Ship with a built-in NeMo Guardrails evaluator.** Rejected: one evaluator without others is awkward ("why NeMo and not Lakera?"), and the integration alone is larger than the rest of this release.
+- **Omit defence profile entirely this release.** Rejected: blocks the "evasion rate" story from the milestone without solving it later, and the schema is cheap to land now.
+
+## 4. YAML schema additions and backwards compatibility
+
+**Decision**: The new `atlas_mapping` field on attack vectors is added to the Pydantic model with `default_factory=list`. Existing YAML files without the field continue to load. The field is populated in a second pass (Phase 3 — "ATLAS retro-mapping") so that Phase 1 and Phase 2 can land independently.
+
+**Rationale**:
+- Splits risk: domain changes land without any YAML churn; YAML churn lands separately and touches only data.
+- Matches how `owasp_mapping` was added historically (single PR per layer).
+- The library-lint helper (`lint_atlas_coverage`) is advisory in Phase 2 but becomes a CI gate after Phase 3 so main never regresses.
+
+## 5. Benchmark coverage targets
+
+**Decision**:
+- **TensorTrust**: ~25 representative patterns — focus on pattern diversity, not count. Pattern families: system-prompt override, credential extraction, tool-output substitution, fake-rulebook framings, multi-language injection.
+- **WildJailbreak**: ~10 new multi-turn tactics beyond the current 11. New tactics: progressive hypothetical escalation, persona rewind, compliance weaponisation, moral inversion, Socratic induction.
+- **ToolEmu**: ~15 dedicated sandbox-evasion vectors distinct from generic tool-manipulation. Patterns: filesystem-path tricks, process-spawn requests, network-egress probes, sandbox-fingerprinting.
+- **CyberSecEval**: ~20 vectors split between code-generation safety and cybersecurity-knowledge.
+
+**Rationale**:
+- Full parity with TensorTrust (126K) and WildJailbreak (105K) is explicitly out of scope (Spec Assumption #3). The numbers above are chosen to materially move the coverage-comparison table and cover each benchmark's pattern families without exploding library size.
+- The counts keep total library size under ~650 vectors, preserving library-load performance and report sizes.
+
+**Alternatives considered**:
+- **Import benchmark datasets directly.** Rejected: licence complexity (TensorTrust is researcher-distributed), and it would 100× library size for diminishing marginal value.
+- **Scripted sampling from the benchmarks at scan time.** Rejected: turns static library into a dynamic one, breaking determinism and making reports irreproducible.
+
+## 6. RAG poisoning category placement
+
+**Decision**: Land as a single new YAML file `rag_poisoning.yaml` under the existing `AttackCategory.INDIRECT_INJECTION` category, distinguished by a `rag-poisoning` tag. Each vector's `prompts[*].template` contains retrieval-optimised content (keyword-dense, credible framing, multiple document-format variants).
+
+**Rationale**:
+- Preserves category-count stability (no new `AttackCategory` enum value, which would bump reports and downstream consumers).
+- Keeps retrieval-targeted attacks discoverable via both `--category indirect_injection` and `--tag rag-poisoning`.
+- The retrieval-ranking step is not exercised within ZIRAN's scan loop today (we can't observe retrieval rankings without instrumenting the RAG pipeline). The vectors are still useful in direct injection tests and in indirect-injection harnesses that load them via existing document-format framings (email, web page, database record).
+
+**Alternatives considered**:
+- **Add a new `AttackCategory.RAG_POISONING`.** Rejected: adds a category to every downstream report and library dashboard for a sub-class of indirect injection; tag-based distinction is cheaper and reversible.
+- **Build a retrieval-ranking harness that scores payloads against a FAISS/Chroma index.** Rejected: scope creep — this is a detection-pipeline change, and the spec excludes detector changes.
+
+## 7. Report determinism
+
+**Decision**: All new fields on `CampaignResult` use `default=None` and are excluded from JSON output via `model_dump(exclude_none=True)`. Lists are emitted in sorted order where sort order is meaningful (techniques by ID, tactics alphabetical), to ensure run-to-run byte-identity.
+
+**Rationale**:
+- Downstream signing workflows (issue #259 asqav signing) hash the JSON output. Any non-deterministic ordering breaks signatures.
+- `exclude_none=True` means a campaign run without a defence profile produces JSON that is byte-identical to a pre-release run, keeping existing hashes stable.
+
+**Alternatives considered**:
+- **Emit `evasion_rate: null` always.** Rejected: breaks byte-identity with pre-release outputs.
+- **Rely on Python dict insertion order.** Rejected: relies on Pydantic version behaviour and on the serialisation library; sorting where meaningful is safer.
+
+## 8. Benchmark-script modifications
+
+**Decision**: Add `benchmarks/atlas_coverage.py` as a parallel script to `owasp_coverage.py` — same CLI flags, same JSON-output pattern, same stdout table style. Register in `generate_all.py`. Extend `benchmark_comparison.py` with an ATLAS row plus bumped counts for TensorTrust, WildJailbreak, ToolEmu, CyberSecEval. Regenerate `docs/reference/benchmarks/coverage-comparison.md` — no manual edits.
+
+**Rationale**:
+- Symmetric with OWASP keeps developer cognitive load low.
+- Generating the Markdown via a script (not by hand) preserves the determinism story — regeneration should be a no-op if library state is unchanged.
+
+## 9. CLI `--atlas` filter UX
+
+**Decision**: `ziran library --atlas AML.T0051` — `click.Choice` built from `[t.value for t in AtlasTechnique]`, case-sensitive (ATLAS IDs are case-sensitive in the canonical form). Error on invalid ID with a suggestion pulled from the closest-matching known technique (`difflib.get_close_matches`, already stdlib).
+
+**Rationale**:
+- Mirrors the existing `--owasp` flag exactly.
+- `difflib` is stdlib, no dependency added.
+
+**Alternatives considered**:
+- **Free-form string filter with post-hoc validation.** Rejected: loses mypy/click validation and gives worse error messages.
+- **Case-insensitive matching.** Rejected: ATLAS IDs are case-sensitive in the canonical form and standardising on the canonical form in the CLI reduces report-comparison friction.
+
+## 10. Test strategy
+
+**Decision**:
+- **Unit**: enum completeness (`AtlasTechnique` keys == `ATLAS_TECHNIQUE_DESCRIPTIONS` keys == `ATLAS_TECHNIQUE_TO_TACTIC` keys); agent-specific set has exactly 14 entries; `get_attacks_by_atlas` returns correct subsets; `compute_evasion_rate` handles all four cases (None profile, empty profile, profile with no evaluable defences, profile with evaluable defences); `DefenceProfile` Pydantic validation.
+- **Integration**: CLI `--atlas` filter end-to-end; `benchmarks/atlas_coverage.py` JSON-output shape and byte-for-byte determinism on two runs; MD and HTML reports contain ATLAS sections when findings exist; campaign-with-profile includes declared-defences metadata; campaign-without-profile has zero evasion-related fields in JSON.
+- **Regression**: existing OWASP coverage script still passes; existing report snapshots still round-trip; library load time unchanged within 10% tolerance (smoke test, not blocking).
+
+**Rationale**: Coverage ≥ 85% on new code is enforced by the constitution. The integration tests mirror the existing CLI and benchmark tests to keep the surface consistent.
+
+## Open items for Phase 1
+
+None. All decisions above are concrete enough to proceed to data-model and contracts.

--- a/specs/012-benchmark-maturity/spec.md
+++ b/specs/012-benchmark-maturity/spec.md
@@ -1,0 +1,177 @@
+# Feature Specification: Benchmark Maturity
+
+**Feature Branch**: `012-benchmark-maturity`
+**Created**: 2026-04-21
+**Status**: Draft
+**Input**: Close out the v0.13.0 "Benchmark Maturity" milestone by expanding ZIRAN's coverage against published AI agent security benchmarks and adding a structured MITRE ATLAS threat-framework mapping. Covers issues #61, #57, #58, #56, #55, #45, #44, #43, #42.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Align ZIRAN findings with MITRE ATLAS (Priority: P1)
+
+A red team assessor running a ZIRAN campaign against a customer AI agent needs to hand their report to the customer's threat-intelligence team. That team aligns everything to MITRE ATLAS — the recognised taxonomy for adversarial AI threats. Today, ZIRAN reports expose OWASP LLM Top 10 categories but not ATLAS techniques, which forces the assessor to re-classify findings by hand before delivery.
+
+**Why this priority**: ATLAS is the dominant taxonomy for adversarial AI threats, and the 14 agent-specific techniques added in October 2025 align directly with the attacks ZIRAN already executes. Without this mapping, findings are harder to operationalise in customer threat models. This is the flagship outcome of the release.
+
+**Independent Test**: Run any ZIRAN campaign (e.g., against the example LangChain agent) and open the resulting report. Every finding is tagged with one or more ATLAS technique identifiers, and the report contains a coverage summary grouped by ATLAS tactic. Can be validated without any of the other stories in this release landing.
+
+**Acceptance Scenarios**:
+
+1. **Given** a completed campaign, **When** the assessor views the Markdown or HTML report, **Then** each finding displays at least one ATLAS technique identifier and its human-readable name.
+2. **Given** the attack library, **When** the assessor filters by a specific ATLAS technique, **Then** they get the list of attack vectors mapped to that technique.
+3. **Given** the benchmark dashboard, **When** the assessor reviews it, **Then** the ATLAS coverage row shows a concrete number of techniques mapped and highlights the agent-specific techniques covered.
+4. **Given** an attack vector that was previously only OWASP-tagged, **When** the library is re-loaded, **Then** that vector now also carries an ATLAS mapping without its OWASP mapping changing.
+
+---
+
+### User Story 2 - Complete OWASP LLM Top 10 coverage (Priority: P1)
+
+A compliance analyst evaluating ZIRAN for adoption asks "does it cover all ten OWASP LLM categories?". Today the answer is "nine out of ten" — LLM05 (Supply Chain) has only moderate coverage and LLM10 (Model Theft / Unbounded Consumption) is absent. These gaps are visible on the public benchmark dashboard and block a clean compliance story.
+
+**Why this priority**: OWASP is the most common compliance framework asked about by prospective users. The gap is small and well-defined, and closing it turns 90% coverage into 100% — a material change in how ZIRAN reads on comparison sheets.
+
+**Independent Test**: Run the OWASP coverage report generator. All ten categories are reported as "strong" or "comprehensive" (≥10 vectors each), with no "moderate", "planned", or "not covered" entries. Can be validated independently of the ATLAS work.
+
+**Acceptance Scenarios**:
+
+1. **Given** the OWASP coverage dashboard, **When** the analyst reviews LLM05 and LLM10, **Then** both show status "strong" or better with at least 10 vectors each.
+2. **Given** the attack library, **When** the analyst runs the library listing filtered by LLM10, **Then** they see concrete vectors covering model extraction, weight approximation, and fine-tuning data extraction.
+3. **Given** the same library filtered by LLM05, **When** the analyst reviews results, **Then** they see coverage of malicious plugin detection, dependency compromise, and data pipeline poisoning.
+
+---
+
+### User Story 3 - Demonstrably higher coverage on public benchmarks (Priority: P2)
+
+A prospective user evaluating ZIRAN against competing tools (e.g., Promptfoo, Garak) reads the benchmark comparison table to decide whether the tool justifies adoption. Today ZIRAN shows very low coverage numbers against TensorTrust (<0.1%), WildJailbreak (<0.1%), and partial coverage against ToolEmu and CyberSecEval. Even though full parity is unrealistic for the largest datasets, the current numbers under-represent ZIRAN's actual capabilities because they don't yet reflect unique pattern coverage.
+
+**Why this priority**: This is marketing-adjacent but materially affects adoption decisions. The underlying work also fills real gaps — the current vector library is missing representative patterns from these benchmarks.
+
+**Independent Test**: Regenerate the benchmark comparison table. The TensorTrust, WildJailbreak, ToolEmu, and CyberSecEval rows all show measurably higher coverage or pattern-diversity numbers than before this release.
+
+**Acceptance Scenarios**:
+
+1. **Given** the auto-generated coverage comparison document, **When** a reader views the benchmark comparison table, **Then** the ZIRAN column shows increased vector counts for TensorTrust and WildJailbreak and the progress bar for each is visibly higher.
+2. **Given** the ToolEmu coverage row, **When** the reader reviews it, **Then** the sandbox-evasion dimension shows dedicated vectors (not just generic tool-manipulation reuse).
+3. **Given** the CyberSecEval row, **When** the reader reviews it, **Then** the row shows specific coverage of code-generation safety and cybersecurity-knowledge dimensions, not just a generic "partial overlap" note.
+
+---
+
+### User Story 4 - Detect retrieval-targeted prompt injection in RAG systems (Priority: P2)
+
+A security engineer whose product uses a retrieval-augmented pipeline (RAG) wants to know whether attackers could plant content that a similarity search would retrieve and the agent would then act on. Today, ZIRAN's indirect-injection vectors assume the injected content is already present in context and don't exercise the retrieval ranking step. The engineer needs attacks that specifically target retrieval.
+
+**Why this priority**: RAG is one of the most common agent architectures in production today, and ZIRAN claims to cover indirect injection. Without retrieval-aware vectors, the coverage story has a visible hole.
+
+**Independent Test**: Select the new RAG poisoning category from the attack library and run those vectors against a test agent. The vectors contain content crafted to rank highly for common queries and are embeddable in multiple document formats.
+
+**Acceptance Scenarios**:
+
+1. **Given** the attack library, **When** the engineer filters by the RAG-poisoning category, **Then** they see vectors specifically designed for retrieval-ranking manipulation.
+2. **Given** a RAG-poisoning vector, **When** the engineer reviews its payload, **Then** the content is formatted to appear credible and high-ranking in similarity search (e.g., keyword-dense, credible framing, multiple document-format variants).
+3. **Given** these vectors, **When** they are included in a campaign report, **Then** they appear in the OWASP LLM01 category and in the ATLAS indirect-injection mapping alongside existing indirect-injection vectors.
+
+---
+
+### User Story 5 - Measure attacks that bypass active defences (Priority: P3)
+
+A blue team that has already deployed a guardrail system (an input filter, an output guard, or a hybrid) wants to know: of the attacks ZIRAN runs, how many bypass the defences in place? Today, ZIRAN measures success rate against the raw agent but does not report a separate bypass rate against active defences. Without that metric, the team cannot distinguish "the agent is safe" from "the guardrail happened to catch it this time".
+
+**Why this priority**: This is a meaningful capability expansion rather than a coverage fill. It directly addresses the LLMail-Inject / PINT gaps but is more involved than the other work items. It can be scoped as a minimal first version in this release with deeper integrations in a follow-up.
+
+**Independent Test**: Configure a defence profile (declaring what defences are active on the target), run a campaign, and view the resulting report. An evasion rate metric is reported separately from the raw success rate.
+
+**Acceptance Scenarios**:
+
+1. **Given** a campaign configuration, **When** the team declares one or more active defences via a defence profile, **Then** the campaign results include an evasion rate metric alongside the existing success rate.
+2. **Given** two campaigns against the same target — one with a defence profile declared, one without — **When** the team compares the reports, **Then** the evasion-rate column only appears on the first report.
+3. **Given** the campaign report, **When** a finding is listed, **Then** it indicates whether that specific attack bypassed the declared defences.
+
+---
+
+### Edge Cases
+
+- **Vector without an obvious ATLAS technique.** Some vectors may not map cleanly to any ATLAS technique. The system treats ATLAS mapping as a list (zero or more techniques) so that edge cases can map to "no known technique" rather than forcing a bad fit, but a coverage audit flags any vector with an empty mapping as a follow-up.
+- **Deprecated or renamed ATLAS techniques.** ATLAS evolves. If a referenced technique identifier is renamed or deprecated upstream, the coverage report surfaces the discrepancy rather than silently failing.
+- **Vector appears in multiple OWASP and multiple ATLAS categories.** Some attacks span categories (e.g., indirect injection used for exfiltration). Both taxonomies accept multi-value mappings and the reports handle multi-tagging without double-counting on coverage totals.
+- **Defence profile declared without any defences.** An empty profile is treated the same as no profile — no evasion rate metric is computed; the existing success rate is reported unchanged.
+- **Defence profile declares a defence the system doesn't know how to evaluate.** The system accepts the declaration, records it in the report metadata, but marks the evasion rate as "not computable" for that defence rather than silently substituting zero.
+- **Generated report consumed by a downstream signing step.** Output remains deterministic (stable key order, stable array order) so that hash-and-sign workflows downstream (e.g., asqav integration in issue #259) remain valid.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Threat-framework mapping
+
+- **FR-001**: Every attack vector in the library MUST carry a MITRE ATLAS mapping field, independent of its existing OWASP LLM mapping. Both mappings are lists (zero or more entries per vector).
+- **FR-002**: The library MUST allow filtering by ATLAS technique identifier, in addition to the existing OWASP filter.
+- **FR-003**: Campaign findings MUST expose the ATLAS mapping of the attack that produced them, in both machine-readable (JSON) and human-readable (Markdown / HTML) report formats.
+- **FR-004**: The coverage reporting infrastructure MUST produce an ATLAS coverage summary listing the number of techniques mapped, grouped by ATLAS tactic, and highlighting AI-agent-specific techniques.
+
+#### OWASP gap closure
+
+- **FR-005**: The library MUST include at least ten vectors mapped to OWASP LLM05 (Supply Chain Vulnerabilities), spanning malicious tool/plugin detection, compromised dependencies, and data pipeline poisoning.
+- **FR-006**: The library MUST include at least ten vectors mapped to OWASP LLM10 (Model Theft / Unbounded Consumption), spanning model extraction, weight approximation, fine-tuning data extraction, and model fingerprinting.
+- **FR-007**: The OWASP coverage dashboard MUST report every category as "strong" or "comprehensive" after this release — no category is left at "moderate", "planned", or "not covered".
+
+#### Benchmark coverage expansion
+
+- **FR-008**: The library MUST add representative prompt-injection patterns drawn from TensorTrust, chosen to diversify pattern coverage rather than increase raw count toward full parity.
+- **FR-009**: The library MUST add multi-turn jailbreak tactics from WildJailbreak that are not already represented among the existing tactics.
+- **FR-010**: The library MUST include dedicated sandbox-evasion vectors that map to ToolEmu's emulated-sandbox evaluation dimension, distinguishable from generic tool-manipulation vectors.
+- **FR-011**: The library MUST cover CyberSecEval's code-generation safety and cybersecurity-knowledge dimensions with identifiable vectors rather than relying on generic overlap.
+
+#### RAG poisoning
+
+- **FR-012**: The library MUST include a retrieval-aware indirect-injection category containing vectors whose payloads are crafted for high similarity-search ranking.
+- **FR-013**: RAG poisoning vectors MUST include multiple document-format framings (e.g., email, web page, database record) so that realistic retrieval contexts are exercised.
+- **FR-014**: Each RAG poisoning vector MUST carry both an OWASP LLM01 mapping and an ATLAS indirect-injection technique mapping.
+
+#### Defence-evasion measurement
+
+- **FR-015**: Campaign configuration MUST accept an optional defence profile declaring which defences (input filters, output guards, hybrid guardrail systems) are active on the target.
+- **FR-016**: When a non-empty defence profile is declared, campaign results MUST include an evasion rate metric defined as the proportion of attempted attacks that succeeded despite the declared defences.
+- **FR-017**: When no defence profile is declared (or when the declared profile is empty), reports MUST omit the evasion rate rather than reporting a misleading zero.
+- **FR-018**: Individual findings MUST indicate whether they bypassed the declared defences, when a defence profile was present.
+
+#### Report and CLI surface
+
+- **FR-019**: The CLI attack-library listing MUST support filtering by ATLAS technique in the same way it currently supports filtering by OWASP category.
+- **FR-020**: All generated report artefacts (JSON, Markdown, HTML) MUST produce deterministic output (stable key and array ordering) so that hash-and-sign workflows downstream are not broken.
+- **FR-021**: The auto-generated benchmark comparison document MUST reflect the new vector counts and ATLAS technique mapping after regeneration, without manual edits.
+
+### Key Entities
+
+- **ATLAS Technique Mapping**: A typed reference from an attack vector to one or more MITRE ATLAS techniques, carrying a technique identifier and human-readable name. Parallel to the existing OWASP mapping.
+- **Defence Profile**: A named declaration, supplied at campaign time, describing which defences are active on the target. Consumed by the evasion-rate calculation. Empty profiles are treated as absent.
+- **Evasion Rate**: A campaign-level metric expressing the proportion of attacks that succeeded in the presence of the declared defences. Reported only when a non-empty defence profile is present.
+- **Coverage Report**: A structured artefact summarising how many ATLAS techniques, OWASP categories, and benchmark dimensions are represented in the library at a given time. Feeds both machine-readable JSON and the published comparison document.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Every attack vector in the library carries a non-empty ATLAS mapping (validated automatically by a lint/coverage script); at least 60 distinct ATLAS techniques are represented; all 14 October-2025 AI-agent-specific techniques are represented.
+- **SC-002**: The OWASP coverage dashboard reports all ten categories at "strong" or "comprehensive"; no category is left at a lower tier.
+- **SC-003**: On the auto-generated benchmark comparison table, the TensorTrust, WildJailbreak, ToolEmu, and CyberSecEval rows each show a measurable increase in vector count or pattern-diversity versus the v0.26 baseline.
+- **SC-004**: A reader of a ZIRAN report can find, for any given finding, the exact ATLAS techniques and OWASP categories it exercises without leaving the report.
+- **SC-005**: An operator who declares a defence profile and runs a campaign sees a separate evasion-rate metric in the report; an operator who declares no profile sees an unchanged report with no misleading evasion number.
+- **SC-006**: The benchmark comparison document regenerates cleanly (no manual edits) and matches the library state; running the regeneration twice in a row produces identical output (determinism is preserved for downstream signing).
+- **SC-007**: A security engineer evaluating a RAG pipeline can select retrieval-targeted vectors from the library and run them against their agent using only existing CLI commands — no one-off scripts.
+
+## Assumptions
+
+- **ATLAS mapping granularity.** Technique-level mapping is the target for this release. Sub-technique detail is welcome where obvious (e.g., where a vector clearly exercises one specific sub-technique) but is not required for completeness. Later releases can tighten granularity if there's demand.
+- **ATLAS as a static snapshot.** The set of ATLAS tactics, techniques, and sub-techniques is embedded in the project at a specific snapshot date (the October 2025 release). ATLAS changes are picked up by later releases, not automatically. This matches how OWASP LLM Top 10 is currently embedded.
+- **No full benchmark parity.** TensorTrust (126K vectors) and WildJailbreak (105K) are explicitly not targeted for full parity. The release targets representative diversity across unique pattern families.
+- **Defence-evasion scope.** This release ships the configuration schema, the evasion-rate metric, and report surfacing. Real integrations with specific commercial guardrails (NeMo Guardrails, Lakera Guard, and similar) are out of scope and tracked as follow-up work.
+- **No detection-pipeline changes.** Detection logic (the detector pipeline that classifies a response as successful attack vs refusal) is not modified by this release. Work is confined to the coverage, mapping, reporting, and configuration layers.
+- **No UI changes in scope.** The web UI can display ATLAS and evasion-rate fields in a follow-up release. This release ensures the data is present in the API and generated reports so that UI work can consume it.
+- **Backwards compatibility.** Existing consumers of the library YAML format, the campaign result JSON, and the CLI continue to work. New fields are additive; old fields are not renamed or removed.
+- **Release packaging.** The release is one version bump. Internally it may land as several focused pull requests (e.g., ATLAS mapping → OWASP gaps → benchmark expansion → RAG poisoning → defence evasion) sequenced so each is independently reviewable, but the user-visible delivery is a single version.
+
+## Dependencies
+
+- ZIRAN v0.26 (v0.8 runtime bridge) is the baseline. No unreleased dependencies.
+- Existing benchmark infrastructure (`benchmarks/*.py`, `docs/reference/benchmarks/coverage-comparison.md`) is reused and extended; no rewrite.
+- Existing attack library YAML format is extended additively; no migration needed for existing consumers.

--- a/specs/012-benchmark-maturity/tasks.md
+++ b/specs/012-benchmark-maturity/tasks.md
@@ -1,0 +1,333 @@
+---
+description: "Tasks for Benchmark Maturity release (012)"
+---
+
+# Tasks: Benchmark Maturity
+
+**Input**: Design documents from `/specs/012-benchmark-maturity/`
+**Prerequisites**: plan.md, spec.md (user stories), research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Coverage ≥ 85% is a constitution requirement, so test tasks are included alongside implementation. No strict TDD ordering enforced — write tests in the same PR as the implementation they cover.
+
+**Organization**: Tasks are grouped by user story (US1–US5, matching spec.md priorities). Cross-cutting ATLAS CLI and report-surface work lives within US1 because it is the user-visible delivery of the ATLAS mapping. Release polish lives in the final phase.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no in-flight dependency)
+- **[Story]**: Which user story a task belongs to (US1, US2, US3, US4, US5)
+- All paths are relative to repo root
+
+## Path Conventions (project-specific)
+
+- Domain: `ziran/domain/entities/`
+- Application: `ziran/application/`
+- Interfaces (CLI): `ziran/interfaces/cli/`
+- Infrastructure: `ziran/infrastructure/`
+- Attack vectors (YAML): `ziran/application/attacks/vectors/`
+- Benchmark tooling: `benchmarks/`
+- Docs: `docs/reference/benchmarks/`
+- Tests: `tests/unit/`, `tests/integration/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Baseline validation before any changes land on the feature branch.
+
+- [X] T001 Verify branch `012-benchmark-maturity` is checked out and baseline quality gates pass (`uv run ruff check . && uv run ruff format --check . && uv run mypy ziran/ && uv run pytest -q`)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Domain enums, mapping fields, and library helpers that every user story touching ATLAS (US1, US2, US3, US4) depends on. US5 (defence profile) is independent and does its own foundational work inside its phase.
+
+**⚠️ CRITICAL**: No user-story work on ATLAS may begin until this phase is complete.
+
+### Domain: ATLAS taxonomy
+
+- [X] T002 Add `AtlasTactic` StrEnum (15 values from October 2025 ATLAS snapshot) to `ziran/domain/entities/attack.py`
+- [X] T003 Add `AtlasTechnique` StrEnum seeded with the 14 agent-specific techniques plus the ~20 techniques that cover the existing top-category vectors (prompt injection, tool manipulation, exfiltration) in `ziran/domain/entities/attack.py`
+- [X] T004 Add `ATLAS_TECHNIQUE_DESCRIPTIONS: dict[AtlasTechnique, str]` to `ziran/domain/entities/attack.py` (must be complete for every enum member)
+- [X] T005 Add `ATLAS_TECHNIQUE_TO_TACTIC: dict[AtlasTechnique, AtlasTactic]` to `ziran/domain/entities/attack.py` (must be complete for every enum member)
+- [X] T006 Add `AGENT_SPECIFIC_TECHNIQUES: frozenset[AtlasTechnique]` with exactly the 14 agent-specific techniques to `ziran/domain/entities/attack.py`
+
+### Domain: mapping fields on existing entities
+
+- [X] T007 [P] Add `atlas_mapping: list[AtlasTechnique] = Field(default_factory=list, ...)` to `AttackVector` in `ziran/domain/entities/attack.py`
+- [X] T008 [P] Add `atlas_mapping: list[AtlasTechnique] = Field(default_factory=list, ...)` to `AttackResult` in `ziran/domain/entities/attack.py` and propagate from vector to result in the scanner dispatch path (mirror how `owasp_mapping` is copied today — search `owasp_mapping=` in `ziran/application/` to locate call sites)
+
+### Application: library helpers
+
+- [X] T009 Add `AttackLibrary.get_attacks_by_atlas(technique: AtlasTechnique) -> list[AttackVector]` in `ziran/application/attacks/library.py` (mirror `get_attacks_by_owasp` exactly)
+- [X] T010 Add `AttackLibrary.lint_atlas_coverage() -> list[str]` in `ziran/application/attacks/library.py` — returns vector IDs whose `atlas_mapping` is empty
+
+### Tests (foundational)
+
+- [X] T011 [P] Unit test `tests/unit/test_atlas_enum.py` implementing the 7 contract tests from `contracts/atlas-taxonomy.md` (enum completeness ×2, agent-specific cardinality, subset property, tactic-reference validity, technique ID regex, tactic ID regex)
+- [X] T012 [P] Unit test `tests/unit/test_library_atlas_filter.py` covering `get_attacks_by_atlas` (valid technique, unknown technique, empty-library case) and `lint_atlas_coverage` (reports vectors with empty mapping, returns empty when all mapped)
+- [X] T013 [P] Unit test `tests/unit/test_attack_vector_atlas_field.py` confirming `AttackVector` and `AttackResult` round-trip `atlas_mapping` through `model_dump`/`model_validate` and that the field defaults to empty list for YAML without it
+
+**Checkpoint**: Foundation ready. ATLAS enum exists, mapping field on vectors/results is live (empty defaults), library filters and lint helper usable. US1–US4 can begin.
+
+---
+
+## Phase 3: User Story 1 — Align ZIRAN findings with MITRE ATLAS (Priority: P1) 🎯 MVP
+
+**Goal**: Every attack vector carries an ATLAS technique mapping. The benchmark dashboard reports ATLAS coverage. Reports and the CLI library listing surface ATLAS IDs alongside OWASP. This is the flagship deliverable of the release and the "ATLAS mapping" row on the coverage comparison moves from 0 to ≥ 60 techniques.
+
+**Independent Test**: Run `uv run python benchmarks/atlas_coverage.py` — every vector is mapped, ≥ 60 techniques covered, all 14 agent-specific techniques present. Run `ziran library --atlas AML.T0051` — returns a non-empty list. View any campaign report — every finding shows an ATLAS technique.
+
+### ATLAS enum expansion to cover existing library (iterative — grows with annotation)
+
+- [ ] T014 [US1] Enumerate every MITRE ATLAS technique that will be referenced during annotation, expanding `AtlasTechnique`, `ATLAS_TECHNIQUE_DESCRIPTIONS`, and `ATLAS_TECHNIQUE_TO_TACTIC` until the enum covers ≥ 60 techniques. Source the IDs and names from the October 2025 ATLAS release notes and matrix
+
+### Retro-mapping pass — annotate `atlas_mapping` on every existing vector
+
+Each task below touches one file (or a tight family of closely-related files) and can run in parallel with the others.
+
+- [ ] T015 [P] [US1] Annotate `ziran/application/attacks/vectors/prompt_injection.yaml` — every vector gets one or more ATLAS technique IDs
+- [ ] T016 [P] [US1] Annotate prompt-injection family in `ziran/application/attacks/vectors/jailbreakbench.yaml`, `multi_turn_tactics.yaml`, and `expanded_tactics.yaml`
+- [ ] T017 [P] [US1] Annotate `ziran/application/attacks/vectors/chain_of_thought_manipulation.yaml` and `memory_poisoning.yaml`
+- [ ] T018 [P] [US1] Annotate indirect-injection family: `ziran/application/attacks/vectors/indirect_injection.yaml`, `indirect_injection_escalation.yaml`, `indirect_injection_exfiltration.yaml`, `indirect_injection_tool_abuse.yaml`
+- [ ] T019 [P] [US1] Annotate `ziran/application/attacks/vectors/mcp_attacks.yaml`, `mcp_attacks_expanded.yaml`, and `model_dos.yaml`
+- [ ] T020 [P] [US1] Annotate `ziran/application/attacks/vectors/data_exfiltration.yaml` and `system_prompt_extraction.yaml`
+- [ ] T021 [P] [US1] Annotate `ziran/application/attacks/vectors/authorization.yaml` and `privilege_escalation.yaml`
+- [ ] T022 [P] [US1] Annotate `ziran/application/attacks/vectors/multi_agent.yaml`, `a2a_attacks.yaml`, and `rjudge.yaml`
+- [ ] T023 [P] [US1] Annotate `ziran/application/attacks/vectors/harmful_tasks.yaml`, `harmful_tasks_expanded.yaml`, and `alert_coverage.yaml`
+
+### Benchmark script and dashboard
+
+- [ ] T024 [US1] Create `benchmarks/atlas_coverage.py` implementing the JSON schema and stdout table defined in `contracts/benchmark-reports.md` (uses `ATLAS_TECHNIQUE_TO_TACTIC` and `AGENT_SPECIFIC_TECHNIQUES`; exit code 0 on full coverage, 1 on empty mappings or missing agent-specific techniques)
+- [ ] T025 [US1] Add `benchmarks/atlas_coverage.py` to the regeneration list in `benchmarks/generate_all.py`
+- [ ] T026 [US1] Extend `benchmarks/benchmark_comparison.py` with a MITRE ATLAS row whose numerator is the count of covered techniques (from `atlas_coverage.py`) and denominator is `len(AtlasTechnique)`
+
+### CLI and report surface
+
+- [ ] T027 [US1] Add `--atlas` option to the `library` subcommand in `ziran/interfaces/cli/main.py` (Click choice derived from `AtlasTechnique`; include `difflib.get_close_matches` suggestion on invalid values; compose with existing `--owasp`, `--category`, `--severity`, `--tag` as AND)
+- [ ] T028 [US1] Add an `ATLAS` column to the `library` subcommand's Rich table output in `ziran/interfaces/cli/main.py` (mirror the existing `OWASP` column rendering)
+- [ ] T029 [US1] Add an "ATLAS" section to the Markdown report template in `ziran/interfaces/cli/reports.py` — per-finding technique list and a tactic-level coverage summary, with agent-specific techniques highlighted
+- [ ] T030 [US1] Add the equivalent "ATLAS" section to the HTML report template (same file or adjacent — whichever holds the current OWASP compliance table)
+- [ ] T031 [US1] Regenerate `docs/reference/benchmarks/coverage-comparison.md` by running `uv run python benchmarks/generate_all.py` and committing the output
+
+### Tests (US1)
+
+- [ ] T032 [P] [US1] Integration test `tests/integration/test_atlas_coverage_script.py` — runs `atlas_coverage.py`, asserts JSON matches schema, asserts byte-identical output on two runs (determinism), asserts exit 0 when all mapped
+- [ ] T033 [P] [US1] Integration test `tests/integration/test_cli_atlas_filter.py` — valid technique → non-empty; invalid technique → exit 2 with suggestion; combined `--atlas X --owasp Y` AND semantics
+- [ ] T034 [P] [US1] Integration test `tests/integration/test_report_atlas_section.py` — run a synthetic campaign, assert Markdown and HTML reports include per-finding ATLAS ID and the ATLAS coverage section
+- [ ] T035 [US1] Unit test extension in `tests/unit/test_library_atlas_filter.py` — assert `lint_atlas_coverage()` returns empty list after retro-mapping
+
+**Checkpoint**: US1 fully deliverable. Every vector has an ATLAS mapping, `atlas_coverage.py` passes, CLI filter works, reports surface the mapping, benchmark comparison table shows the new row.
+
+---
+
+## Phase 4: User Story 2 — Complete OWASP LLM Top 10 coverage (Priority: P1)
+
+**Goal**: OWASP coverage dashboard reports all 10 categories at "strong" or "comprehensive". LLM05 (≥10) and LLM10 (≥10) are closed out. All new vectors carry both OWASP and ATLAS mappings.
+
+**Independent Test**: Run `uv run python benchmarks/owasp_coverage.py` — every category shows `strong` or `comprehensive`; no `moderate`, `planned`, or `not covered`. Run `ziran library --owasp LLM10` — returns ≥ 10 vectors.
+
+### New attack vector YAML files
+
+- [ ] T036 [P] [US2] Create `ziran/application/attacks/vectors/supply_chain.yaml` with ≥ 10 vectors covering malicious tool/plugin manifests, typosquatted tool names, compromised dependency framings, RAG connector poisoning, and fine-tuning data exfiltration. Each vector carries `owasp_mapping: [LLM05]` and `atlas_mapping:` with one or more techniques from the supply-chain family
+- [ ] T037 [P] [US2] Create `ziran/application/attacks/vectors/model_theft.yaml` with ≥ 10 vectors covering systematic API querying for model extraction, weight approximation probes, fine-tuning data extraction (memorisation probes), model fingerprinting, and fine-tuning inversion prompts. Each vector carries `owasp_mapping: [LLM10]` and `atlas_mapping:` with exfiltration/reconnaissance techniques
+
+### Benchmark script updates
+
+- [ ] T038 [US2] Update `benchmarks/owasp_coverage.py`: remove entries for `"LLM05"` and `"LLM10"` from `_PLANNED_ISSUES`; add a strict floor check that every category is at `_STRONG` or better, emitting exit 1 on violation
+- [ ] T039 [US2] Regenerate `docs/reference/benchmarks/coverage-comparison.md` and `benchmarks/results/owasp_coverage.json` (via `benchmarks/generate_all.py`)
+
+### Tests (US2)
+
+- [ ] T040 [P] [US2] Unit test extension in `tests/unit/test_owasp_coverage.py` asserting LLM05 count ≥ 10, LLM10 count ≥ 10, and strict floor across all 10 categories (add the test file if it does not yet exist — parallel to `benchmarks/owasp_coverage.py` coverage logic)
+- [ ] T041 [P] [US2] Integration test `tests/integration/test_owasp_full_coverage.py` asserting `ziran library --owasp LLM05` and `--owasp LLM10` both return ≥ 10 vectors and every one carries a non-empty `atlas_mapping`
+
+**Checkpoint**: OWASP coverage is 10/10. US2 deliverable independent of US3, US4, US5.
+
+---
+
+## Phase 5: User Story 3 — Demonstrably higher coverage on public benchmarks (Priority: P2)
+
+**Goal**: TensorTrust, WildJailbreak, ToolEmu, and CyberSecEval rows on the benchmark comparison table show measurable increases. New vectors cover unique pattern families, not raw count parity.
+
+**Independent Test**: Regenerate the coverage-comparison.md. Inspect the four rows — numerator increased versus the pre-release baseline. Run `ziran library --tag tensortrust` (and similar for other benchmarks) — each returns the expected count of new vectors.
+
+### New attack vector YAML files
+
+- [ ] T042 [P] [US3] Create `ziran/application/attacks/vectors/tensortrust_patterns.yaml` with ~25 vectors spanning system-prompt override, credential extraction, tool-output substitution, fake-rulebook framings, and multi-language injection. Each carries `owasp_mapping: [LLM01]`, `atlas_mapping:` with prompt-injection techniques, and `tags: [tensortrust]`
+- [ ] T043 [P] [US3] Create `ziran/application/attacks/vectors/wildjailbreak_tactics.yaml` with ~10 new multi-turn tactics (progressive hypothetical escalation, persona rewind, compliance weaponisation, moral inversion, Socratic induction). Each carries `owasp_mapping: [LLM01]` and appropriate ATLAS techniques; tag `wildjailbreak`
+- [ ] T044 [P] [US3] Create `ziran/application/attacks/vectors/toolemu_sandbox.yaml` with ~15 sandbox-evasion vectors (filesystem-path tricks, process spawn, network-egress probes, sandbox-fingerprinting). Distinct from generic tool-manipulation; tag `toolemu`
+- [ ] T045 [P] [US3] Create `ziran/application/attacks/vectors/cyberseceval_codegen.yaml` with ~20 vectors split between code-generation safety (unsafe code requests, insecure-pattern solicitation) and cybersecurity knowledge (CVE elicitation, exploit-detail probing); tag `cyberseceval`
+
+### Benchmark script updates
+
+- [ ] T046 [US3] Update `benchmarks/benchmark_comparison.py` to reflect new vector counts for TensorTrust, WildJailbreak, ToolEmu, and CyberSecEval rows. Replace the "Not yet implemented" LLMail-Inject row with a RAG injection row pointing to the new `rag_poisoning.yaml` (deliverable completed in US4 — tolerate zero when US4 has not landed yet via a late-binding count)
+- [ ] T047 [US3] Regenerate `docs/reference/benchmarks/coverage-comparison.md` via `benchmarks/generate_all.py`
+
+### Tests (US3)
+
+- [ ] T048 [P] [US3] Integration test `tests/integration/test_benchmark_tag_filters.py` asserting `ziran library --tag tensortrust`, `--tag wildjailbreak`, `--tag toolemu`, and `--tag cyberseceval` each return the expected vector counts and all vectors in each subset carry ATLAS and OWASP mappings
+
+**Checkpoint**: US3 deliverable. Benchmark comparison table shows measurable lifts.
+
+---
+
+## Phase 6: User Story 4 — Detect retrieval-targeted prompt injection in RAG systems (Priority: P2)
+
+**Goal**: New `rag_poisoning.yaml` in the indirect-injection category with retrieval-optimised payloads across multiple document-format framings.
+
+**Independent Test**: `ziran library --tag rag-poisoning` returns the new vectors. Every vector carries `category: indirect_injection`, `owasp_mapping: [LLM01]`, and an ATLAS indirect-injection technique mapping. Sample payloads are keyword-dense and framed for multiple document types (email / web page / database record).
+
+- [ ] T049 [US4] Create `ziran/application/attacks/vectors/rag_poisoning.yaml` with ~12 vectors. Each uses `category: indirect_injection`, `tags: [rag-poisoning]`, `owasp_mapping: [LLM01]`, and an ATLAS indirect-injection technique. Include three vectors per document framing: email, web page, database record, knowledge-base article
+- [ ] T050 [US4] Update `benchmarks/benchmark_comparison.py` to populate the RAG-injection row's numerator from the new file (late-binding via library query, not hardcoded count)
+- [ ] T051 [P] [US4] Integration test `tests/integration/test_rag_poisoning_filter.py` asserting `--tag rag-poisoning` returns the expected vectors, every vector carries the OWASP + ATLAS mappings declared in the spec, and each of the four document framings is represented at least once
+
+**Checkpoint**: US4 deliverable independently. RAG poisoning vectors discoverable and runnable via existing CLI.
+
+---
+
+## Phase 7: User Story 5 — Measure attacks that bypass active defences (Priority: P3)
+
+**Goal**: Campaign configuration accepts an optional defence profile. When a non-empty profile is declared, the campaign report carries a `defence_profile` block and — if evaluable defences exist — an `evasion_rate`. When no profile is declared, the report is byte-identical to a pre-release report (no defence or evasion fields).
+
+**Independent Test**: Run `ziran scan --target <agent> --defence-profile profiles/sample.yaml` — report includes declared defences and (since no evaluable defences ship in this release) "not computable" notation in Markdown/HTML. Run the same command without `--defence-profile` — report contains zero defence/evasion content.
+
+### Domain additions
+
+- [ ] T052 [US5] Create `ziran/domain/entities/defence.py` containing `DefenceProfile` (name, defences list) and `DefenceDeclaration` (kind literal, identifier, evaluable=False default) Pydantic models per `contracts/defence-profile-yaml.md`
+- [ ] T053 [US5] Extend `CampaignResult` (locate in existing domain/entities — the campaign/phase module) with `defence_profile: DefenceProfile | None = None` and `evasion_rate: float | None = None`. Ensure the model's serialisation excludes `None` fields (use `model_config` with `ConfigDict(exclude_none=True)` at JSON-dump time, or call `model_dump(exclude_none=True)` in the report pipeline)
+
+### Application layer
+
+- [ ] T054 [US5] Create `ziran/application/campaign/__init__.py` (if absent) and `ziran/application/campaign/evasion.py` implementing `compute_evasion_rate(findings, profile) -> float | None` with the 4-case logic documented in `data-model.md` (None profile, empty profile, no evaluable defences, evaluable defences)
+- [ ] T055 [US5] Wire defence-profile loading in the scan CLI: add `--defence-profile <path>` option to `ziran/interfaces/cli/main.py` scan subcommand; accept inline `defence_profile:` key in scan config YAML; flag wins on conflict (log warning). Load via `DefenceProfile.model_validate(yaml.safe_load(path))`
+- [ ] T056 [US5] Wire `compute_evasion_rate` into the campaign finalisation step. Locate where `CampaignResult` is built at end-of-campaign and call the helper to populate `evasion_rate` and echo the loaded `defence_profile`
+
+### Report surface
+
+- [ ] T057 [US5] Extend Markdown report template in `ziran/interfaces/cli/reports.py` with a conditional "Declared Defences" section (table: kind / identifier / evaluable) and an Evasion-rate row. When no profile is declared, emit nothing (preserve byte-identity with pre-release reports)
+- [ ] T058 [US5] Mirror T057 in the HTML report template
+
+### Tests (US5)
+
+- [ ] T059 [P] [US5] Unit test `tests/unit/test_defence_profile.py` — Pydantic validation of `DefenceProfile` / `DefenceDeclaration` (required fields, literal constraint on `kind`, default `evaluable=False`)
+- [ ] T060 [P] [US5] Unit test `tests/unit/test_evasion_metric.py` — four cases (None profile, empty profile, profile with no evaluable defences, profile with evaluable defences using a mock count)
+- [ ] T061 [P] [US5] Integration test `tests/integration/test_campaign_with_defence.py` — run a synthetic campaign with a sample profile; assert declared-defences section appears in MD and JSON; assert `evasion_rate` is omitted from JSON but the report explains "not computable"
+- [ ] T062 [P] [US5] Integration test `tests/integration/test_campaign_without_defence.py` — run the same campaign without `--defence-profile`; assert the JSON output contains no `defence_profile` or `evasion_rate` keys (byte-identity preserved)
+
+**Checkpoint**: US5 deliverable. Defence profile schema + evasion-rate metric field is in place and report-facing. Future releases can add real evaluators without schema change.
+
+---
+
+## Phase 8: Polish & Release Readiness
+
+**Purpose**: Cross-cutting work, documentation, determinism validation, and the final quality-gate run.
+
+### Documentation
+
+- [ ] T063 Create `docs/reference/benchmarks/atlas-mapping.md` explaining how ATLAS mapping is structured, the snapshot date (October 2025), how to interpret the coverage dashboard, and links to the MITRE ATLAS website. Register the page in `mkdocs.yml`
+- [ ] T064 [P] Update `README.md` "Benchmark Coverage" or equivalent section to mention ATLAS coverage alongside OWASP (one short paragraph + link to the atlas-mapping.md doc)
+- [ ] T065 [P] Add a release-notes entry in `CHANGELOG.md` (release-please will regenerate this — manual edit if needed to record: ATLAS mapping added, OWASP coverage 10/10, benchmark expansion, RAG poisoning category, defence-profile schema)
+
+### Regeneration and determinism
+
+- [ ] T066 Run `uv run python benchmarks/generate_all.py` to regenerate `benchmarks/results/*.json` and `docs/reference/benchmarks/coverage-comparison.md` in a clean state; commit the updated artefacts
+- [ ] T067 Manually verify determinism: hash `benchmarks/results/*.json` with `sha256sum`, run `benchmarks/generate_all.py` a second time, re-hash, confirm the hashes match byte-for-byte. Fix any non-determinism discovered (most likely: dict iteration order in `atlas_coverage.py` or similar) before proceeding
+
+### Quality gates
+
+- [ ] T068 Run `uv run ruff check .` and fix any new violations
+- [ ] T069 Run `uv run ruff format --check .` and re-format if drift detected
+- [ ] T070 Run `uv run mypy ziran/` and fix any strict-mode errors introduced
+- [ ] T071 Run `uv run pytest --cov=ziran` and confirm total coverage ≥ 85%. Investigate any module that regressed below 85% and add tests to close the gap
+
+### Acceptance validation
+
+- [ ] T072 Walk through every numbered section in `specs/012-benchmark-maturity/quickstart.md` end-to-end (manual QA). Any step that doesn't produce the documented output is a bug — fix and re-walk
+
+**Checkpoint**: Release-ready. Ready to open PRs per the packaging strategy in `plan.md` (5-PR split).
+
+---
+
+## Dependencies & Execution Order
+
+### Phase dependencies
+
+- **Phase 1 (Setup)**: no dependencies.
+- **Phase 2 (Foundational)**: depends on Phase 1. **Blocks** Phases 3, 4, 5, 6 (all ATLAS-touching stories).
+- **Phase 3 (US1)**: depends on Phase 2. Also depends on T014 (enum expansion) before any retro-mapping task can annotate a vector with a specific technique.
+- **Phases 4, 5, 6 (US2, US3, US4)**: depend on Phase 2. Parallel with each other and with Phase 3, but their YAML files should not conflict (each creates a new file, no file overlap).
+- **Phase 7 (US5)**: independent of Phases 3–6. Depends only on Phase 1. Can run in parallel with any ATLAS story.
+- **Phase 8 (Polish)**: depends on all desired user-story phases completing.
+
+### User-story dependencies
+
+- **US1 (P1)**: blocks nothing else by contract; however the CI lint (`lint_atlas_coverage`) only hard-fails after US1's retro-mapping pass lands. Until then, US2/US3/US4 new vectors must still carry non-empty `atlas_mapping` to avoid blocking when the CI gate flips strict.
+- **US2 (P1)**: independent of US1; new vectors must carry ATLAS mapping — the Phase 2 enum must cover supply-chain + model-theft techniques.
+- **US3 (P2)**: independent of US1 and US2; same enum requirement.
+- **US4 (P2)**: independent. Benchmark-comparison row (T050) prefers late-binding via library query so US3's T046 doesn't block.
+- **US5 (P3)**: fully independent.
+
+### Parallel opportunities
+
+- **Foundational**: T002–T006 are sequential (same file, ordering-sensitive). T007/T008 can run in parallel (same file, but straightforward to merge). T011/T012/T013 are independent tests → parallel.
+- **US1 retro-mapping**: T015–T023 all edit different YAML files → all `[P]`, all parallel.
+- **US1 surface**: T027–T030 touch different files (CLI vs reports) → parallel where noted.
+- **US2/US3/US4 new YAML**: T036, T037, T042, T043, T044, T045, T049 are each a new file → all `[P]`, all parallel.
+- **US5 tests**: T059–T062 are independent files → parallel.
+
+---
+
+## Parallel Example: US1 retro-mapping pass
+
+```bash
+# After T014 (enum expansion) lands, launch every annotation task in parallel:
+Task: "Annotate ziran/application/attacks/vectors/prompt_injection.yaml"
+Task: "Annotate prompt-injection family: jailbreakbench.yaml, multi_turn_tactics.yaml, expanded_tactics.yaml"
+Task: "Annotate chain_of_thought_manipulation.yaml and memory_poisoning.yaml"
+Task: "Annotate indirect-injection family: indirect_injection.yaml, indirect_injection_escalation.yaml, indirect_injection_exfiltration.yaml, indirect_injection_tool_abuse.yaml"
+Task: "Annotate mcp_attacks.yaml, mcp_attacks_expanded.yaml, model_dos.yaml"
+Task: "Annotate data_exfiltration.yaml and system_prompt_extraction.yaml"
+Task: "Annotate authorization.yaml and privilege_escalation.yaml"
+Task: "Annotate multi_agent.yaml, a2a_attacks.yaml, rjudge.yaml"
+Task: "Annotate harmful_tasks.yaml, harmful_tasks_expanded.yaml, alert_coverage.yaml"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP first (US1 only)
+
+1. Complete Phase 1 (Setup) — ~5 min.
+2. Complete Phase 2 (Foundational) — the enum, mapping fields, library helpers. Ships as **PR #1**.
+3. Complete Phase 3 (US1) — retro-map every vector, add `atlas_coverage.py`, CLI filter, report surface. Ships as **PR #2**.
+4. **STOP and VALIDATE**: Run quickstart sections 1–5. Demo ATLAS coverage to anyone who cares. v0.27 could ship here if we want the milestone closed in two releases instead of one.
+
+### Incremental delivery (full milestone)
+
+1. **PR #1** — Phases 1 + 2 (Foundation).
+2. **PR #2** — Phase 3 (US1 ATLAS mapping + surface).
+3. **PR #3** — Phases 4 + 5 + 6 (US2 + US3 + US4 — all YAML-heavy, minimal code churn, reviewed together).
+4. **PR #4** — Phase 7 (US5 defence profile + evasion rate).
+5. **PR #5** — Phase 8 (polish, regen, release notes).
+
+### Parallel team strategy
+
+If staffed with 2–3 engineers:
+
+1. Engineer A: Phase 2 foundation, then PR #2 (US1 retro-mapping + surface).
+2. Engineer B: Phase 2 review, then PR #3 (US2 + US3 + US4 YAML work).
+3. Engineer C (if available): PR #4 (US5 — schema + wiring + tests).
+4. All converge on PR #5 for regeneration and release.
+
+---
+
+## Notes
+
+- `[P]` tasks edit different files, have no in-flight dependency on other `[P]` tasks in the same phase.
+- `[Story]` labels map tasks to user stories for PR-scope tracing.
+- Every new vector added in US2/US3/US4/US6 MUST carry both `owasp_mapping` and `atlas_mapping` from day one (don't accumulate new debt).
+- Determinism check (T067) is non-optional: downstream signing (issue #259) relies on byte-identity.
+- No `Co-Authored-By: Claude` trailers in any commit on this branch (constitution + user preference).
+- Every PR must include a GitHub label indicating its scope (e.g., `benchmark`, `cli`, `docs`) — see user memory on PR labels.

--- a/tests/unit/test_atlas_enum.py
+++ b/tests/unit/test_atlas_enum.py
@@ -1,0 +1,68 @@
+"""Contract tests for MITRE ATLAS taxonomy embedded in the domain layer.
+
+Mirrors the contract in ``specs/012-benchmark-maturity/contracts/atlas-taxonomy.md``.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from ziran.domain.entities.attack import (
+    AGENT_SPECIFIC_TECHNIQUES,
+    ATLAS_TACTIC_DESCRIPTIONS,
+    ATLAS_TECHNIQUE_DESCRIPTIONS,
+    ATLAS_TECHNIQUE_TO_TACTIC,
+    AtlasTactic,
+    AtlasTechnique,
+)
+
+
+class TestAtlasTacticEnum:
+    @pytest.mark.unit
+    def test_tactic_values_follow_expected_format(self) -> None:
+        pattern = re.compile(r"^AML\.TA\d{4}$")
+        for tactic in AtlasTactic:
+            assert pattern.match(tactic.value), f"Invalid tactic ID format: {tactic.value}"
+
+    @pytest.mark.unit
+    def test_tactic_descriptions_cover_every_enum_member(self) -> None:
+        assert set(ATLAS_TACTIC_DESCRIPTIONS) == set(AtlasTactic)
+
+    @pytest.mark.unit
+    def test_tactic_count_matches_october_2025_snapshot(self) -> None:
+        # October 2025 ATLAS release has 16 tactics. See spec 012 research.md.
+        assert len(list(AtlasTactic)) == 16
+
+
+class TestAtlasTechniqueEnum:
+    @pytest.mark.unit
+    def test_technique_values_follow_expected_format(self) -> None:
+        pattern = re.compile(r"^AML\.T\d{4}(\.\d{3})?$")
+        for technique in AtlasTechnique:
+            assert pattern.match(technique.value), f"Invalid technique ID format: {technique.value}"
+
+    @pytest.mark.unit
+    def test_technique_descriptions_cover_every_enum_member(self) -> None:
+        assert set(ATLAS_TECHNIQUE_DESCRIPTIONS) == set(AtlasTechnique)
+
+    @pytest.mark.unit
+    def test_tactic_map_covers_every_enum_member(self) -> None:
+        assert set(ATLAS_TECHNIQUE_TO_TACTIC) == set(AtlasTechnique)
+
+    @pytest.mark.unit
+    def test_tactic_map_values_are_valid_tactics(self) -> None:
+        for tactics in ATLAS_TECHNIQUE_TO_TACTIC.values():
+            assert len(tactics) > 0, "Every technique must belong to at least one tactic"
+            for tactic in tactics:
+                assert isinstance(tactic, AtlasTactic)
+
+    @pytest.mark.unit
+    def test_agent_specific_techniques_has_14_entries(self) -> None:
+        # Matches the October 2025 ATLAS release's agent-focused addition count.
+        assert len(AGENT_SPECIFIC_TECHNIQUES) == 14
+
+    @pytest.mark.unit
+    def test_agent_specific_techniques_subset_of_enum(self) -> None:
+        assert AGENT_SPECIFIC_TECHNIQUES.issubset(set(AtlasTechnique))

--- a/tests/unit/test_attack_vector_atlas_field.py
+++ b/tests/unit/test_attack_vector_atlas_field.py
@@ -1,0 +1,137 @@
+"""Round-trip and default-value tests for the new ``atlas_mapping`` field on
+:class:`AttackVector` and :class:`AttackResult`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ziran.domain.entities.attack import (
+    AtlasTechnique,
+    AttackCategory,
+    AttackPrompt,
+    AttackResult,
+    AttackVector,
+)
+from ziran.domain.entities.phase import ScanPhase
+
+
+class TestAttackVectorAtlasMapping:
+    @pytest.mark.unit
+    def test_defaults_to_empty_list(self) -> None:
+        v = AttackVector(
+            id="t",
+            name="t",
+            category=AttackCategory.PROMPT_INJECTION,
+            target_phase=ScanPhase.EXECUTION,
+            description="test",
+            severity="low",
+            prompts=[AttackPrompt(template="x")],
+        )
+        assert v.atlas_mapping == []
+
+    @pytest.mark.unit
+    def test_preserves_populated_mapping(self) -> None:
+        techniques = [
+            AtlasTechnique.LLM_PROMPT_INJECTION,
+            AtlasTechnique.LLM_JAILBREAK,
+        ]
+        v = AttackVector(
+            id="t",
+            name="t",
+            category=AttackCategory.PROMPT_INJECTION,
+            target_phase=ScanPhase.EXECUTION,
+            description="test",
+            severity="low",
+            prompts=[AttackPrompt(template="x")],
+            atlas_mapping=techniques,
+        )
+        assert v.atlas_mapping == techniques
+
+    @pytest.mark.unit
+    def test_round_trips_through_model_dump_and_validate(self) -> None:
+        original = AttackVector(
+            id="t",
+            name="t",
+            category=AttackCategory.PROMPT_INJECTION,
+            target_phase=ScanPhase.EXECUTION,
+            description="test",
+            severity="low",
+            prompts=[AttackPrompt(template="x")],
+            atlas_mapping=[AtlasTechnique.RAG_POISONING],
+        )
+        dumped = original.model_dump()
+        restored = AttackVector.model_validate(dumped)
+        assert restored.atlas_mapping == [AtlasTechnique.RAG_POISONING]
+
+    @pytest.mark.unit
+    def test_accepts_string_values_from_yaml(self) -> None:
+        # YAML loaders emit strings; Pydantic must coerce to enum members.
+        data = {
+            "id": "t",
+            "name": "t",
+            "category": "prompt_injection",
+            "target_phase": "execution",
+            "description": "test",
+            "severity": "low",
+            "prompts": [{"template": "x"}],
+            "atlas_mapping": ["AML.T0051", "AML.T0054"],
+        }
+        v = AttackVector.model_validate(data)
+        assert AtlasTechnique.LLM_PROMPT_INJECTION in v.atlas_mapping
+        assert AtlasTechnique.LLM_JAILBREAK in v.atlas_mapping
+
+    @pytest.mark.unit
+    def test_rejects_unknown_technique_id(self) -> None:
+        data = {
+            "id": "t",
+            "name": "t",
+            "category": "prompt_injection",
+            "target_phase": "execution",
+            "description": "test",
+            "severity": "low",
+            "prompts": [{"template": "x"}],
+            "atlas_mapping": ["AML.T9999"],
+        }
+        with pytest.raises(ValueError):
+            AttackVector.model_validate(data)
+
+
+class TestAttackResultAtlasMapping:
+    @pytest.mark.unit
+    def test_defaults_to_empty_list(self) -> None:
+        r = AttackResult(
+            vector_id="v",
+            vector_name="v",
+            category=AttackCategory.PROMPT_INJECTION,
+            severity="low",
+            successful=False,
+        )
+        assert r.atlas_mapping == []
+
+    @pytest.mark.unit
+    def test_preserves_populated_mapping(self) -> None:
+        techniques = [AtlasTechnique.LLM_DATA_LEAKAGE]
+        r = AttackResult(
+            vector_id="v",
+            vector_name="v",
+            category=AttackCategory.DATA_EXFILTRATION,
+            severity="high",
+            successful=True,
+            atlas_mapping=techniques,
+        )
+        assert r.atlas_mapping == techniques
+
+    @pytest.mark.unit
+    def test_round_trips_through_model_dump_and_validate(self) -> None:
+        original = AttackResult(
+            vector_id="v",
+            vector_name="v",
+            category=AttackCategory.DATA_EXFILTRATION,
+            severity="high",
+            successful=True,
+            atlas_mapping=[AtlasTechnique.EXTRACT_LLM_SYSTEM_PROMPT],
+        )
+        dumped = original.model_dump()
+        restored = AttackResult.model_validate(dumped)
+        assert restored.atlas_mapping == [AtlasTechnique.EXTRACT_LLM_SYSTEM_PROMPT]

--- a/tests/unit/test_library_atlas_filter.py
+++ b/tests/unit/test_library_atlas_filter.py
@@ -1,0 +1,133 @@
+"""Tests for :func:`AttackLibrary.get_attacks_by_atlas` and lint helper.
+
+These tests run against synthetic vectors (not the built-in library) so they
+don't depend on how many real vectors happen to be annotated.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ziran.application.attacks.library import AttackLibrary
+from ziran.domain.entities.attack import (
+    AtlasTechnique,
+    AttackCategory,
+    AttackPrompt,
+    AttackVector,
+)
+from ziran.domain.entities.phase import ScanPhase
+
+
+def _make_vector(
+    vector_id: str,
+    atlas: list[AtlasTechnique] | None = None,
+) -> AttackVector:
+    return AttackVector(
+        id=vector_id,
+        name=vector_id.replace("_", " ").title(),
+        category=AttackCategory.PROMPT_INJECTION,
+        target_phase=ScanPhase.EXECUTION,
+        description="synthetic test vector",
+        severity="medium",
+        prompts=[AttackPrompt(template="test")],
+        atlas_mapping=atlas or [],
+    )
+
+
+def _build_library(vectors: list[AttackVector]) -> AttackLibrary:
+    """Build a test library from a list of vectors without touching disk."""
+    lib = AttackLibrary(load_builtin=False)
+    # Test-only: populate the internal registry directly (no public add API).
+    for v in vectors:
+        lib._vectors[v.id] = v
+    lib._rebuild_indices()
+    return lib
+
+
+@pytest.fixture
+def library_with_atlas_vectors() -> AttackLibrary:
+    """An AttackLibrary with four vectors, three ATLAS-mapped, one not."""
+    return _build_library(
+        [
+            _make_vector("pi_override", [AtlasTechnique.LLM_PROMPT_INJECTION_DIRECT]),
+            _make_vector(
+                "pi_indirect",
+                [
+                    AtlasTechnique.LLM_PROMPT_INJECTION_INDIRECT,
+                    AtlasTechnique.RAG_POISONING,
+                ],
+            ),
+            _make_vector("jailbreak_dan", [AtlasTechnique.LLM_JAILBREAK]),
+            _make_vector("unmapped_vector", []),
+        ]
+    )
+
+
+class TestGetAttacksByAtlas:
+    @pytest.mark.unit
+    def test_returns_vectors_with_matching_technique(
+        self, library_with_atlas_vectors: AttackLibrary
+    ) -> None:
+        result = library_with_atlas_vectors.get_attacks_by_atlas(
+            AtlasTechnique.LLM_PROMPT_INJECTION_DIRECT
+        )
+        assert [v.id for v in result] == ["pi_override"]
+
+    @pytest.mark.unit
+    def test_returns_vectors_for_multi_mapped_technique(
+        self, library_with_atlas_vectors: AttackLibrary
+    ) -> None:
+        # pi_indirect carries two techniques; both should select it.
+        a = library_with_atlas_vectors.get_attacks_by_atlas(
+            AtlasTechnique.LLM_PROMPT_INJECTION_INDIRECT
+        )
+        b = library_with_atlas_vectors.get_attacks_by_atlas(AtlasTechnique.RAG_POISONING)
+        assert [v.id for v in a] == ["pi_indirect"]
+        assert [v.id for v in b] == ["pi_indirect"]
+
+    @pytest.mark.unit
+    def test_returns_empty_list_for_unused_technique(
+        self, library_with_atlas_vectors: AttackLibrary
+    ) -> None:
+        result = library_with_atlas_vectors.get_attacks_by_atlas(AtlasTechnique.GENERATE_DEEPFAKES)
+        assert result == []
+
+    @pytest.mark.unit
+    def test_does_not_return_unmapped_vectors(
+        self, library_with_atlas_vectors: AttackLibrary
+    ) -> None:
+        # Every technique query must exclude unmapped_vector.
+        for technique in AtlasTechnique:
+            result = library_with_atlas_vectors.get_attacks_by_atlas(technique)
+            assert "unmapped_vector" not in [v.id for v in result]
+
+
+class TestLintAtlasCoverage:
+    @pytest.mark.unit
+    def test_reports_vectors_with_empty_atlas_mapping(
+        self, library_with_atlas_vectors: AttackLibrary
+    ) -> None:
+        offenders = library_with_atlas_vectors.lint_atlas_coverage()
+        assert offenders == ["unmapped_vector"]
+
+    @pytest.mark.unit
+    def test_returns_empty_when_all_mapped(self) -> None:
+        lib = _build_library(
+            [
+                _make_vector("a", [AtlasTechnique.LLM_PROMPT_INJECTION_DIRECT]),
+                _make_vector("b", [AtlasTechnique.LLM_JAILBREAK]),
+            ]
+        )
+        assert lib.lint_atlas_coverage() == []
+
+    @pytest.mark.unit
+    def test_returns_sorted_ids_for_determinism(self) -> None:
+        # Add in reverse alphabetical order — helper must emit sorted result.
+        lib = _build_library(
+            [
+                _make_vector("zebra", []),
+                _make_vector("alpha", []),
+                _make_vector("mango", []),
+            ]
+        )
+        assert lib.lint_atlas_coverage() == ["alpha", "mango", "zebra"]

--- a/ziran/application/agent_scanner/attack_executor.py
+++ b/ziran/application/agent_scanner/attack_executor.py
@@ -111,6 +111,7 @@ class AttackExecutor:
                 successful=False,
                 error="No prompts defined for this attack vector",
                 owasp_mapping=attack.owasp_mapping,
+                atlas_mapping=attack.atlas_mapping,
                 business_impact=get_business_impacts(attack.category, attack.severity),
                 harm_category=attack.harm_category,
             )
@@ -242,6 +243,7 @@ class AttackExecutor:
             agent_response=last_response_content,
             prompt_used=last_prompt_used,
             owasp_mapping=attack.owasp_mapping,
+            atlas_mapping=attack.atlas_mapping,
             business_impact=get_business_impacts(attack.category, attack.severity),
             harm_category=attack.harm_category,
             token_usage=attack_tokens,

--- a/ziran/application/attacks/library.py
+++ b/ziran/application/attacks/library.py
@@ -35,6 +35,7 @@ import yaml
 from pydantic import ValidationError
 
 from ziran.domain.entities.attack import (
+    AtlasTechnique,
     AttackCategory,
     AttackPrompt,
     AttackVector,
@@ -228,6 +229,29 @@ class AttackLibrary:
             List of vectors mapped to this OWASP category.
         """
         return [v for v in self._vectors.values() if owasp_id in v.owasp_mapping]
+
+    def get_attacks_by_atlas(self, technique: AtlasTechnique) -> list[AttackVector]:
+        """Get all attack vectors mapped to a specific MITRE ATLAS technique.
+
+        Args:
+            technique: The ATLAS technique to filter by.
+
+        Returns:
+            List of vectors that exercise this technique.
+        """
+        return [v for v in self._vectors.values() if technique in v.atlas_mapping]
+
+    def lint_atlas_coverage(self) -> list[str]:
+        """Report attack vector IDs whose ``atlas_mapping`` is empty.
+
+        Used by the benchmark coverage script as a lint gate — after the
+        retro-mapping pass lands (spec 012, Phase 3), this list must be empty
+        in ``main``. Returns IDs in deterministic (sorted) order.
+
+        Returns:
+            Sorted list of vector IDs that lack an ATLAS mapping.
+        """
+        return sorted(v.id for v in self._vectors.values() if not v.atlas_mapping)
 
     def get_attacks_by_protocol(self, protocol: str) -> list[AttackVector]:
         """Get attack vectors applicable to a specific protocol.

--- a/ziran/application/attacks/tactics.py
+++ b/ziran/application/attacks/tactics.py
@@ -103,6 +103,7 @@ class TacticExecutor:
                 successful=False,
                 error="No prompts defined for this attack vector",
                 owasp_mapping=attack.owasp_mapping,
+                atlas_mapping=attack.atlas_mapping,
                 harm_category=attack.harm_category,
             )
 
@@ -172,6 +173,7 @@ class TacticExecutor:
                         agent_response=response.content,
                         prompt_used=rendered_prompt,
                         owasp_mapping=attack.owasp_mapping,
+                        atlas_mapping=attack.atlas_mapping,
                         harm_category=attack.harm_category,
                         token_usage=total_tokens,
                     )
@@ -202,6 +204,7 @@ class TacticExecutor:
             agent_response=last_response_content,
             prompt_used=last_prompt_used,
             owasp_mapping=attack.owasp_mapping,
+            atlas_mapping=attack.atlas_mapping,
             harm_category=attack.harm_category,
             token_usage=total_tokens,
         )

--- a/ziran/domain/entities/attack.py
+++ b/ziran/domain/entities/attack.py
@@ -98,6 +98,363 @@ OWASP_LLM_DESCRIPTIONS: dict[OwaspLlmCategory, str] = {
 }
 
 
+class AtlasTactic(StrEnum):
+    """MITRE ATLAS tactics (adversary goals against AI systems).
+
+    Taxonomy for adversarial AI threats, parallel to MITRE ATT&CK for traditional
+    enterprise systems. Snapshot pinned to the October 2025 ATLAS release
+    (16 tactics).
+    See: https://atlas.mitre.org/
+    """
+
+    AI_MODEL_ACCESS = "AML.TA0000"
+    AI_ATTACK_STAGING = "AML.TA0001"
+    RECONNAISSANCE = "AML.TA0002"
+    RESOURCE_DEVELOPMENT = "AML.TA0003"
+    INITIAL_ACCESS = "AML.TA0004"
+    EXECUTION = "AML.TA0005"
+    PERSISTENCE = "AML.TA0006"
+    DEFENSE_EVASION = "AML.TA0007"
+    DISCOVERY = "AML.TA0008"
+    COLLECTION = "AML.TA0009"
+    EXFILTRATION = "AML.TA0010"
+    IMPACT = "AML.TA0011"
+    PRIVILEGE_ESCALATION = "AML.TA0012"
+    CREDENTIAL_ACCESS = "AML.TA0013"
+    COMMAND_AND_CONTROL = "AML.TA0014"
+    LATERAL_MOVEMENT = "AML.TA0015"
+
+
+#: Human-readable names for each ATLAS tactic.
+ATLAS_TACTIC_DESCRIPTIONS: dict[AtlasTactic, str] = {
+    AtlasTactic.AI_MODEL_ACCESS: "AI Model Access",
+    AtlasTactic.AI_ATTACK_STAGING: "AI Attack Staging",
+    AtlasTactic.RECONNAISSANCE: "Reconnaissance",
+    AtlasTactic.RESOURCE_DEVELOPMENT: "Resource Development",
+    AtlasTactic.INITIAL_ACCESS: "Initial Access",
+    AtlasTactic.EXECUTION: "Execution",
+    AtlasTactic.PERSISTENCE: "Persistence",
+    AtlasTactic.DEFENSE_EVASION: "Defense Evasion",
+    AtlasTactic.DISCOVERY: "Discovery",
+    AtlasTactic.COLLECTION: "Collection",
+    AtlasTactic.EXFILTRATION: "Exfiltration",
+    AtlasTactic.IMPACT: "Impact",
+    AtlasTactic.PRIVILEGE_ESCALATION: "Privilege Escalation",
+    AtlasTactic.CREDENTIAL_ACCESS: "Credential Access",
+    AtlasTactic.COMMAND_AND_CONTROL: "Command and Control",
+    AtlasTactic.LATERAL_MOVEMENT: "Lateral Movement",
+}
+
+
+class AtlasTechnique(StrEnum):
+    """MITRE ATLAS techniques — how an adversary achieves a tactical goal.
+
+    Snapshot pinned to the October 2025 ATLAS release. This enum includes
+    the techniques referenced by at least one ZIRAN attack vector, plus all
+    agent-specific techniques (see AGENT_SPECIFIC_TECHNIQUES).
+    See: https://atlas.mitre.org/techniques/
+    """
+
+    # ── Reconnaissance (AML.TA0002) ──────────────────────────────────
+    SEARCH_OPEN_TECHNICAL_DATABASES = "AML.T0000"
+    SEARCH_OPEN_AI_VULNERABILITY_ANALYSIS = "AML.T0001"
+    SEARCH_VICTIM_OWNED_WEBSITES = "AML.T0003"
+    SEARCH_APPLICATION_REPOSITORIES = "AML.T0004"
+    ACTIVE_SCANNING = "AML.T0006"
+    GATHER_RAG_INDEXED_TARGETS = "AML.T0064"
+
+    # ── Resource Development (AML.TA0003) ────────────────────────────
+    ACQUIRE_PUBLIC_AI_ARTIFACTS = "AML.T0002"
+    ACQUIRE_INFRASTRUCTURE = "AML.T0008"
+    OBTAIN_CAPABILITIES = "AML.T0016"
+    DEVELOP_CAPABILITIES = "AML.T0017"
+    PUBLISH_POISONED_DATASETS = "AML.T0019"
+    ESTABLISH_ACCOUNTS = "AML.T0021"
+    PUBLISH_POISONED_MODELS = "AML.T0058"
+    PUBLISH_HALLUCINATED_ENTITIES = "AML.T0060"
+    LLM_PROMPT_CRAFTING = "AML.T0065"
+    RETRIEVAL_CONTENT_CRAFTING = "AML.T0066"
+    AI_SUPPLY_CHAIN_RUG_PULL = "AML.T0109"
+
+    # ── Initial Access (AML.TA0004) ──────────────────────────────────
+    AI_SUPPLY_CHAIN_COMPROMISE = "AML.T0010"
+    VALID_ACCOUNTS = "AML.T0012"
+    EVADE_AI_MODEL = "AML.T0015"
+    EXPLOIT_PUBLIC_FACING_APPLICATION = "AML.T0049"
+    PHISHING = "AML.T0052"
+
+    # ── AI Model Access (AML.TA0000) ─────────────────────────────────
+    AI_MODEL_INFERENCE_API_ACCESS = "AML.T0040"
+    PHYSICAL_ENVIRONMENT_ACCESS = "AML.T0041"
+    FULL_AI_MODEL_ACCESS = "AML.T0044"
+    AI_ENABLED_PRODUCT_OR_SERVICE = "AML.T0047"
+
+    # ── Execution (AML.TA0005) ───────────────────────────────────────
+    USER_EXECUTION = "AML.T0011"
+    COMMAND_AND_SCRIPTING_INTERPRETER = "AML.T0050"
+    LLM_PROMPT_INJECTION = "AML.T0051"
+    LLM_PROMPT_INJECTION_DIRECT = "AML.T0051.000"
+    LLM_PROMPT_INJECTION_INDIRECT = "AML.T0051.001"
+    AI_AGENT_TOOL_INVOCATION = "AML.T0053"
+
+    # ── Persistence (AML.TA0006) ─────────────────────────────────────
+    MANIPULATE_AI_MODEL = "AML.T0018"
+    POISON_TRAINING_DATA = "AML.T0020"
+    LLM_PROMPT_SELF_REPLICATION = "AML.T0061"
+    RAG_POISONING = "AML.T0070"
+
+    # ── Privilege Escalation (AML.TA0012) ────────────────────────────
+    LLM_JAILBREAK = "AML.T0054"
+
+    # ── Defense Evasion (AML.TA0007) ─────────────────────────────────
+    LLM_TRUSTED_OUTPUT_COMPONENTS_MANIPULATION = "AML.T0067"
+    LLM_TRUSTED_OUTPUT_CITATIONS = "AML.T0067.000"
+    LLM_PROMPT_OBFUSCATION = "AML.T0068"
+    FALSE_RAG_ENTRY_INJECTION = "AML.T0071"
+
+    # ── Credential Access (AML.TA0013) ───────────────────────────────
+    UNSECURED_CREDENTIALS = "AML.T0055"
+
+    # ── Discovery (AML.TA0008) ───────────────────────────────────────
+    DISCOVER_AI_ARTIFACTS = "AML.T0007"
+    DISCOVER_AI_MODEL_ONTOLOGY = "AML.T0013"
+    DISCOVER_AI_MODEL_FAMILY = "AML.T0014"
+    DISCOVER_LLM_HALLUCINATIONS = "AML.T0062"
+    DISCOVER_AI_MODEL_OUTPUTS = "AML.T0063"
+    DISCOVER_LLM_SYSTEM_INFORMATION = "AML.T0069"
+    DISCOVER_LLM_SYSTEM_PROMPT = "AML.T0069.002"
+
+    # ── Collection (AML.TA0009) ──────────────────────────────────────
+    COLLECTION = "AML.T0009"
+    AI_ARTIFACT_COLLECTION = "AML.T0035"
+    DATA_FROM_INFORMATION_REPOSITORIES = "AML.T0036"
+    DATA_FROM_LOCAL_SYSTEM = "AML.T0037"
+
+    # ── AI Attack Staging (AML.TA0001) ───────────────────────────────
+    CREATE_PROXY_AI_MODEL = "AML.T0005"
+    VERIFY_ATTACK = "AML.T0042"
+    CRAFT_ADVERSARIAL_DATA = "AML.T0043"
+
+    # ── Command and Control (AML.TA0014) ─────────────────────────────
+    REVERSE_SHELL = "AML.T0072"
+
+    # ── Exfiltration (AML.TA0010) ────────────────────────────────────
+    EXFILTRATION_VIA_AI_INFERENCE_API = "AML.T0024"
+    INFER_TRAINING_DATA_MEMBERSHIP = "AML.T0024.000"
+    INVERT_AI_MODEL = "AML.T0024.001"
+    EXTRACT_AI_MODEL = "AML.T0024.002"
+    EXFILTRATION_VIA_CYBER_MEANS = "AML.T0025"
+    EXTRACT_LLM_SYSTEM_PROMPT = "AML.T0056"
+    LLM_DATA_LEAKAGE = "AML.T0057"
+
+    # ── Impact (AML.TA0011) ──────────────────────────────────────────
+    DENIAL_OF_AI_SERVICE = "AML.T0029"
+    ERODE_AI_MODEL_INTEGRITY = "AML.T0031"
+    COST_HARVESTING = "AML.T0034"
+    SPAMMING_AI_SYSTEM_WITH_CHAFF_DATA = "AML.T0046"
+    EXTERNAL_HARMS = "AML.T0048"
+    EXTERNAL_HARMS_AI_IP_THEFT = "AML.T0048.004"
+    ERODE_DATASET_INTEGRITY = "AML.T0059"
+    GENERATE_DEEPFAKES = "AML.T0088"
+    GENERATE_MALICIOUS_COMMANDS = "AML.T0102"
+
+
+#: Human-readable name for each ATLAS technique.
+ATLAS_TECHNIQUE_DESCRIPTIONS: dict[AtlasTechnique, str] = {
+    AtlasTechnique.SEARCH_OPEN_TECHNICAL_DATABASES: "Search Open Technical Databases",
+    AtlasTechnique.SEARCH_OPEN_AI_VULNERABILITY_ANALYSIS: "Search Open AI Vulnerability Analysis",
+    AtlasTechnique.SEARCH_VICTIM_OWNED_WEBSITES: "Search Victim-Owned Websites",
+    AtlasTechnique.SEARCH_APPLICATION_REPOSITORIES: "Search Application Repositories",
+    AtlasTechnique.ACTIVE_SCANNING: "Active Scanning",
+    AtlasTechnique.GATHER_RAG_INDEXED_TARGETS: "Gather RAG-Indexed Targets",
+    AtlasTechnique.ACQUIRE_PUBLIC_AI_ARTIFACTS: "Acquire Public AI Artifacts",
+    AtlasTechnique.ACQUIRE_INFRASTRUCTURE: "Acquire Infrastructure",
+    AtlasTechnique.OBTAIN_CAPABILITIES: "Obtain Capabilities",
+    AtlasTechnique.DEVELOP_CAPABILITIES: "Develop Capabilities",
+    AtlasTechnique.PUBLISH_POISONED_DATASETS: "Publish Poisoned Datasets",
+    AtlasTechnique.ESTABLISH_ACCOUNTS: "Establish Accounts",
+    AtlasTechnique.PUBLISH_POISONED_MODELS: "Publish Poisoned Models",
+    AtlasTechnique.PUBLISH_HALLUCINATED_ENTITIES: "Publish Hallucinated Entities",
+    AtlasTechnique.LLM_PROMPT_CRAFTING: "LLM Prompt Crafting",
+    AtlasTechnique.RETRIEVAL_CONTENT_CRAFTING: "Retrieval Content Crafting",
+    AtlasTechnique.AI_SUPPLY_CHAIN_RUG_PULL: "AI Supply Chain Rug Pull",
+    AtlasTechnique.AI_SUPPLY_CHAIN_COMPROMISE: "AI Supply Chain Compromise",
+    AtlasTechnique.VALID_ACCOUNTS: "Valid Accounts",
+    AtlasTechnique.EVADE_AI_MODEL: "Evade AI Model",
+    AtlasTechnique.EXPLOIT_PUBLIC_FACING_APPLICATION: "Exploit Public-Facing Application",
+    AtlasTechnique.PHISHING: "Phishing",
+    AtlasTechnique.AI_MODEL_INFERENCE_API_ACCESS: "AI Model Inference API Access",
+    AtlasTechnique.PHYSICAL_ENVIRONMENT_ACCESS: "Physical Environment Access",
+    AtlasTechnique.FULL_AI_MODEL_ACCESS: "Full AI Model Access",
+    AtlasTechnique.AI_ENABLED_PRODUCT_OR_SERVICE: "AI-Enabled Product or Service",
+    AtlasTechnique.USER_EXECUTION: "User Execution",
+    AtlasTechnique.COMMAND_AND_SCRIPTING_INTERPRETER: "Command and Scripting Interpreter",
+    AtlasTechnique.LLM_PROMPT_INJECTION: "LLM Prompt Injection",
+    AtlasTechnique.LLM_PROMPT_INJECTION_DIRECT: "LLM Prompt Injection: Direct",
+    AtlasTechnique.LLM_PROMPT_INJECTION_INDIRECT: "LLM Prompt Injection: Indirect",
+    AtlasTechnique.AI_AGENT_TOOL_INVOCATION: "AI Agent Tool Invocation",
+    AtlasTechnique.MANIPULATE_AI_MODEL: "Manipulate AI Model",
+    AtlasTechnique.POISON_TRAINING_DATA: "Poison Training Data",
+    AtlasTechnique.LLM_PROMPT_SELF_REPLICATION: "LLM Prompt Self-Replication",
+    AtlasTechnique.RAG_POISONING: "RAG Poisoning",
+    AtlasTechnique.LLM_JAILBREAK: "LLM Jailbreak",
+    AtlasTechnique.LLM_TRUSTED_OUTPUT_COMPONENTS_MANIPULATION: (
+        "LLM Trusted Output Components Manipulation"
+    ),
+    AtlasTechnique.LLM_TRUSTED_OUTPUT_CITATIONS: "LLM Trusted Output Citations",
+    AtlasTechnique.LLM_PROMPT_OBFUSCATION: "LLM Prompt Obfuscation",
+    AtlasTechnique.FALSE_RAG_ENTRY_INJECTION: "False RAG Entry Injection",
+    AtlasTechnique.UNSECURED_CREDENTIALS: "Unsecured Credentials",
+    AtlasTechnique.DISCOVER_AI_ARTIFACTS: "Discover AI Artifacts",
+    AtlasTechnique.DISCOVER_AI_MODEL_ONTOLOGY: "Discover AI Model Ontology",
+    AtlasTechnique.DISCOVER_AI_MODEL_FAMILY: "Discover AI Model Family",
+    AtlasTechnique.DISCOVER_LLM_HALLUCINATIONS: "Discover LLM Hallucinations",
+    AtlasTechnique.DISCOVER_AI_MODEL_OUTPUTS: "Discover AI Model Outputs",
+    AtlasTechnique.DISCOVER_LLM_SYSTEM_INFORMATION: "Discover LLM System Information",
+    AtlasTechnique.DISCOVER_LLM_SYSTEM_PROMPT: "Discover LLM System Prompt",
+    AtlasTechnique.COLLECTION: "Collection",
+    AtlasTechnique.AI_ARTIFACT_COLLECTION: "AI Artifact Collection",
+    AtlasTechnique.DATA_FROM_INFORMATION_REPOSITORIES: "Data from Information Repositories",
+    AtlasTechnique.DATA_FROM_LOCAL_SYSTEM: "Data from Local System",
+    AtlasTechnique.CREATE_PROXY_AI_MODEL: "Create Proxy AI Model",
+    AtlasTechnique.VERIFY_ATTACK: "Verify Attack",
+    AtlasTechnique.CRAFT_ADVERSARIAL_DATA: "Craft Adversarial Data",
+    AtlasTechnique.REVERSE_SHELL: "Reverse Shell",
+    AtlasTechnique.EXFILTRATION_VIA_AI_INFERENCE_API: "Exfiltration via AI Inference API",
+    AtlasTechnique.INFER_TRAINING_DATA_MEMBERSHIP: "Infer Training Data Membership",
+    AtlasTechnique.INVERT_AI_MODEL: "Invert AI Model",
+    AtlasTechnique.EXTRACT_AI_MODEL: "Extract AI Model",
+    AtlasTechnique.EXFILTRATION_VIA_CYBER_MEANS: "Exfiltration via Cyber Means",
+    AtlasTechnique.EXTRACT_LLM_SYSTEM_PROMPT: "Extract LLM System Prompt",
+    AtlasTechnique.LLM_DATA_LEAKAGE: "LLM Data Leakage",
+    AtlasTechnique.DENIAL_OF_AI_SERVICE: "Denial of AI Service",
+    AtlasTechnique.ERODE_AI_MODEL_INTEGRITY: "Erode AI Model Integrity",
+    AtlasTechnique.COST_HARVESTING: "Cost Harvesting",
+    AtlasTechnique.SPAMMING_AI_SYSTEM_WITH_CHAFF_DATA: "Spamming AI System with Chaff Data",
+    AtlasTechnique.EXTERNAL_HARMS: "External Harms",
+    AtlasTechnique.EXTERNAL_HARMS_AI_IP_THEFT: "External Harms: AI Intellectual Property Theft",
+    AtlasTechnique.ERODE_DATASET_INTEGRITY: "Erode Dataset Integrity",
+    AtlasTechnique.GENERATE_DEEPFAKES: "Generate Deepfakes",
+    AtlasTechnique.GENERATE_MALICIOUS_COMMANDS: "Generate Malicious Commands",
+}
+
+
+#: Canonical parent tactic(s) for each ATLAS technique. Some techniques legitimately
+#: span multiple tactics in the ATLAS data (e.g., LLM Jailbreak is both
+#: Privilege Escalation and Defense Evasion).
+ATLAS_TECHNIQUE_TO_TACTIC: dict[AtlasTechnique, list[AtlasTactic]] = {
+    AtlasTechnique.SEARCH_OPEN_TECHNICAL_DATABASES: [AtlasTactic.RECONNAISSANCE],
+    AtlasTechnique.SEARCH_OPEN_AI_VULNERABILITY_ANALYSIS: [AtlasTactic.RECONNAISSANCE],
+    AtlasTechnique.SEARCH_VICTIM_OWNED_WEBSITES: [AtlasTactic.RECONNAISSANCE],
+    AtlasTechnique.SEARCH_APPLICATION_REPOSITORIES: [AtlasTactic.RECONNAISSANCE],
+    AtlasTechnique.ACTIVE_SCANNING: [AtlasTactic.RECONNAISSANCE],
+    AtlasTechnique.GATHER_RAG_INDEXED_TARGETS: [AtlasTactic.RECONNAISSANCE],
+    AtlasTechnique.ACQUIRE_PUBLIC_AI_ARTIFACTS: [AtlasTactic.RESOURCE_DEVELOPMENT],
+    AtlasTechnique.ACQUIRE_INFRASTRUCTURE: [AtlasTactic.RESOURCE_DEVELOPMENT],
+    AtlasTechnique.OBTAIN_CAPABILITIES: [AtlasTactic.RESOURCE_DEVELOPMENT],
+    AtlasTechnique.DEVELOP_CAPABILITIES: [AtlasTactic.RESOURCE_DEVELOPMENT],
+    AtlasTechnique.PUBLISH_POISONED_DATASETS: [AtlasTactic.RESOURCE_DEVELOPMENT],
+    AtlasTechnique.ESTABLISH_ACCOUNTS: [AtlasTactic.RESOURCE_DEVELOPMENT],
+    AtlasTechnique.PUBLISH_POISONED_MODELS: [AtlasTactic.RESOURCE_DEVELOPMENT],
+    AtlasTechnique.PUBLISH_HALLUCINATED_ENTITIES: [AtlasTactic.RESOURCE_DEVELOPMENT],
+    AtlasTechnique.LLM_PROMPT_CRAFTING: [AtlasTactic.RESOURCE_DEVELOPMENT],
+    AtlasTechnique.RETRIEVAL_CONTENT_CRAFTING: [AtlasTactic.RESOURCE_DEVELOPMENT],
+    AtlasTechnique.AI_SUPPLY_CHAIN_RUG_PULL: [AtlasTactic.RESOURCE_DEVELOPMENT],
+    AtlasTechnique.AI_SUPPLY_CHAIN_COMPROMISE: [AtlasTactic.INITIAL_ACCESS],
+    AtlasTechnique.VALID_ACCOUNTS: [AtlasTactic.INITIAL_ACCESS, AtlasTactic.PRIVILEGE_ESCALATION],
+    AtlasTechnique.EVADE_AI_MODEL: [
+        AtlasTactic.INITIAL_ACCESS,
+        AtlasTactic.DEFENSE_EVASION,
+        AtlasTactic.IMPACT,
+    ],
+    AtlasTechnique.EXPLOIT_PUBLIC_FACING_APPLICATION: [AtlasTactic.INITIAL_ACCESS],
+    AtlasTechnique.PHISHING: [AtlasTactic.INITIAL_ACCESS, AtlasTactic.LATERAL_MOVEMENT],
+    AtlasTechnique.AI_MODEL_INFERENCE_API_ACCESS: [AtlasTactic.AI_MODEL_ACCESS],
+    AtlasTechnique.PHYSICAL_ENVIRONMENT_ACCESS: [AtlasTactic.AI_MODEL_ACCESS],
+    AtlasTechnique.FULL_AI_MODEL_ACCESS: [AtlasTactic.AI_MODEL_ACCESS],
+    AtlasTechnique.AI_ENABLED_PRODUCT_OR_SERVICE: [AtlasTactic.AI_MODEL_ACCESS],
+    AtlasTechnique.USER_EXECUTION: [AtlasTactic.EXECUTION],
+    AtlasTechnique.COMMAND_AND_SCRIPTING_INTERPRETER: [AtlasTactic.EXECUTION],
+    AtlasTechnique.LLM_PROMPT_INJECTION: [AtlasTactic.EXECUTION],
+    AtlasTechnique.LLM_PROMPT_INJECTION_DIRECT: [AtlasTactic.EXECUTION],
+    AtlasTechnique.LLM_PROMPT_INJECTION_INDIRECT: [AtlasTactic.EXECUTION],
+    AtlasTechnique.AI_AGENT_TOOL_INVOCATION: [
+        AtlasTactic.EXECUTION,
+        AtlasTactic.PRIVILEGE_ESCALATION,
+    ],
+    AtlasTechnique.MANIPULATE_AI_MODEL: [AtlasTactic.PERSISTENCE, AtlasTactic.AI_ATTACK_STAGING],
+    AtlasTechnique.POISON_TRAINING_DATA: [
+        AtlasTactic.PERSISTENCE,
+        AtlasTactic.RESOURCE_DEVELOPMENT,
+    ],
+    AtlasTechnique.LLM_PROMPT_SELF_REPLICATION: [AtlasTactic.PERSISTENCE],
+    AtlasTechnique.RAG_POISONING: [AtlasTactic.PERSISTENCE],
+    AtlasTechnique.LLM_JAILBREAK: [
+        AtlasTactic.PRIVILEGE_ESCALATION,
+        AtlasTactic.DEFENSE_EVASION,
+    ],
+    AtlasTechnique.LLM_TRUSTED_OUTPUT_COMPONENTS_MANIPULATION: [AtlasTactic.DEFENSE_EVASION],
+    AtlasTechnique.LLM_TRUSTED_OUTPUT_CITATIONS: [AtlasTactic.DEFENSE_EVASION],
+    AtlasTechnique.LLM_PROMPT_OBFUSCATION: [AtlasTactic.DEFENSE_EVASION],
+    AtlasTechnique.FALSE_RAG_ENTRY_INJECTION: [AtlasTactic.DEFENSE_EVASION],
+    AtlasTechnique.UNSECURED_CREDENTIALS: [AtlasTactic.CREDENTIAL_ACCESS],
+    AtlasTechnique.DISCOVER_AI_ARTIFACTS: [AtlasTactic.DISCOVERY],
+    AtlasTechnique.DISCOVER_AI_MODEL_ONTOLOGY: [AtlasTactic.DISCOVERY],
+    AtlasTechnique.DISCOVER_AI_MODEL_FAMILY: [AtlasTactic.DISCOVERY],
+    AtlasTechnique.DISCOVER_LLM_HALLUCINATIONS: [AtlasTactic.DISCOVERY],
+    AtlasTechnique.DISCOVER_AI_MODEL_OUTPUTS: [AtlasTactic.DISCOVERY],
+    AtlasTechnique.DISCOVER_LLM_SYSTEM_INFORMATION: [AtlasTactic.DISCOVERY],
+    AtlasTechnique.DISCOVER_LLM_SYSTEM_PROMPT: [AtlasTactic.DISCOVERY],
+    AtlasTechnique.COLLECTION: [AtlasTactic.COLLECTION],
+    AtlasTechnique.AI_ARTIFACT_COLLECTION: [AtlasTactic.COLLECTION],
+    AtlasTechnique.DATA_FROM_INFORMATION_REPOSITORIES: [AtlasTactic.COLLECTION],
+    AtlasTechnique.DATA_FROM_LOCAL_SYSTEM: [AtlasTactic.COLLECTION],
+    AtlasTechnique.CREATE_PROXY_AI_MODEL: [AtlasTactic.AI_ATTACK_STAGING],
+    AtlasTechnique.VERIFY_ATTACK: [AtlasTactic.AI_ATTACK_STAGING],
+    AtlasTechnique.CRAFT_ADVERSARIAL_DATA: [AtlasTactic.AI_ATTACK_STAGING],
+    AtlasTechnique.REVERSE_SHELL: [AtlasTactic.COMMAND_AND_CONTROL],
+    AtlasTechnique.EXFILTRATION_VIA_AI_INFERENCE_API: [AtlasTactic.EXFILTRATION],
+    AtlasTechnique.INFER_TRAINING_DATA_MEMBERSHIP: [AtlasTactic.EXFILTRATION],
+    AtlasTechnique.INVERT_AI_MODEL: [AtlasTactic.EXFILTRATION],
+    AtlasTechnique.EXTRACT_AI_MODEL: [AtlasTactic.EXFILTRATION],
+    AtlasTechnique.EXFILTRATION_VIA_CYBER_MEANS: [AtlasTactic.EXFILTRATION],
+    AtlasTechnique.EXTRACT_LLM_SYSTEM_PROMPT: [AtlasTactic.EXFILTRATION],
+    AtlasTechnique.LLM_DATA_LEAKAGE: [AtlasTactic.EXFILTRATION],
+    AtlasTechnique.DENIAL_OF_AI_SERVICE: [AtlasTactic.IMPACT],
+    AtlasTechnique.ERODE_AI_MODEL_INTEGRITY: [AtlasTactic.IMPACT],
+    AtlasTechnique.COST_HARVESTING: [AtlasTactic.IMPACT],
+    AtlasTechnique.SPAMMING_AI_SYSTEM_WITH_CHAFF_DATA: [AtlasTactic.IMPACT],
+    AtlasTechnique.EXTERNAL_HARMS: [AtlasTactic.IMPACT],
+    AtlasTechnique.EXTERNAL_HARMS_AI_IP_THEFT: [AtlasTactic.IMPACT],
+    AtlasTechnique.ERODE_DATASET_INTEGRITY: [AtlasTactic.IMPACT],
+    AtlasTechnique.GENERATE_DEEPFAKES: [AtlasTactic.IMPACT],
+    AtlasTechnique.GENERATE_MALICIOUS_COMMANDS: [AtlasTactic.IMPACT],
+}
+
+
+#: ATLAS techniques that are specific to generative-AI agents and LLM-based systems,
+#: distinct from traditional ML attacks. Highlighted in the coverage dashboard so
+#: readers can see at a glance which agent-focused techniques ZIRAN covers.
+AGENT_SPECIFIC_TECHNIQUES: frozenset[AtlasTechnique] = frozenset(
+    {
+        AtlasTechnique.LLM_PROMPT_INJECTION,
+        AtlasTechnique.LLM_PROMPT_INJECTION_DIRECT,
+        AtlasTechnique.LLM_PROMPT_INJECTION_INDIRECT,
+        AtlasTechnique.LLM_JAILBREAK,
+        AtlasTechnique.AI_AGENT_TOOL_INVOCATION,
+        AtlasTechnique.LLM_PROMPT_SELF_REPLICATION,
+        AtlasTechnique.RAG_POISONING,
+        AtlasTechnique.FALSE_RAG_ENTRY_INJECTION,
+        AtlasTechnique.RETRIEVAL_CONTENT_CRAFTING,
+        AtlasTechnique.GATHER_RAG_INDEXED_TARGETS,
+        AtlasTechnique.LLM_PROMPT_OBFUSCATION,
+        AtlasTechnique.LLM_TRUSTED_OUTPUT_COMPONENTS_MANIPULATION,
+        AtlasTechnique.LLM_TRUSTED_OUTPUT_CITATIONS,
+        AtlasTechnique.DISCOVER_LLM_SYSTEM_INFORMATION,
+    }
+)
+
+
 class BusinessImpact(StrEnum):
     """Business impact categories aligned with Agent-SafetyBench taxonomy."""
 
@@ -324,6 +681,10 @@ class AttackVector(BaseModel):
         default_factory=list,
         description="OWASP Top 10 for LLM Applications categories this vector maps to",
     )
+    atlas_mapping: list[AtlasTechnique] = Field(
+        default_factory=list,
+        description="MITRE ATLAS techniques this vector exercises (October 2025 snapshot)",
+    )
     protocol_filter: list[str] = Field(
         default_factory=list,
         description="Protocols this vector applies to (empty = all). Values: rest, openai, mcp, a2a.",
@@ -378,6 +739,10 @@ class AttackResult(BaseModel):
     owasp_mapping: list[OwaspLlmCategory] = Field(
         default_factory=list,
         description="OWASP Top 10 for LLM Applications categories for this finding",
+    )
+    atlas_mapping: list[AtlasTechnique] = Field(
+        default_factory=list,
+        description="MITRE ATLAS techniques exercised by this finding (copied from vector)",
     )
     business_impact: list[BusinessImpact] = Field(
         default_factory=list,


### PR DESCRIPTION
## Summary

Foundation PR (1 of 5) for the **Benchmark Maturity** release (spec [`012-benchmark-maturity`](specs/012-benchmark-maturity/spec.md) — closes v0.13.0 milestone).

Adds MITRE ATLAS as a second threat-framework taxonomy alongside OWASP LLM Top 10, and wires an `atlas_mapping` field through `AttackVector` → `AttackResult`. All additions are backwards-compatible: the field defaults to empty, existing YAML loads unchanged, and no existing behaviour is altered.

- 16 ATLAS tactics + 65 techniques (October 2025 snapshot, sourced from the upstream `mitre-atlas/atlas-data` GitHub repo)
- `AGENT_SPECIFIC_TECHNIQUES` frozenset highlighting the 14 agent-focused techniques for dashboard surfacing
- `atlas_mapping: list[AtlasTechnique]` on `AttackVector` and `AttackResult`, propagated through both single-turn and multi-turn executors
- `AttackLibrary.get_attacks_by_atlas()` mirroring the existing OWASP filter
- `AttackLibrary.lint_atlas_coverage()` reporting un-annotated vectors (advisory now, hard gate after the Phase 3 retro-mapping PR)

Ships the full spec/plan/research/tasks/contracts/checklists/quickstart set under [`specs/012-benchmark-maturity/`](specs/012-benchmark-maturity/) so reviewers can see where this PR fits in the 5-PR plan.

## What's NOT in this PR

- YAML retro-mapping of the ~565 existing vectors (Phase 3, next PR)
- `benchmarks/atlas_coverage.py` script (Phase 3)
- CLI `--atlas` filter and report-surface ATLAS sections (Phase 3)
- OWASP LLM05 / LLM10 gap closure (Phase 4)
- Benchmark coverage expansion and RAG poisoning (Phases 5, 6)
- Defence profile + evasion rate metric (Phase 7)

## Test plan

- [x] 24 new unit tests pass — enum contracts, library filter, lint helper, field round-trip through YAML and `model_dump`/`model_validate`
- [x] Existing test suite regression-free (1941 passed, same as baseline excluding pre-existing `pentest`-extra env failures)
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run mypy ziran/` clean (only the pre-existing unrelated `ws_handler.py:30` error remains)
- [x] Await CI green on the PR before merging

Refs #61 #57 #58 #56 #55 #45 #44 #43 #42