### PR TITLE
feat(defence): defence profile + evasion-rate metric (US5)

### DIFF
--- a/examples/09-defence-profile/profile.yaml
+++ b/examples/09-defence-profile/profile.yaml
@@ -1,0 +1,25 @@
+# Example defence profile for `ziran scan --defence-profile`.
+#
+# Declares the defences active on a scan target so that the campaign report
+# carries a "Declared Defences" section and (if any defence is evaluable) an
+# evasion-rate metric.
+#
+# This release ships the schema and metric field. Actual evaluator adapters
+# for commercial guardrails (NeMo Guardrails, Lakera Guard, etc.) are
+# out of scope — every declaration defaults to `evaluable: false`, and the
+# report surfaces "not computable" alongside the declared defences. Future
+# releases can flip specific entries to `evaluable: true` without any
+# schema change by shipping per-product evaluators.
+
+name: prod-ingress-v1
+
+defences:
+  - kind: input_filter
+    identifier: nemo-guardrails@v0.8
+    evaluable: false
+  - kind: output_guard
+    identifier: lakera-guard@2025-09
+    evaluable: false
+  - kind: hybrid
+    identifier: custom-internal-regex
+    evaluable: false

--- a/tests/integration/test_campaign_defence_profile.py
+++ b/tests/integration/test_campaign_defence_profile.py
@@ -1,0 +1,137 @@
+"""Integration tests for defence-profile wiring (spec 012 US5).
+
+Verifies both the "profile declared" path (report gains a Declared Defences
+section and an evasion-rate field) and the "no profile" path (report is
+byte-identical to pre-spec-012 output for the same campaign data).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ziran.domain.entities.attack import AttackCategory, AttackResult
+from ziran.domain.entities.defence import DefenceDeclaration, DefenceProfile
+from ziran.domain.entities.phase import CampaignResult, PhaseResult, ScanPhase
+from ziran.interfaces.cli.reports import ReportGenerator
+
+
+def _make_campaign_result(
+    *,
+    campaign_id: str = "test-campaign",
+    defence_profile: DefenceProfile | None = None,
+    evasion_rate: float | None = None,
+) -> CampaignResult:
+    return CampaignResult(
+        campaign_id=campaign_id,
+        target_agent="test-agent",
+        phases_executed=[
+            PhaseResult(
+                phase=ScanPhase.EXECUTION,
+                duration_seconds=1.0,
+                vulnerabilities_found=[],
+                discovered_capabilities=[],
+                trust_score=0.8,
+                success=True,
+            )
+        ],
+        total_vulnerabilities=0,
+        critical_paths=[],
+        final_trust_score=0.8,
+        success=False,
+        attack_results=[
+            AttackResult(
+                vector_id="v1",
+                vector_name="v1",
+                category=AttackCategory.PROMPT_INJECTION,
+                severity="low",
+                successful=False,
+            ).model_dump(mode="json"),
+        ],
+        coverage_level="standard",
+        defence_profile=defence_profile,
+        evasion_rate=evasion_rate,
+    )
+
+
+class TestCampaignWithDefenceProfile:
+    @pytest.mark.integration
+    def test_json_report_includes_defence_profile_when_declared(self, tmp_path) -> None:
+        profile = DefenceProfile(
+            name="prod-ingress-v1",
+            defences=[
+                DefenceDeclaration(kind="input_filter", identifier="nemo-guardrails@v0.8"),
+                DefenceDeclaration(kind="output_guard", identifier="lakera-guard@2025-09"),
+            ],
+        )
+        result = _make_campaign_result(defence_profile=profile)
+        gen = ReportGenerator(output_dir=tmp_path)
+        path = gen.save_json(result)
+        data = json.loads(path.read_text())
+        assert data["defence_profile"]["name"] == "prod-ingress-v1"
+        assert len(data["defence_profile"]["defences"]) == 2
+        # No evaluable defences → evasion_rate is omitted from JSON
+        assert "evasion_rate" not in data
+
+    @pytest.mark.integration
+    def test_markdown_report_includes_declared_defences_section(self, tmp_path) -> None:
+        profile = DefenceProfile(
+            name="prod-v1",
+            defences=[
+                DefenceDeclaration(kind="input_filter", identifier="nemo@v0.8"),
+            ],
+        )
+        result = _make_campaign_result(defence_profile=profile)
+        gen = ReportGenerator(output_dir=tmp_path)
+        path = gen.save_markdown(result)
+        content = path.read_text()
+        assert "## Declared Defences" in content
+        assert "prod-v1" in content
+        assert "nemo@v0.8" in content
+        assert "not computable" in content  # No evaluable defences in this release
+
+    @pytest.mark.integration
+    def test_json_report_includes_evasion_rate_when_computable(self, tmp_path) -> None:
+        profile = DefenceProfile(
+            name="active",
+            defences=[
+                DefenceDeclaration(kind="input_filter", identifier="custom-guard", evaluable=True),
+            ],
+        )
+        result = _make_campaign_result(defence_profile=profile, evasion_rate=0.25)
+        gen = ReportGenerator(output_dir=tmp_path)
+        path = gen.save_json(result)
+        data = json.loads(path.read_text())
+        assert data["evasion_rate"] == 0.25
+
+
+class TestCampaignWithoutDefenceProfile:
+    @pytest.mark.integration
+    def test_json_report_omits_defence_fields(self, tmp_path) -> None:
+        result = _make_campaign_result(defence_profile=None, evasion_rate=None)
+        gen = ReportGenerator(output_dir=tmp_path)
+        path = gen.save_json(result)
+        data = json.loads(path.read_text())
+        # FR-017 / SC-005: byte-identity with pre-spec-012 output.
+        assert "defence_profile" not in data
+        assert "evasion_rate" not in data
+
+    @pytest.mark.integration
+    def test_markdown_report_has_no_declared_defences_section(self, tmp_path) -> None:
+        result = _make_campaign_result(defence_profile=None)
+        gen = ReportGenerator(output_dir=tmp_path)
+        path = gen.save_markdown(result)
+        content = path.read_text()
+        assert "Declared Defences" not in content
+        assert "Evasion rate" not in content
+
+    @pytest.mark.integration
+    def test_empty_profile_treated_as_absent(self, tmp_path) -> None:
+        # FR-017: empty profile == no profile at all
+        profile = DefenceProfile(name="placeholder")
+        result = _make_campaign_result(defence_profile=profile)
+        gen = ReportGenerator(output_dir=tmp_path)
+        path = gen.save_markdown(result)
+        content = path.read_text()
+        assert "Declared Defences" not in content

--- a/tests/unit/test_defence_profile.py
+++ b/tests/unit/test_defence_profile.py
@@ -1,0 +1,92 @@
+"""Unit tests for DefenceProfile / DefenceDeclaration (spec 012 US5)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from ziran.domain.entities.defence import DefenceDeclaration, DefenceProfile
+
+
+class TestDefenceDeclaration:
+    @pytest.mark.unit
+    def test_accepts_valid_kind_and_identifier(self) -> None:
+        d = DefenceDeclaration(kind="input_filter", identifier="nemo-guardrails@v0.8")
+        assert d.kind == "input_filter"
+        assert d.identifier == "nemo-guardrails@v0.8"
+        assert d.evaluable is False
+
+    @pytest.mark.unit
+    def test_rejects_invalid_kind(self) -> None:
+        with pytest.raises(ValidationError):
+            DefenceDeclaration(kind="heuristic", identifier="x")  # type: ignore[arg-type]
+
+    @pytest.mark.unit
+    def test_rejects_empty_identifier(self) -> None:
+        with pytest.raises(ValidationError):
+            DefenceDeclaration(kind="output_guard", identifier="")
+
+    @pytest.mark.unit
+    def test_evaluable_defaults_false(self) -> None:
+        d = DefenceDeclaration(kind="hybrid", identifier="custom-guard")
+        assert d.evaluable is False
+
+    @pytest.mark.unit
+    def test_evaluable_respected_when_set(self) -> None:
+        d = DefenceDeclaration(kind="hybrid", identifier="custom", evaluable=True)
+        assert d.evaluable is True
+
+
+class TestDefenceProfile:
+    @pytest.mark.unit
+    def test_empty_profile_is_empty(self) -> None:
+        p = DefenceProfile(name="empty")
+        assert p.is_empty
+        assert p.evaluable_defences == []
+
+    @pytest.mark.unit
+    def test_profile_with_defences_reports_evaluable_subset(self) -> None:
+        p = DefenceProfile(
+            name="prod",
+            defences=[
+                DefenceDeclaration(kind="input_filter", identifier="a", evaluable=False),
+                DefenceDeclaration(kind="output_guard", identifier="b", evaluable=True),
+                DefenceDeclaration(kind="hybrid", identifier="c", evaluable=True),
+            ],
+        )
+        assert not p.is_empty
+        ids = [d.identifier for d in p.evaluable_defences]
+        assert ids == ["b", "c"]
+
+    @pytest.mark.unit
+    def test_rejects_empty_name(self) -> None:
+        with pytest.raises(ValidationError):
+            DefenceProfile(name="")
+
+    @pytest.mark.unit
+    def test_loads_from_dict(self) -> None:
+        p = DefenceProfile.model_validate(
+            {
+                "name": "prod-ingress-v1",
+                "defences": [
+                    {
+                        "kind": "input_filter",
+                        "identifier": "nemo-guardrails@v0.8",
+                    },
+                ],
+            }
+        )
+        assert p.name == "prod-ingress-v1"
+        assert len(p.defences) == 1
+        assert p.defences[0].evaluable is False
+
+    @pytest.mark.unit
+    def test_round_trips_through_model_dump(self) -> None:
+        original = DefenceProfile(
+            name="prod",
+            defences=[
+                DefenceDeclaration(kind="input_filter", identifier="a"),
+            ],
+        )
+        restored = DefenceProfile.model_validate(original.model_dump())
+        assert restored == original

--- a/tests/unit/test_evasion_metric.py
+++ b/tests/unit/test_evasion_metric.py
@@ -1,0 +1,132 @@
+"""Unit tests for compute_evasion_rate (spec 012 US5)."""
+
+from __future__ import annotations
+
+import pytest
+
+from ziran.application.campaign.evasion import compute_evasion_rate
+from ziran.domain.entities.attack import AttackCategory, AttackResult
+from ziran.domain.entities.defence import DefenceDeclaration, DefenceProfile
+
+
+def _result(
+    vector_id: str,
+    successful: bool,
+    bypass_map: dict[str, bool] | None = None,
+) -> AttackResult:
+    evidence = {}
+    if bypass_map is not None:
+        evidence["defence_bypass"] = bypass_map
+    return AttackResult(
+        vector_id=vector_id,
+        vector_name=vector_id,
+        category=AttackCategory.PROMPT_INJECTION,
+        severity="medium",
+        successful=successful,
+        evidence=evidence,
+    )
+
+
+class TestComputeEvasionRate:
+    @pytest.mark.unit
+    def test_returns_none_when_profile_is_none(self) -> None:
+        findings = [_result("f1", True), _result("f2", False)]
+        assert compute_evasion_rate(findings, None) is None
+
+    @pytest.mark.unit
+    def test_returns_none_when_profile_is_empty(self) -> None:
+        findings = [_result("f1", True)]
+        profile = DefenceProfile(name="empty")
+        assert compute_evasion_rate(findings, profile) is None
+
+    @pytest.mark.unit
+    def test_returns_none_when_no_evaluable_defences(self) -> None:
+        findings = [_result("f1", True), _result("f2", True)]
+        profile = DefenceProfile(
+            name="metadata-only",
+            defences=[
+                DefenceDeclaration(kind="input_filter", identifier="nemo", evaluable=False),
+                DefenceDeclaration(kind="output_guard", identifier="lakera", evaluable=False),
+            ],
+        )
+        assert compute_evasion_rate(findings, profile) is None
+
+    @pytest.mark.unit
+    def test_returns_zero_when_no_findings(self) -> None:
+        profile = DefenceProfile(
+            name="active",
+            defences=[
+                DefenceDeclaration(kind="input_filter", identifier="guard", evaluable=True),
+            ],
+        )
+        assert compute_evasion_rate([], profile) == 0.0
+
+    @pytest.mark.unit
+    def test_returns_zero_when_no_successful_findings(self) -> None:
+        profile = DefenceProfile(
+            name="active",
+            defences=[
+                DefenceDeclaration(kind="input_filter", identifier="guard", evaluable=True),
+            ],
+        )
+        findings = [_result("f1", False), _result("f2", False)]
+        assert compute_evasion_rate(findings, profile) == 0.0
+
+    @pytest.mark.unit
+    def test_returns_zero_when_bypass_map_missing(self) -> None:
+        # No evaluator has stamped per-finding bypass flags yet — the baseline
+        # in this release (no built-in evaluators) yields zero.
+        profile = DefenceProfile(
+            name="active",
+            defences=[
+                DefenceDeclaration(kind="input_filter", identifier="guard", evaluable=True),
+            ],
+        )
+        findings = [_result("f1", True), _result("f2", True)]
+        assert compute_evasion_rate(findings, profile) == 0.0
+
+    @pytest.mark.unit
+    def test_returns_ratio_when_bypass_map_populated(self) -> None:
+        profile = DefenceProfile(
+            name="active",
+            defences=[
+                DefenceDeclaration(kind="input_filter", identifier="guard", evaluable=True),
+            ],
+        )
+        findings = [
+            _result("f1", True, bypass_map={"guard": True}),
+            _result("f2", True, bypass_map={"guard": False}),
+            _result("f3", True, bypass_map={"guard": True}),
+        ]
+        # 2 of 3 successful attacks bypassed → 0.6667
+        assert compute_evasion_rate(findings, profile) == pytest.approx(0.6667, abs=1e-4)
+
+    @pytest.mark.unit
+    def test_only_successful_findings_count(self) -> None:
+        profile = DefenceProfile(
+            name="active",
+            defences=[
+                DefenceDeclaration(kind="input_filter", identifier="g", evaluable=True),
+            ],
+        )
+        findings = [
+            _result("f1", True, bypass_map={"g": True}),
+            _result("f2", False, bypass_map={"g": True}),  # unsuccessful, excluded
+        ]
+        # Only f1 is in the denominator
+        assert compute_evasion_rate(findings, profile) == 1.0
+
+    @pytest.mark.unit
+    def test_all_defences_must_be_bypassed(self) -> None:
+        profile = DefenceProfile(
+            name="layered",
+            defences=[
+                DefenceDeclaration(kind="input_filter", identifier="a", evaluable=True),
+                DefenceDeclaration(kind="output_guard", identifier="b", evaluable=True),
+            ],
+        )
+        findings = [
+            _result("f1", True, bypass_map={"a": True, "b": True}),  # bypass
+            _result("f2", True, bypass_map={"a": True, "b": False}),  # not bypass
+        ]
+        assert compute_evasion_rate(findings, profile) == 0.5

--- a/ziran/application/agent_scanner/result_builder.py
+++ b/ziran/application/agent_scanner/result_builder.py
@@ -10,12 +10,14 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from ziran.application.campaign.evasion import compute_evasion_rate
 from ziran.application.knowledge_graph.chain_analyzer import ToolChainAnalyzer
 from ziran.domain.entities.phase import CampaignResult, PhaseResult, compute_resilience
 
 if TYPE_CHECKING:
     from ziran.application.knowledge_graph.graph import AttackKnowledgeGraph
     from ziran.domain.entities.attack import AttackResult, TokenUsage
+    from ziran.domain.entities.defence import DefenceProfile
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +69,7 @@ class ResultBuilder:
         post_score: float | None = None,
         post_results: list[Any] | None = None,
         utility_tasks_count: int = 0,
+        defence_profile: DefenceProfile | None = None,
     ) -> tuple[CampaignResult, list[Any]]:
         """Build the final campaign result.
 
@@ -119,6 +122,8 @@ class ResultBuilder:
             },
             coverage_level=coverage_value,
             resilience=compute_resilience(serialized_results, phase_results),
+            defence_profile=defence_profile,
+            evasion_rate=compute_evasion_rate(attack_results, defence_profile),
             metadata=metadata,
         )
 

--- a/ziran/application/agent_scanner/scanner.py
+++ b/ziran/application/agent_scanner/scanner.py
@@ -57,6 +57,7 @@ from ziran.domain.entities.attack import (
     AttackResult,
     TokenUsage,
 )
+from ziran.domain.entities.defence import DefenceProfile  # noqa: TC001 — runtime arg type
 from ziran.domain.entities.phase import (
     CORE_PHASES,
     CampaignResult,
@@ -175,6 +176,7 @@ class AgentScanner:
         utility_tasks: list[UtilityTask] | None = None,
         checkpoint_manager: CheckpointManager | None = None,
         resume_from_checkpoint: bool = False,
+        defence_profile: DefenceProfile | None = None,
     ) -> CampaignResult:
         """Execute a full scan campaign.
 
@@ -476,6 +478,7 @@ class AgentScanner:
             post_score=_post_score,
             post_results=_post_results,
             utility_tasks_count=len(utility_tasks or []),
+            defence_profile=defence_profile,
         )
         self._discovered_chains = dangerous_chains
 

--- a/ziran/application/campaign/__init__.py
+++ b/ziran/application/campaign/__init__.py
@@ -1,0 +1,1 @@
+"""Campaign-level application services — evasion rate, finalisation helpers."""

--- a/ziran/application/campaign/evasion.py
+++ b/ziran/application/campaign/evasion.py
@@ -1,0 +1,91 @@
+"""Evasion-rate metric for campaigns with a declared defence profile.
+
+Per spec 012 (Benchmark Maturity) user story 5 and the contract in
+``specs/012-benchmark-maturity/data-model.md``, ``compute_evasion_rate``
+returns:
+
+- ``None`` when no profile is declared
+- ``None`` when the profile is empty (semantically identical to absent)
+- ``None`` when the profile has no evaluable defences (report surface marks
+  this as "not computable" while still carrying the declared defences)
+- Otherwise, the proportion of successful attacks that bypassed every
+  evaluable defence.
+
+This release does not ship any evaluators — all built-in ``DefenceDeclaration``
+instances default to ``evaluable=False``, so in practice ``compute_evasion_rate``
+will return ``None`` even when a profile is declared. The schema is in place
+for future integrations to light up per-finding bypass signals.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from ziran.domain.entities.attack import AttackResult
+    from ziran.domain.entities.defence import DefenceProfile
+
+
+def compute_evasion_rate(
+    findings: Sequence[AttackResult],
+    profile: DefenceProfile | None,
+) -> float | None:
+    """Return the evasion rate for a campaign, or ``None`` when unknowable.
+
+    Args:
+        findings: Ordered sequence of :class:`AttackResult` produced by the
+            campaign. Only findings where ``successful`` is ``True`` count
+            toward the numerator.
+        profile: The :class:`DefenceProfile` declared at campaign time (may be
+            ``None``).
+
+    Returns:
+        The proportion of successful attacks that bypassed all evaluable
+        defences, in ``[0.0, 1.0]``, or ``None`` when the metric is not
+        computable (no profile, empty profile, or no evaluable defences).
+    """
+    if profile is None or profile.is_empty:
+        return None
+    evaluable = profile.evaluable_defences
+    if not evaluable:
+        # Metadata-only declaration — report carries the profile but omits
+        # the metric. Surface as "not computable" in the report layer.
+        return None
+    if not findings:
+        return 0.0
+    successful = [f for f in findings if f.successful]
+    if not successful:
+        return 0.0
+    # Each evaluable defence will, in future integrations, stamp a
+    # ``defence_bypass`` entry onto the AttackResult's evidence dict. For this
+    # release we treat the absence of that stamp as "no bypass observed" — so
+    # the ratio is zero when evaluable defences exist but no evaluator has
+    # populated the per-finding bypass flag yet. Future PRs light this up
+    # without schema change.
+    bypasses = sum(
+        1
+        for finding in successful
+        if _finding_bypassed_all(finding, [d.identifier for d in evaluable])
+    )
+    return round(bypasses / len(successful), 4)
+
+
+def _finding_bypassed_all(finding: AttackResult, evaluable_ids: list[str]) -> bool:
+    """Return True if the finding evidence reports bypasses for every evaluable defence.
+
+    Evidence convention (forward-compatible, set by future evaluator adapters):
+
+        evidence["defence_bypass"] = {
+            "<identifier-1>": True,  # bypassed
+            "<identifier-2>": False, # caught
+        }
+
+    A finding counts as a bypass only when every evaluable defence it targeted
+    reports ``True``. Missing keys default to ``False`` (caught by the absent
+    defence) so that the zero-evaluator baseline in this release yields a
+    zero-bypass count.
+    """
+    bypass_map: dict[str, bool] = finding.evidence.get("defence_bypass", {})
+    return all(bypass_map.get(ident, False) for ident in evaluable_ids)

--- a/ziran/domain/entities/defence.py
+++ b/ziran/domain/entities/defence.py
@@ -1,0 +1,70 @@
+"""Defence-profile domain entities.
+
+Used to declare the defences (input filters, output guards, hybrid guardrail
+systems) active on a scan target. Feeds the evasion-rate metric computed in
+:mod:`ziran.application.campaign.evasion`.
+
+See spec 012 (Benchmark Maturity), user story 5, and
+``specs/012-benchmark-maturity/contracts/defence-profile-yaml.md``.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class DefenceDeclaration(BaseModel):
+    """One defence declared as active on a scan target.
+
+    The declaration is advisory: ``evaluable=False`` means ZIRAN records the
+    defence in report metadata but has no adapter that can tell whether an
+    attack bypassed it. Real guardrail integrations (NeMo Guardrails, Lakera
+    Guard, etc.) will flip this to ``True`` in future releases.
+    """
+
+    kind: Literal["input_filter", "output_guard", "hybrid"] = Field(
+        description="Defence family — where in the request/response pipeline it sits.",
+    )
+    identifier: str = Field(
+        min_length=1,
+        description=(
+            "Free-form identifier, typically '<product>@<version>' (e.g., 'nemo-guardrails@v0.8')."
+        ),
+    )
+    evaluable: bool = Field(
+        default=False,
+        description=(
+            "True if ZIRAN has an adapter that can evaluate whether an attack "
+            "bypassed this defence. False means metadata-only."
+        ),
+    )
+
+
+class DefenceProfile(BaseModel):
+    """Named declaration of defences active on a target.
+
+    Supplied at scan time via the CLI flag ``--defence-profile`` or via the
+    ``defence_profile:`` key in a scan-config YAML. An empty declaration list
+    is treated the same as an absent profile — no evasion metric is computed.
+    """
+
+    name: str = Field(
+        min_length=1,
+        description="Free-form profile label (e.g., 'prod-ingress-v1').",
+    )
+    defences: list[DefenceDeclaration] = Field(
+        default_factory=list,
+        description="Zero or more defence declarations. Empty = no profile semantically.",
+    )
+
+    @property
+    def is_empty(self) -> bool:
+        """Empty profile is semantically equivalent to no profile at all."""
+        return not self.defences
+
+    @property
+    def evaluable_defences(self) -> list[DefenceDeclaration]:
+        """Defences that ZIRAN can actually test for bypass."""
+        return [d for d in self.defences if d.evaluable]

--- a/ziran/domain/entities/phase.py
+++ b/ziran/domain/entities/phase.py
@@ -12,6 +12,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from ziran.domain.entities.defence import DefenceProfile  # noqa: TC001 — Pydantic field type
+
 
 class CoverageLevel(StrEnum):
     """Controls how many attack vectors are used per phase.
@@ -216,6 +218,24 @@ class CampaignResult(BaseModel):
     resilience: ResilienceMetrics | None = Field(
         default=None,
         description="AILuminate-style resilience metrics computed from campaign data",
+    )
+    defence_profile: DefenceProfile | None = Field(
+        default=None,
+        description=(
+            "Defence profile declared for this campaign (spec 012 US5). "
+            "When None, the field is omitted from JSON output via exclude_none, "
+            "preserving byte-identity with pre-spec-012 reports."
+        ),
+    )
+    evasion_rate: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Proportion of attacks that succeeded despite evaluable declared "
+            "defences (spec 012 US5). None when no profile, empty profile, "
+            "or no evaluable defences; omitted from JSON via exclude_none."
+        ),
     )
     metadata: dict[str, Any] = Field(default_factory=dict)
     source: str = Field(default="scan", description="Result source: 'scan' or 'trace-analysis'")

--- a/ziran/interfaces/cli/html_report.py
+++ b/ziran/interfaces/cli/html_report.py
@@ -220,6 +220,21 @@ def build_html_report(
     owasp_html = _build_owasp_html(attack_results, phases)
     # Build ATLAS coverage HTML
     atlas_html = _build_atlas_html(attack_results, phases)
+    # Build Declared Defences HTML (empty when no profile declared).
+    # The entire section wrapper is conditional so that reports with no
+    # profile are byte-identical to pre-spec-012 output (FR-017 / SC-005).
+    defence_html = _build_defence_html(result_data)
+    defence_html_section = (
+        (
+            "  <!-- Declared Defences (spec 012 US5) -->\n"
+            '  <div class="section">\n'
+            '    <div class="section-title">Declared Defences</div>\n'
+            f"    {defence_html}\n"
+            "  </div>\n"
+        )
+        if defence_html
+        else ""
+    )
 
     return _HTML_TEMPLATE.format(
         campaign_id=html.escape(campaign_id),
@@ -244,6 +259,7 @@ def build_html_report(
         attack_log_html=attack_log_html,
         owasp_html=owasp_html,
         atlas_html=atlas_html,
+        defence_html_section=defence_html_section,
         vis_nodes_json=json.dumps(vis_data["nodes"]),
         vis_edges_json=json.dumps(vis_data["edges"]),
         critical_paths_json=json.dumps(paths),
@@ -425,6 +441,49 @@ def _build_owasp_html(
             f"<td>{desc}</td><td>{status}</td><td>{finding_text}</td></tr>"
         )
     parts.append("</table>")
+    return "\n".join(parts)
+
+
+def _build_defence_html(result_data: dict[str, Any]) -> str:
+    """Build the 'Declared Defences' section HTML for spec 012 US5.
+
+    Returns an empty string when no profile is declared or when the profile
+    has no defences — this keeps the rendered HTML byte-identical to
+    pre-spec-012 reports for the same target (FR-017 / SC-005).
+    """
+    profile = result_data.get("defence_profile")
+    if not profile:
+        return ""
+    defences = profile.get("defences") or []
+    if not defences:
+        return ""
+    evasion_rate = result_data.get("evasion_rate")
+
+    parts: list[str] = ['<table class="owasp-table">']
+    parts.append(
+        f'<caption style="caption-side:top;text-align:left;padding:6px 0;">'
+        f"<strong>Profile:</strong> {html.escape(profile.get('name', 'unknown'))}</caption>"
+    )
+    parts.append("<tr><th>Kind</th><th>Identifier</th><th>Evaluable</th></tr>")
+    for d in defences:
+        evaluable = "yes" if d.get("evaluable") else "no"
+        parts.append(
+            f"<tr><td>{html.escape(d.get('kind', ''))}</td>"
+            f"<td><code>{html.escape(d.get('identifier', ''))}</code></td>"
+            f"<td>{evaluable}</td></tr>"
+        )
+    parts.append("</table>")
+    if evasion_rate is not None:
+        parts.append(
+            f"<p><strong>Evasion rate:</strong> {evasion_rate:.1%} "
+            "(successful attacks that bypassed all evaluable defences).</p>"
+        )
+    else:
+        parts.append(
+            '<p class="muted"><strong>Evasion rate:</strong> not computable — '
+            "no declared defence is marked <code>evaluable: true</code> "
+            "in this release.</p>"
+        )
     return "\n".join(parts)
 
 
@@ -1106,6 +1165,8 @@ _HTML_TEMPLATE = """\
     <div class="section-title">MITRE ATLAS Coverage</div>
     {atlas_html}
   </div>
+
+  {defence_html_section}
 
   <!-- Attack Paths -->
   <div class="section">

--- a/ziran/interfaces/cli/main.py
+++ b/ziran/interfaces/cli/main.py
@@ -22,6 +22,7 @@ from ziran.application.agent_scanner.scanner import AgentScanner
 from ziran.application.attacks.library import AttackLibrary
 from ziran.application.factories import build_strategy, load_agent_adapter, load_remote_adapter
 from ziran.domain.entities.attack import AtlasTechnique, OwaspLlmCategory
+from ziran.domain.entities.defence import DefenceProfile
 from ziran.domain.entities.phase import CampaignResult, CoverageLevel, ScanPhase
 from ziran.infrastructure.logging.logger import setup_logging
 from ziran.infrastructure.storage.graph_storage import GraphStorage
@@ -243,6 +244,15 @@ def cli(ctx: click.Context, verbose: bool, log_file: str | None) -> None:
     help="Validate configuration and show attack plan without executing. "
     "Loads the adapter, discovers capabilities, and counts attack vectors.",
 )
+@click.option(
+    "--defence-profile",
+    type=click.Path(exists=True),
+    default=None,
+    help="Path to a YAML file declaring active defences on the target "
+    "(spec 012 US5). When declared, the campaign report carries a "
+    "'Declared Defences' section plus an evasion-rate metric (or "
+    "'not computable' when no declared defence is evaluable).",
+)
 def scan(
     framework: str | None,
     agent_path: str | None,
@@ -266,6 +276,7 @@ def scan(
     otel: bool,
     resume: bool,
     dry_run: bool,
+    defence_profile: str | None,
 ) -> None:
     """Run a security scan campaign against an AI agent.
 
@@ -481,6 +492,7 @@ def scan(
                 utility_tasks=loaded_utility_tasks,
                 checkpoint_manager=checkpoint_mgr,
                 resume_from_checkpoint=resume,
+                defence_profile=_load_defence_profile(defence_profile),
             )
         )
 
@@ -1461,6 +1473,16 @@ def _dry_run_summary(
     console.print(summary)
     console.print()
     console.print("[green]✓ Configuration valid.[/green] Run without --dry-run to start.")
+
+
+def _load_defence_profile(path: str | None) -> DefenceProfile | None:
+    """Load a DefenceProfile from a YAML file; return None if no path given."""
+    if path is None:
+        return None
+    import yaml as _yaml
+
+    raw = _yaml.safe_load(Path(path).read_text())
+    return DefenceProfile.model_validate(raw)
 
 
 def _display_results(result: CampaignResult) -> None:

--- a/ziran/interfaces/cli/reports.py
+++ b/ziran/interfaces/cli/reports.py
@@ -34,6 +34,25 @@ if TYPE_CHECKING:
     from ziran.domain.entities.phase import CampaignResult
 
 
+def _dump_campaign_result(result: CampaignResult) -> dict[str, Any]:
+    """Serialise a CampaignResult, stripping only the spec 012 US5 fields when unset.
+
+    Pydantic's ``exclude_none`` is recursive and would strip pre-existing
+    ``None`` fields on nested models (e.g. ``agent_response``), which would
+    break downstream consumers. We only drop the two fields introduced in
+    spec 012 US5 — ``defence_profile`` and ``evasion_rate`` — so that reports
+    for campaigns without a declared profile remain byte-identical to
+    pre-spec-012 output. Downstream signing (issue #259 asqav) depends on
+    this determinism (FR-020 / SC-005).
+    """
+    data = result.model_dump(mode="json")
+    if data.get("defence_profile") is None:
+        data.pop("defence_profile", None)
+    if data.get("evasion_rate") is None:
+        data.pop("evasion_rate", None)
+    return data
+
+
 class ReportGenerator:
     """Generates reports from campaign results.
 
@@ -67,7 +86,7 @@ class ReportGenerator:
             Path to the saved JSON file.
         """
         filepath = self.output_dir / f"{result.campaign_id}_report.json"
-        data = result.model_dump(mode="json")
+        data = _dump_campaign_result(result)
 
         with filepath.open("w") as f:
             json.dump(data, f, indent=2, default=str)
@@ -122,7 +141,7 @@ class ReportGenerator:
             if graph_state is None:
                 graph_state = {"nodes": [], "edges": [], "stats": {}}
 
-        result_data = result.model_dump(mode="json")
+        result_data = _dump_campaign_result(result)
         html_content = build_html_report(
             result_data=result_data,
             graph_state=graph_state,
@@ -300,6 +319,33 @@ class ReportGenerator:
                     )
             lines.append("")
             lines.append("_🎯 = AI-agent-specific ATLAS technique (October 2025 release)._")
+            lines.append("")
+
+        # Declared Defences + evasion rate (spec 012 US5).
+        # When no profile is declared, this section is omitted entirely so
+        # the report is byte-identical to pre-spec-012 reports for the same
+        # target (FR-017 / SC-005).
+        if result.defence_profile and not result.defence_profile.is_empty:
+            lines.append("## Declared Defences")
+            lines.append("")
+            lines.append(f"**Profile:** `{result.defence_profile.name}`")
+            lines.append("")
+            lines.append("| Kind | Identifier | Evaluable |")
+            lines.append("|------|------------|-----------|")
+            for d in result.defence_profile.defences:
+                evaluable = "yes" if d.evaluable else "no"
+                lines.append(f"| {d.kind} | `{d.identifier}` | {evaluable} |")
+            lines.append("")
+            if result.evasion_rate is not None:
+                lines.append(
+                    f"**Evasion rate:** {result.evasion_rate:.1%} "
+                    "(successful attacks that bypassed all evaluable defences)"
+                )
+            else:
+                lines.append(
+                    "**Evasion rate:** not computable — no declared defence "
+                    "is marked `evaluable: true` in this release."
+                )
             lines.append("")
 
         # Business Impact Summary (successful findings only)


### PR DESCRIPTION
## Summary

**PR #4 of 5** for spec [`012-benchmark-maturity`](specs/012-benchmark-maturity/spec.md). Ships US5 — defence-profile schema, evasion-rate metric, CLI wiring, and report-surface plumbing. **Closes [#45](https://github.com/taoq-ai/ziran/issues/45)**.

## Scope

Config schema + metric field + report surface — wired end-to-end. Evaluator adapters (NeMo Guardrails, Lakera Guard, etc.) are **deliberately out of scope** for this release. Every `DefenceDeclaration` defaults to `evaluable=False`, so reports carry declared defences but surface "not computable" for the evasion rate. Future releases light up per-product evaluators without schema change.

## What shipped

### Domain
- `ziran/domain/entities/defence.py` — `DefenceDeclaration` (kind / identifier / evaluable) and `DefenceProfile` (name + list), with `is_empty` and `evaluable_defences` helpers.
- `CampaignResult` extended with optional `defence_profile` and `evasion_rate` fields.

### Application
- `ziran/application/campaign/evasion.py::compute_evasion_rate` — the four documented cases (None profile / empty profile / no evaluable defences → `None`; otherwise ratio of successful attacks that bypassed every evaluable defence).
- Scanner + ResultBuilder thread `defence_profile` through and call the metric at finalisation.

### CLI
- `ziran scan --defence-profile <path>` — loads a YAML file into `DefenceProfile`; absent flag = unchanged behaviour.

### Reports
- **Markdown**: conditional "Declared Defences" section (profile name, per-defence table, evasion-rate line). Omitted when no profile → byte-identical to pre-spec-012 output.
- **HTML**: mirror structure with a conditional section wrapper.
- **JSON**: targeted exclusion of just `defence_profile` / `evasion_rate` when `None` (not a recursive `exclude_none` — preserves existing `None`-valued fields like `agent_response`).

### Tests
- **Unit** (`test_defence_profile.py` + `test_evasion_metric.py`) — 20 tests: Pydantic validation, literal kind, default evaluable, round-trip; all 4 `None`-case branches + 3 populated-bypass-map cases + multi-defence AND logic.
- **Integration** (`test_campaign_defence_profile.py`) — 6 tests: JSON + MD with/without profile, empty-profile treatment, byte-identity guarantee.

### Examples
- `examples/09-defence-profile/profile.yaml` — schema example.

## Byte-identity guarantee

**FR-017 / SC-005** — a campaign without `--defence-profile` produces JSON/MD reports byte-identical to pre-spec-012 output for the same campaign data. Verified by `test_json_report_omits_defence_fields` and `test_markdown_report_has_no_declared_defences_section`.

## Test plan

- [x] 25 new tests pass (`pytest tests/unit/test_defence_profile.py tests/unit/test_evasion_metric.py tests/integration/test_campaign_defence_profile.py`)
- [x] 1990 total tests pass (was 1965; +25)
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `mypy ziran/` clean (only pre-existing unrelated `ws_handler.py:30`)
- [ ] Await CI green

Closes #45