### PR TITLE
docs(readme): animated SVGs for hero, star CTA, and key differentiators

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,84 +339,19 @@ See [examples/15-remote-agent-scan/](examples/15-remote-agent-scan/) for ready-t
 
 ## How It Works
 
-```mermaid
-flowchart LR
-    subgraph agent["🤖 Your Agent"]
-        direction TB
-        T["🔧 Tools"]
-        M["🧠 Memory"]
-        P["🔑 Permissions"]
-    end
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/pipeline-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="docs/assets/pipeline-light.svg">
+    <img src="docs/assets/pipeline-light.svg" alt="ZIRAN pipeline diagram: your agent (with tools, memory, and permissions) connects through an adapter layer into the ZIRAN pipeline — DISCOVER probes capabilities, MAP builds a NetworkX MultiDiGraph, ANALYZE walks the graph for dangerous chains across 30+ patterns, ATTACK runs multi-phase exploits informed by the graph, and REPORT emits scored findings. Outputs land in three formats: HTML interactive graph, Markdown CI/CD tables, and JSON for programmatic consumption." width="100%"/>
+  </picture>
+</p>
 
-    agent -->|"adapter layer"| D
+Five sequential stages: **DISCOVER** probes tools, permissions, and data access; **MAP** builds a NetworkX MultiDiGraph of capabilities; **ANALYZE** walks the graph against 30+ dangerous-chain patterns; **ATTACK** runs multi-phase exploits informed by the graph; **REPORT** emits scored findings with remediation guidance.
 
-    subgraph ziran["⛩️ ZIRAN Pipeline"]
-        direction TB
-        D["🔍 DISCOVER\nProbe tools, permissions,\ndata access"]
-        MAP["🗺️ MAP\nBuild knowledge graph\n(NetworkX MultiDiGraph)"]
-        A["⚡ ANALYZE\nWalk graph for dangerous\nchains (30+ patterns)"]
-        ATK["🎯 ATTACK\nMulti-phase exploits\ninformed by the graph"]
-        R["📋 REPORT\nScored findings with\nremediation guidance"]
-        D --> MAP --> A --> ATK --> R
-    end
+### Campaign phases
 
-    R --> HTML["📊 HTML\nInteractive graph"]
-    R --> MD["📝 Markdown\nCI/CD tables"]
-    R --> JSON["📦 JSON\nMachine-parseable"]
-
-    style agent fill:#1a1a2e,stroke:#e94560,color:#fff,stroke-width:2px
-    style ziran fill:#0f3460,stroke:#e94560,color:#fff,stroke-width:2px
-    style D fill:#16213e,stroke:#0ea5e9,color:#fff
-    style MAP fill:#16213e,stroke:#0ea5e9,color:#fff
-    style A fill:#16213e,stroke:#0ea5e9,color:#fff
-    style ATK fill:#16213e,stroke:#e94560,color:#fff
-    style R fill:#16213e,stroke:#10b981,color:#fff
-    style HTML fill:#1e293b,stroke:#10b981,color:#fff
-    style MD fill:#1e293b,stroke:#10b981,color:#fff
-    style JSON fill:#1e293b,stroke:#10b981,color:#fff
-    style T fill:#2d2d44,stroke:#e94560,color:#fff
-    style M fill:#2d2d44,stroke:#e94560,color:#fff
-    style P fill:#2d2d44,stroke:#e94560,color:#fff
-```
-
-### Campaign Phases
-
-Campaigns run 8 phases: reconnaissance, trust building, capability mapping, vulnerability discovery, exploitation setup, execution, persistence, and exfiltration. Each phase feeds its findings into a live knowledge graph, and the graph informs which phase to run next.
-
-Phases are **not linear** -- the knowledge graph drives execution order. A discovery in the exploitation phase may trigger a return to reconnaissance. An agent that reveals new tools during trust building causes capability mapping to re-run with updated context.
-
-```mermaid
-flowchart TD
-    KG["🧠 Knowledge Graph\n(live state)"]
-
-    R["🔍 Reconnaissance"] --> KG
-    TB["🤝 Trust Building"] --> KG
-    CM["🗺️ Capability Mapping"] --> KG
-    VD["⚡ Vulnerability Discovery"] --> KG
-    ES["🎯 Exploitation Setup"] --> KG
-    EX["💥 Execution"] --> KG
-    PE["🔒 Persistence"] --> KG
-    EXF["📤 Exfiltration"] --> KG
-
-    KG -->|"decides next phase"| R
-    KG -->|"decides next phase"| TB
-    KG -->|"decides next phase"| CM
-    KG -->|"decides next phase"| VD
-    KG -->|"decides next phase"| ES
-    KG -->|"decides next phase"| EX
-    KG -->|"decides next phase"| PE
-    KG -->|"decides next phase"| EXF
-
-    style KG fill:#1a1a2e,stroke:#e94560,color:#fff,stroke-width:2px
-    style R fill:#16213e,stroke:#0ea5e9,color:#fff
-    style TB fill:#16213e,stroke:#0ea5e9,color:#fff
-    style CM fill:#16213e,stroke:#0ea5e9,color:#fff
-    style VD fill:#16213e,stroke:#0ea5e9,color:#fff
-    style ES fill:#16213e,stroke:#e94560,color:#fff
-    style EX fill:#16213e,stroke:#e94560,color:#fff
-    style PE fill:#16213e,stroke:#e94560,color:#fff
-    style EXF fill:#16213e,stroke:#e94560,color:#fff
-```
+The ATTACK stage runs an 8-phase campaign — reconnaissance, trust building, capability mapping, vulnerability discovery, exploitation setup, execution, persistence, exfiltration. Phases are **not linear**: the live knowledge graph drives execution order, so a discovery during exploitation may trigger a return to reconnaissance, and revealed tools cause capability mapping to re-run with updated context. (See [Adaptive 8-phase campaigns](#adaptive-8-phase-campaigns--the-graph-drives-the-next-move) above for an animated walk-through, including how Trust Building and Persistence are skipped when graph state makes them irrelevant.)
 
 Three strategies control this:
 
@@ -436,9 +371,13 @@ Three output formats, generated automatically:
 - **Markdown** -- CI/CD-friendly summary tables
 - **JSON** -- Machine-parseable for programmatic consumption
 
-<div align="center">
-  <img src="docs/assets/report.png" alt="ZIRAN HTML Report" width="800">
-</div>
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/report-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="docs/assets/report-light.svg">
+    <img src="docs/assets/report-light.svg" alt="Mock-up of a ZIRAN HTML campaign report — header with target metadata, severity counters (3 critical, 7 high, 12 medium, 28 low), a findings table listing the top tool-chain vulnerabilities (data exfiltration, SQL-to-RCE, PII leakage, prompt injection, multi-agent trust boundary), and a live knowledge graph with the critical attack paths highlighted." width="100%"/>
+  </picture>
+</p>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,30 @@
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/hero-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="docs/assets/hero-light.svg">
+    <img src="docs/assets/hero-light.svg" alt="ZIRAN: your AI agent — with tools, memory, and permissions — flows through the ZIRAN pipeline (discover, map, analyze, attack, report) and out into a ranked list of findings. The top finding 'read_file → http_request' is highlighted as a critical data-exfiltration tool chain. Keywords: AI agent security, agent red team, tool chain analysis, knowledge graph, MCP, A2A, LangChain, CrewAI, prompt injection, side-effect detection, multi-phase campaigns." width="100%" draggable="false"/>
+  </picture>
+</p>
+
+<h1 align="center">Find vulnerabilities in your <em>AI agents.</em></h1>
+
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/taoq-ai/ziran" title="Star ZIRAN on GitHub — open-source agent security testing framework"><picture><source media="(prefers-color-scheme: dark)" srcset="docs/assets/star-btn-dark.svg"><source media="(prefers-color-scheme: light)" srcset="docs/assets/star-btn-light.svg"><img src="docs/assets/star-btn-light.svg" alt="Star ZIRAN on GitHub — open-source AI agent security scanner with tool chain discovery, side-effect detection, and adaptive multi-phase campaigns" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://taoq-ai.github.io/ziran/"><b>📚 Docs</b></a> &nbsp;·&nbsp;
+  <a href="examples/"><b>🧪 Examples</b></a> &nbsp;·&nbsp;
+  <a href="https://pypi.org/project/ziran/"><b>📦 PyPI</b></a> &nbsp;·&nbsp;
+  <a href="https://github.com/taoq-ai/ziran/issues"><b>🐛 Issues</b></a>
+</p>
+
+<p align="center">
+  ZIRAN finds vulnerabilities in AI agents — not just LLMs, but agents with tools, memory, and multi-step reasoning. It models your agent as a graph of capabilities and tests what happens when they combine — surfacing dangerous tool chains, execution-level side effects, and multi-phase exploits that single-prompt scanners miss.
+</p>
+
+<p align="center">
+  <b>Graph-based</b> · tool-chain discovery &nbsp;·&nbsp; <b>Execution-aware</b> · side-effect detection &nbsp;·&nbsp; <b>Adaptive</b> · 8-phase campaigns
+</p>
+
 <div align="center">
-
-# ZIRAN 🧘
-
-### AI Agent Security Testing
 
 [![CI](https://github.com/taoq-ai/ziran/actions/workflows/ci.yml/badge.svg)](https://github.com/taoq-ai/ziran/actions/workflows/ci.yml)
 [![Tests](https://github.com/taoq-ai/ziran/actions/workflows/test.yml/badge.svg)](https://github.com/taoq-ai/ziran/actions/workflows/test.yml)
@@ -10,14 +32,21 @@
 [![Downloads](https://img.shields.io/pypi/dm/ziran.svg)](https://pypistats.org/packages/ziran)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
-
-**Find vulnerabilities in AI agents -- not just LLMs, but agents with tools, memory, and multi-step reasoning.**
-
-![ZIRAN Dashboard](docs/assets/ui-dashboard.png)
-
-[Install](#install) · [Quick Start](#quick-start) · [Web UI](#web-ui) · [Examples](examples/) · [Docs](https://taoq-ai.github.io/ziran/)
+[![Stars](https://img.shields.io/github/stars/taoq-ai/ziran?style=flat&label=stars&color=fbbf24)](https://github.com/taoq-ai/ziran)
 
 </div>
+
+<p align="center">
+  <a href="#install"><b>Install</b></a> &nbsp;·&nbsp;
+  <a href="#quick-start"><b>Quick Start</b></a> &nbsp;·&nbsp;
+  <a href="#web-ui"><b>Web UI</b></a> &nbsp;·&nbsp;
+  <a href="examples/"><b>Examples</b></a> &nbsp;·&nbsp;
+  <a href="https://taoq-ai.github.io/ziran/"><b>Docs</b></a>
+</p>
+
+<p align="center">
+  <img src="docs/assets/ui-dashboard.png" alt="ZIRAN Dashboard — web UI showing campaign results, attack library, and knowledge graph" width="100%"/>
+</p>
 
 ---
 
@@ -67,10 +96,44 @@ ZIRAN models your agent as a graph of capabilities and tests what happens when t
 
 **What these capabilities catch:**
 
-- **Tool Chain Discovery** -- Individual tools pass security review, but their compositions create vulnerabilities. Graph-based analysis finds transitive attack paths (e.g., `read_file` -> `http_request` = data exfiltration) that list-based testing misses.
-- **Side-Effect Detection** -- Agents can refuse a request in their text response while still executing the dangerous tool call. Without execution-level monitoring, these silent failures go undetected.
-- **Multi-Phase Campaigns** -- Real attackers don't send a single malicious prompt. They build trust, map capabilities, then exploit. Multi-phase campaigns model this behavior to find vulnerabilities that single-turn tests miss.
-- **Knowledge Graph** -- A live graph of discovered tools, permissions, and data flows grows as the scan progresses. Each phase uses it to plan the next, catching vulnerabilities that only appear after building enough context about the agent.
+### Tool-chain discovery — graph beats list
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/toolchain-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="docs/assets/toolchain-light.svg">
+    <img src="docs/assets/toolchain-light.svg" alt="Side-by-side comparison: a list-based scanner sees four individually-safe tools (read_file, http_request, sql_query, exec_code) and reports no findings, while ZIRAN walks the capability graph and surfaces dangerous transitive compositions — read_file→http_request as critical data exfiltration, sql_query→exec_code as high-severity SQL-to-RCE." width="100%"/>
+  </picture>
+</p>
+
+Individual tools pass security review in isolation, but their compositions create vulnerabilities. Graph-based analysis finds transitive attack paths — `read_file → http_request` for data exfiltration, `sql_query → exec_code` for SQL-to-RCE — that list-based testing misses entirely.
+
+### Side-effect detection — chat is not the truth
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/sideeffect-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="docs/assets/sideeffect-light.svg">
+    <img src="docs/assets/sideeffect-light.svg" alt="Two stacked layers: on the surface, the agent replies 'I can't do that — request refused' to 'Delete user 42' and a chat-only scanner marks it safe; on the execution layer below, ZIRAN intercepts the actual tool call delete_user(id=42) firing silently and flags it as critical." width="100%"/>
+  </picture>
+</p>
+
+Agents can refuse a request in their text response while still executing the dangerous tool call underneath. ZIRAN intercepts at the execution layer and flags these silent failures — chat-only scanners mark them as safe.
+
+### Adaptive 8-phase campaigns — the graph drives the next move
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/adaptive-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="docs/assets/adaptive-light.svg">
+    <img src="docs/assets/adaptive-light.svg" alt="A live knowledge graph grows phase by phase: Reconnaissance discovers 3 capabilities, Capability Map adds 3 tools, Vulnerability Discovery surfaces a critical read_file→http_request chain, Exploit Setup attaches an attack node. Trust Building is skipped (no auth surface) and Persistence is skipped (ephemeral target) because the graph state makes them irrelevant. The right panel narrates how each new graph state picks the next phase." width="100%"/>
+  </picture>
+</p>
+
+A live knowledge graph grows as the scan progresses, and the graph picks the next phase — not a fixed sequence. A critical chain found mid-campaign immediately routes to Exploit Setup, while phases like Trust Building or Persistence are skipped when graph state shows they would not yield results. Three strategies control this: `fixed` (sequential, reproducible for CI), `adaptive` (rule-based reordering), and `llm-adaptive` (LLM examines the graph after each phase to plan).
+
+### And…
+
 - **Multi-Agent Coordination** -- In multi-agent systems, an agent may trust messages from peers without validation. Testing cross-agent trust boundaries reveals lateral movement paths.
 - **A2A + MCP Protocols** -- Tests [Agent-to-Agent](https://google.github.io/A2A/) and [MCP](https://modelcontextprotocol.io/) agents through their native protocols, exercising the actual attack surface rather than a simplified proxy.
 - **Framework Agnostic** -- LangChain, CrewAI, Bedrock, MCP, browser UIs, remote HTTPS agents, or [custom adapters](examples/08-custom-adapter/).

--- a/docs/assets/adaptive-dark.svg
+++ b/docs/assets/adaptive-dark.svg
@@ -1,0 +1,268 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 380" role="img" aria-labelledby="ad-title ad-desc" preserveAspectRatio="xMidYMid meet">
+  <title id="ad-title">ZIRAN adaptive campaign: knowledge graph drives next phase</title>
+  <desc id="ad-desc">A live demonstration of ZIRAN's 8-phase campaign. Center: a knowledge graph that grows phase by phase. Reconnaissance discovers 3 capabilities (tools, memory, permissions). Capability Mapping reveals 3 individual tools (read_file, http_request, sql_query). Vulnerability Discovery surfaces a critical edge — read_file → http_request — labelled "data_exfil". Exploit Setup attaches an attack plan to that edge. Execute fires it. The right panel shows how each new graph state picks the next phase: Trust Building is skipped (no auth surface), and Persistence is skipped (ephemeral target). Two of the eight phases are bypassed entirely because the graph state makes them irrelevant. Keywords: adaptive campaign, live knowledge graph, non-linear pipeline, agent red team, multi-phase exploitation, ZIRAN, capability discovery, dangerous tool chain.</desc>
+
+  <rect width="1200" height="380" fill="#0f172a" rx="16"/>
+  <rect x="0.5" y="0.5" width="1199" height="379" fill="none" stroke="#1e293b" rx="16"/>
+
+  <text x="600" y="34" text-anchor="middle" fill="#64748b" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" letter-spacing="3">ADAPTIVE 8-PHASE CAMPAIGN  ·  GRAPH-DRIVEN</text>
+
+  <!-- ============================================ -->
+  <!-- LEFT PANEL: CURRENT PHASE                     -->
+  <!-- ============================================ -->
+  <g transform="translate(40, 60)" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif">
+    <rect width="200" height="300" rx="14" fill="#1e293b" stroke="#334155"/>
+    <text x="100" y="26" text-anchor="middle" fill="#94a3b8" font-size="10" font-weight="600" letter-spacing="2">RUNNING</text>
+
+    <g text-anchor="middle">
+      <!-- Recon (T 0.00-0.15) -->
+      <g opacity="0">
+        <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.005;0.149;0.155" dur="10s" repeatCount="indefinite"/>
+        <text x="100" y="116" font-size="40">🔍</text>
+        <text x="100" y="160" fill="#0ea5e9" font-size="15" font-weight="700">Reconnaissance</text>
+        <text x="100" y="184" fill="#94a3b8" font-size="11">probe agent surface</text>
+      </g>
+
+      <!-- Capability Map (T 0.15-0.30) -->
+      <g opacity="0">
+        <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.149;0.155;0.299;0.305" dur="10s" repeatCount="indefinite"/>
+        <text x="100" y="116" font-size="40">🗺️</text>
+        <text x="100" y="160" fill="#0ea5e9" font-size="15" font-weight="700">Capability Map</text>
+        <text x="100" y="184" fill="#94a3b8" font-size="11">enumerate tools</text>
+      </g>
+
+      <!-- Vuln Disc (T 0.30-0.45) -->
+      <g opacity="0">
+        <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.299;0.305;0.449;0.455" dur="10s" repeatCount="indefinite"/>
+        <text x="100" y="116" font-size="40">⚡</text>
+        <text x="100" y="160" fill="#0ea5e9" font-size="15" font-weight="700">Vuln Discovery</text>
+        <text x="100" y="184" fill="#94a3b8" font-size="11">walk for chains</text>
+      </g>
+
+      <!-- Exploit (T 0.45-0.60) -->
+      <g opacity="0">
+        <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.449;0.455;0.599;0.605" dur="10s" repeatCount="indefinite"/>
+        <text x="100" y="116" font-size="40">🎯</text>
+        <text x="100" y="160" fill="#e94560" font-size="15" font-weight="700">Exploit Setup</text>
+        <text x="100" y="184" fill="#94a3b8" font-size="11">prime the chain</text>
+      </g>
+
+      <!-- Execute (T 0.60-0.75) -->
+      <g opacity="0">
+        <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.599;0.605;0.749;0.755" dur="10s" repeatCount="indefinite"/>
+        <text x="100" y="116" font-size="40">💥</text>
+        <text x="100" y="160" fill="#e94560" font-size="15" font-weight="700">Execute</text>
+        <text x="100" y="184" fill="#94a3b8" font-size="11">fire exploit</text>
+      </g>
+
+      <!-- Exfiltrate (T 0.75-0.90) -->
+      <g opacity="0">
+        <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.749;0.755;0.899;0.905" dur="10s" repeatCount="indefinite"/>
+        <text x="100" y="116" font-size="40">📤</text>
+        <text x="100" y="160" fill="#e94560" font-size="15" font-weight="700">Exfiltrate</text>
+        <text x="100" y="184" fill="#94a3b8" font-size="11">extract findings</text>
+      </g>
+
+      <!-- Done (T 0.90-1.00) -->
+      <g opacity="0">
+        <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.899;0.905;1" dur="10s" repeatCount="indefinite"/>
+        <text x="100" y="116" font-size="40">✓</text>
+        <text x="100" y="160" fill="#10b981" font-size="15" font-weight="700">Complete</text>
+        <text x="100" y="184" fill="#94a3b8" font-size="11">1 critical · 0 high</text>
+      </g>
+    </g>
+
+    <text x="100" y="270" text-anchor="middle" fill="#fbbf24" font-size="10" font-style="italic">graph-driven · non-linear</text>
+  </g>
+
+  <!-- ============================================ -->
+  <!-- CENTER: LIVE KNOWLEDGE GRAPH                  -->
+  <!-- ============================================ -->
+  <g transform="translate(260, 60)" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif">
+    <rect width="660" height="300" rx="14" fill="#1e293b" stroke="#fbbf24" stroke-width="1.5"/>
+    <text x="330" y="26" text-anchor="middle" fill="#fbbf24" font-size="11" font-weight="600" letter-spacing="2">LIVE KNOWLEDGE GRAPH</text>
+
+    <!-- ===== Agent root (always visible after T=0.02) ===== -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.02;0.99;1" dur="10s" repeatCount="indefinite"/>
+      <circle cx="330" cy="78" r="28" fill="#0f172a" stroke="#0ea5e9" stroke-width="2"/>
+      <text x="330" y="83" text-anchor="middle" fill="#0ea5e9" font-family="ui-monospace, SFMono-Regular, monospace" font-size="11" font-weight="700">agent</text>
+    </g>
+
+    <!-- ===== Capability layer (T=0.15): tools, memory, perms ===== -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.149;0.16;0.99;1" dur="10s" repeatCount="indefinite"/>
+      <!-- edges from agent -->
+      <line x1="312" y1="100" x2="180" y2="135" stroke="#475569" stroke-width="1.5"/>
+      <line x1="330" y1="106" x2="330" y2="133" stroke="#475569" stroke-width="1.5"/>
+      <line x1="348" y1="100" x2="480" y2="135" stroke="#475569" stroke-width="1.5"/>
+      <!-- nodes -->
+      <circle cx="180" cy="148" r="22" fill="#0f172a" stroke="#0ea5e9" stroke-width="1.5"/>
+      <text x="180" y="152" text-anchor="middle" fill="#cbd5e1" font-size="10">tools</text>
+      <circle cx="330" cy="148" r="22" fill="#0f172a" stroke="#0ea5e9" stroke-width="1.5"/>
+      <text x="330" y="152" text-anchor="middle" fill="#cbd5e1" font-size="10">memory</text>
+      <circle cx="480" cy="148" r="22" fill="#0f172a" stroke="#0ea5e9" stroke-width="1.5"/>
+      <text x="480" y="152" text-anchor="middle" fill="#cbd5e1" font-size="10">perms</text>
+      <!-- "+ 3 nodes" pulse -->
+      <text x="580" y="148" fill="#10b981" font-size="11" font-weight="600" opacity="0">
+        <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.155;0.20;0.22;1" dur="10s" repeatCount="indefinite"/>+3</text>
+    </g>
+
+    <!-- ===== Tool layer (T=0.30): read_file, http_req, sql_query under "tools" ===== -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.299;0.31;0.99;1" dur="10s" repeatCount="indefinite"/>
+      <!-- edges from "tools" (180, 148) -->
+      <line x1="170" y1="168" x2="100" y2="208" stroke="#475569" stroke-width="1.5"/>
+      <line x1="180" y1="170" x2="190" y2="208" stroke="#475569" stroke-width="1.5"/>
+      <line x1="195" y1="166" x2="280" y2="208" stroke="#475569" stroke-width="1.5"/>
+      <!-- nodes -->
+      <circle cx="100" cy="222" r="22" fill="#0f172a" stroke="#94a3b8" stroke-width="1.5"/>
+      <text x="100" y="226" text-anchor="middle" fill="#cbd5e1" font-family="ui-monospace, SFMono-Regular, monospace" font-size="9">read_file</text>
+      <circle cx="190" cy="222" r="22" fill="#0f172a" stroke="#94a3b8" stroke-width="1.5"/>
+      <text x="190" y="226" text-anchor="middle" fill="#cbd5e1" font-family="ui-monospace, SFMono-Regular, monospace" font-size="9">http_req</text>
+      <circle cx="280" cy="222" r="22" fill="#0f172a" stroke="#94a3b8" stroke-width="1.5"/>
+      <text x="280" y="226" text-anchor="middle" fill="#cbd5e1" font-family="ui-monospace, SFMono-Regular, monospace" font-size="9">sql_query</text>
+      <!-- "+ 3 nodes" pulse -->
+      <text x="360" y="226" fill="#10b981" font-size="11" font-weight="600" opacity="0">
+        <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.305;0.35;0.37;1" dur="10s" repeatCount="indefinite"/>+3</text>
+    </g>
+
+    <!-- ===== Critical chain edge (T=0.45): read_file → http_req ===== -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.449;0.46;0.99;1" dur="10s" repeatCount="indefinite"/>
+      <!-- the red edge with arrow head, sitting above the existing grey edge -->
+      <line x1="122" y1="222" x2="166" y2="222" stroke="#e94560" stroke-width="3"/>
+      <polygon points="170,222 162,218 162,226" fill="#e94560"/>
+      <!-- exfil packet oscillating along the edge -->
+      <circle cy="222" r="4" fill="#e94560">
+        <animate attributeName="cx" values="122;166;122" dur="1.6s" repeatCount="indefinite"/>
+      </circle>
+      <!-- chain label -->
+      <rect x="100" y="252" width="90" height="20" rx="4" fill="#7f1d1d" stroke="#e94560"/>
+      <text x="145" y="266" text-anchor="middle" fill="#fff" font-size="9" font-weight="700">⚠ data_exfil</text>
+      <!-- "critical detected" pulse -->
+      <text x="220" y="266" fill="#e94560" font-size="11" font-weight="700" opacity="0">
+        <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.455;0.51;0.53;1" dur="10s" repeatCount="indefinite"/>+1 critical</text>
+    </g>
+
+    <!-- ===== Attack node (T=0.60): connects to the red edge ===== -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.599;0.61;0.99;1" dur="10s" repeatCount="indefinite"/>
+      <!-- arc from attack box up to red edge midpoint (145, 222) -->
+      <path d="M 145 282 L 145 252" stroke="#e94560" stroke-width="1.5" fill="none" stroke-dasharray="3 3"/>
+      <!-- attack badge -->
+      <rect x="105" y="280" width="80" height="22" rx="4" fill="#450a0a" stroke="#e94560" stroke-width="1.5"/>
+      <text x="145" y="295" text-anchor="middle" fill="#fecaca" font-size="11" font-weight="700">🎯 exploit</text>
+    </g>
+
+    <!-- ===== "1 CRITICAL" hero badge (T=0.75) ===== -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.749;0.755;0.99;1" dur="10s" repeatCount="indefinite"/>
+      <rect x="430" y="230" width="200" height="56" rx="10" fill="#e94560"/>
+      <text x="530" y="256" text-anchor="middle" fill="#fff" font-size="18" font-weight="800">⚠ 1 CRITICAL</text>
+      <text x="530" y="276" text-anchor="middle" fill="#fff" font-family="ui-monospace, SFMono-Regular, monospace" font-size="10">read_file → http_request</text>
+    </g>
+
+    <!-- ===== "2 phases skipped" tag, visible from T=0.90 ===== -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.899;0.905;1" dur="10s" repeatCount="indefinite"/>
+      <rect x="430" y="60" width="200" height="22" rx="11" fill="#0f172a" stroke="#10b981"/>
+      <text x="530" y="75" text-anchor="middle" fill="#10b981" font-size="10" font-weight="700">2 phases skipped by graph state</text>
+    </g>
+  </g>
+
+  <!-- ============================================ -->
+  <!-- RIGHT PANEL: GRAPH STATE → NEXT PHASE         -->
+  <!-- ============================================ -->
+  <g transform="translate(940, 60)" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif">
+    <rect width="220" height="300" rx="14" fill="#1e293b" stroke="#334155"/>
+    <text x="110" y="26" text-anchor="middle" fill="#94a3b8" font-size="10" font-weight="600" letter-spacing="2">GRAPH STATE  →  NEXT</text>
+
+    <!-- starting (0.00-0.15) -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.005;0.149;0.155" dur="10s" repeatCount="indefinite"/>
+      <text x="20" y="64" fill="#94a3b8" font-size="11">graph state:</text>
+      <text x="20" y="86" fill="#cbd5e1" font-size="11">• agent only</text>
+      <line x1="20" y1="120" x2="200" y2="120" stroke="#334155"/>
+      <text x="20" y="148" fill="#fbbf24" font-size="10" font-weight="700" letter-spacing="1">→ NEXT</text>
+      <text x="20" y="172" fill="#f1f5f9" font-size="14" font-weight="600">Reconnaissance</text>
+      <text x="20" y="194" fill="#94a3b8" font-size="10">map agent surface</text>
+    </g>
+
+    <!-- after recon (0.15-0.30) — Trust Build skipped -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.149;0.155;0.299;0.305" dur="10s" repeatCount="indefinite"/>
+      <text x="20" y="64" fill="#94a3b8" font-size="11">graph state:</text>
+      <text x="20" y="84" fill="#cbd5e1" font-size="11">• 3 capabilities</text>
+      <text x="20" y="102" fill="#94a3b8" font-size="11">• no auth surface</text>
+      <line x1="20" y1="118" x2="200" y2="118" stroke="#334155"/>
+      <text x="20" y="138" fill="#64748b" font-size="9" font-style="italic">↳ skip Trust Building</text>
+      <text x="20" y="160" fill="#fbbf24" font-size="10" font-weight="700" letter-spacing="1">→ NEXT</text>
+      <text x="20" y="182" fill="#f1f5f9" font-size="14" font-weight="600">Capability Map</text>
+      <text x="20" y="204" fill="#94a3b8" font-size="10">enumerate tools</text>
+    </g>
+
+    <!-- after cap map (0.30-0.45) -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.299;0.305;0.449;0.455" dur="10s" repeatCount="indefinite"/>
+      <text x="20" y="64" fill="#94a3b8" font-size="11">graph state:</text>
+      <text x="20" y="84" fill="#cbd5e1" font-size="11">• 3 tools mapped</text>
+      <text x="20" y="102" fill="#cbd5e1" font-size="11">• capability matrix</text>
+      <line x1="20" y1="120" x2="200" y2="120" stroke="#334155"/>
+      <text x="20" y="148" fill="#fbbf24" font-size="10" font-weight="700" letter-spacing="1">→ NEXT</text>
+      <text x="20" y="172" fill="#f1f5f9" font-size="14" font-weight="600">Vuln Discovery</text>
+      <text x="20" y="194" fill="#94a3b8" font-size="10">walk for chains</text>
+    </g>
+
+    <!-- after vuln disc (0.45-0.60) — critical chain found -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.449;0.455;0.599;0.605" dur="10s" repeatCount="indefinite"/>
+      <text x="20" y="64" fill="#94a3b8" font-size="11">graph state:</text>
+      <text x="20" y="84" fill="#fca5a5" font-size="11" font-weight="700">⚠ critical chain</text>
+      <text x="20" y="102" fill="#fca5a5" font-family="ui-monospace, SFMono-Regular, monospace" font-size="10">read_file→http_req</text>
+      <line x1="20" y1="120" x2="200" y2="120" stroke="#334155"/>
+      <text x="20" y="148" fill="#e94560" font-size="10" font-weight="700" letter-spacing="1">→ NEXT</text>
+      <text x="20" y="172" fill="#f1f5f9" font-size="14" font-weight="600">Exploit Setup</text>
+      <text x="20" y="194" fill="#94a3b8" font-size="10">prime the chain</text>
+    </g>
+
+    <!-- after exploit (0.60-0.75) -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.599;0.605;0.749;0.755" dur="10s" repeatCount="indefinite"/>
+      <text x="20" y="64" fill="#94a3b8" font-size="11">graph state:</text>
+      <text x="20" y="84" fill="#fca5a5" font-size="11">• exploit primed</text>
+      <text x="20" y="102" fill="#fca5a5" font-size="11">• ready to fire</text>
+      <line x1="20" y1="120" x2="200" y2="120" stroke="#334155"/>
+      <text x="20" y="148" fill="#e94560" font-size="10" font-weight="700" letter-spacing="1">→ NEXT</text>
+      <text x="20" y="172" fill="#f1f5f9" font-size="14" font-weight="600">Execute</text>
+      <text x="20" y="194" fill="#94a3b8" font-size="10">fire the exploit</text>
+    </g>
+
+    <!-- after execute (0.75-0.90) — Persistence skipped -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.749;0.755;0.899;0.905" dur="10s" repeatCount="indefinite"/>
+      <text x="20" y="64" fill="#94a3b8" font-size="11">graph state:</text>
+      <text x="20" y="84" fill="#fca5a5" font-size="11">• 1 critical fired</text>
+      <text x="20" y="102" fill="#94a3b8" font-size="11">• ephemeral target</text>
+      <line x1="20" y1="118" x2="200" y2="118" stroke="#334155"/>
+      <text x="20" y="138" fill="#64748b" font-size="9" font-style="italic">↳ skip Persistence</text>
+      <text x="20" y="160" fill="#e94560" font-size="10" font-weight="700" letter-spacing="1">→ NEXT</text>
+      <text x="20" y="182" fill="#f1f5f9" font-size="14" font-weight="600">Exfiltrate</text>
+      <text x="20" y="204" fill="#94a3b8" font-size="10">extract findings</text>
+    </g>
+
+    <!-- done (0.90-1.00) -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.899;0.905;1" dur="10s" repeatCount="indefinite"/>
+      <text x="20" y="64" fill="#94a3b8" font-size="11">graph state:</text>
+      <text x="20" y="84" fill="#fca5a5" font-size="11">• 1 critical</text>
+      <text x="20" y="102" fill="#94a3b8" font-size="11">• 6 phases run · 2 skipped</text>
+      <line x1="20" y1="120" x2="200" y2="120" stroke="#334155"/>
+      <text x="20" y="148" fill="#10b981" font-size="10" font-weight="700" letter-spacing="1">CAMPAIGN COMPLETE</text>
+      <text x="20" y="180" fill="#10b981" font-size="22" font-weight="700">✓</text>
+      <text x="20" y="204" fill="#94a3b8" font-size="10">graph: final state</text>
+    </g>
+  </g>
+
+  <text x="600" y="372" text-anchor="middle" fill="#475569" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-style="italic">Each phase updates the graph; the graph picks the next phase. Trust Building & Persistence skipped because graph state made them irrelevant.</text>
+</svg>

--- a/docs/assets/adaptive-dark.svg
+++ b/docs/assets/adaptive-dark.svg
@@ -264,5 +264,5 @@
     </g>
   </g>
 
-  <text x="600" y="372" text-anchor="middle" fill="#475569" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-style="italic">Each phase updates the graph; the graph picks the next phase. Trust Building & Persistence skipped because graph state made them irrelevant.</text>
+  <text x="600" y="372" text-anchor="middle" fill="#475569" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-style="italic">Each phase updates the graph; the graph picks the next phase. Trust Building &amp; Persistence skipped because graph state made them irrelevant.</text>
 </svg>

--- a/docs/assets/adaptive-light.svg
+++ b/docs/assets/adaptive-light.svg
@@ -1,0 +1,230 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 380" role="img" aria-labelledby="ad-title ad-desc" preserveAspectRatio="xMidYMid meet">
+  <title id="ad-title">ZIRAN adaptive campaign: knowledge graph drives next phase</title>
+  <desc id="ad-desc">A live demonstration of ZIRAN's 8-phase campaign. Center: a knowledge graph that grows phase by phase. Reconnaissance discovers 3 capabilities (tools, memory, permissions). Capability Mapping reveals 3 individual tools (read_file, http_request, sql_query). Vulnerability Discovery surfaces a critical edge — read_file → http_request — labelled "data_exfil". Exploit Setup attaches an attack plan to that edge. Execute fires it. The right panel shows how each new graph state picks the next phase: Trust Building is skipped (no auth surface), and Persistence is skipped (ephemeral target). Two of the eight phases are bypassed entirely because the graph state makes them irrelevant. Keywords: adaptive campaign, live knowledge graph, non-linear pipeline, agent red team, multi-phase exploitation, ZIRAN, capability discovery, dangerous tool chain.</desc>
+
+  <rect width="1200" height="380" fill="#f8fafc" rx="16"/>
+  <rect x="0.5" y="0.5" width="1199" height="379" fill="none" stroke="#e2e8f0" rx="16"/>
+
+  <text x="600" y="34" text-anchor="middle" fill="#64748b" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" letter-spacing="3">ADAPTIVE 8-PHASE CAMPAIGN  ·  GRAPH-DRIVEN</text>
+
+  <!-- LEFT PANEL: CURRENT PHASE -->
+  <g transform="translate(40, 60)" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif">
+    <rect width="200" height="300" rx="14" fill="#ffffff" stroke="#cbd5e1"/>
+    <text x="100" y="26" text-anchor="middle" fill="#64748b" font-size="10" font-weight="600" letter-spacing="2">RUNNING</text>
+
+    <g text-anchor="middle">
+      <g opacity="0">
+        <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.005;0.149;0.155" dur="10s" repeatCount="indefinite"/>
+        <text x="100" y="116" font-size="40">🔍</text>
+        <text x="100" y="160" fill="#0284c7" font-size="15" font-weight="700">Reconnaissance</text>
+        <text x="100" y="184" fill="#64748b" font-size="11">probe agent surface</text>
+      </g>
+      <g opacity="0">
+        <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.149;0.155;0.299;0.305" dur="10s" repeatCount="indefinite"/>
+        <text x="100" y="116" font-size="40">🗺️</text>
+        <text x="100" y="160" fill="#0284c7" font-size="15" font-weight="700">Capability Map</text>
+        <text x="100" y="184" fill="#64748b" font-size="11">enumerate tools</text>
+      </g>
+      <g opacity="0">
+        <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.299;0.305;0.449;0.455" dur="10s" repeatCount="indefinite"/>
+        <text x="100" y="116" font-size="40">⚡</text>
+        <text x="100" y="160" fill="#0284c7" font-size="15" font-weight="700">Vuln Discovery</text>
+        <text x="100" y="184" fill="#64748b" font-size="11">walk for chains</text>
+      </g>
+      <g opacity="0">
+        <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.449;0.455;0.599;0.605" dur="10s" repeatCount="indefinite"/>
+        <text x="100" y="116" font-size="40">🎯</text>
+        <text x="100" y="160" fill="#dc2626" font-size="15" font-weight="700">Exploit Setup</text>
+        <text x="100" y="184" fill="#64748b" font-size="11">prime the chain</text>
+      </g>
+      <g opacity="0">
+        <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.599;0.605;0.749;0.755" dur="10s" repeatCount="indefinite"/>
+        <text x="100" y="116" font-size="40">💥</text>
+        <text x="100" y="160" fill="#dc2626" font-size="15" font-weight="700">Execute</text>
+        <text x="100" y="184" fill="#64748b" font-size="11">fire exploit</text>
+      </g>
+      <g opacity="0">
+        <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.749;0.755;0.899;0.905" dur="10s" repeatCount="indefinite"/>
+        <text x="100" y="116" font-size="40">📤</text>
+        <text x="100" y="160" fill="#dc2626" font-size="15" font-weight="700">Exfiltrate</text>
+        <text x="100" y="184" fill="#64748b" font-size="11">extract findings</text>
+      </g>
+      <g opacity="0">
+        <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.899;0.905;1" dur="10s" repeatCount="indefinite"/>
+        <text x="100" y="116" font-size="40">✓</text>
+        <text x="100" y="160" fill="#059669" font-size="15" font-weight="700">Complete</text>
+        <text x="100" y="184" fill="#64748b" font-size="11">1 critical · 0 high</text>
+      </g>
+    </g>
+
+    <text x="100" y="270" text-anchor="middle" fill="#d97706" font-size="10" font-style="italic">graph-driven · non-linear</text>
+  </g>
+
+  <!-- CENTER: LIVE KNOWLEDGE GRAPH -->
+  <g transform="translate(260, 60)" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif">
+    <rect width="660" height="300" rx="14" fill="#ffffff" stroke="#d97706" stroke-width="1.5"/>
+    <text x="330" y="26" text-anchor="middle" fill="#d97706" font-size="11" font-weight="600" letter-spacing="2">LIVE KNOWLEDGE GRAPH</text>
+
+    <!-- Agent root -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.02;0.99;1" dur="10s" repeatCount="indefinite"/>
+      <circle cx="330" cy="78" r="28" fill="#f0f9ff" stroke="#0284c7" stroke-width="2"/>
+      <text x="330" y="83" text-anchor="middle" fill="#0284c7" font-family="ui-monospace, SFMono-Regular, monospace" font-size="11" font-weight="700">agent</text>
+    </g>
+
+    <!-- Capability layer -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.149;0.16;0.99;1" dur="10s" repeatCount="indefinite"/>
+      <line x1="312" y1="100" x2="180" y2="135" stroke="#cbd5e1" stroke-width="1.5"/>
+      <line x1="330" y1="106" x2="330" y2="133" stroke="#cbd5e1" stroke-width="1.5"/>
+      <line x1="348" y1="100" x2="480" y2="135" stroke="#cbd5e1" stroke-width="1.5"/>
+      <circle cx="180" cy="148" r="22" fill="#f0f9ff" stroke="#0284c7" stroke-width="1.5"/>
+      <text x="180" y="152" text-anchor="middle" fill="#334155" font-size="10">tools</text>
+      <circle cx="330" cy="148" r="22" fill="#f0f9ff" stroke="#0284c7" stroke-width="1.5"/>
+      <text x="330" y="152" text-anchor="middle" fill="#334155" font-size="10">memory</text>
+      <circle cx="480" cy="148" r="22" fill="#f0f9ff" stroke="#0284c7" stroke-width="1.5"/>
+      <text x="480" y="152" text-anchor="middle" fill="#334155" font-size="10">perms</text>
+      <text x="580" y="148" fill="#059669" font-size="11" font-weight="600" opacity="0">
+        <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.155;0.20;0.22;1" dur="10s" repeatCount="indefinite"/>+3</text>
+    </g>
+
+    <!-- Tool layer -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.299;0.31;0.99;1" dur="10s" repeatCount="indefinite"/>
+      <line x1="170" y1="168" x2="100" y2="208" stroke="#cbd5e1" stroke-width="1.5"/>
+      <line x1="180" y1="170" x2="190" y2="208" stroke="#cbd5e1" stroke-width="1.5"/>
+      <line x1="195" y1="166" x2="280" y2="208" stroke="#cbd5e1" stroke-width="1.5"/>
+      <circle cx="100" cy="222" r="22" fill="#ffffff" stroke="#94a3b8" stroke-width="1.5"/>
+      <text x="100" y="226" text-anchor="middle" fill="#334155" font-family="ui-monospace, SFMono-Regular, monospace" font-size="9">read_file</text>
+      <circle cx="190" cy="222" r="22" fill="#ffffff" stroke="#94a3b8" stroke-width="1.5"/>
+      <text x="190" y="226" text-anchor="middle" fill="#334155" font-family="ui-monospace, SFMono-Regular, monospace" font-size="9">http_req</text>
+      <circle cx="280" cy="222" r="22" fill="#ffffff" stroke="#94a3b8" stroke-width="1.5"/>
+      <text x="280" y="226" text-anchor="middle" fill="#334155" font-family="ui-monospace, SFMono-Regular, monospace" font-size="9">sql_query</text>
+      <text x="360" y="226" fill="#059669" font-size="11" font-weight="600" opacity="0">
+        <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.305;0.35;0.37;1" dur="10s" repeatCount="indefinite"/>+3</text>
+    </g>
+
+    <!-- Critical chain edge -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.449;0.46;0.99;1" dur="10s" repeatCount="indefinite"/>
+      <line x1="122" y1="222" x2="166" y2="222" stroke="#dc2626" stroke-width="3"/>
+      <polygon points="170,222 162,218 162,226" fill="#dc2626"/>
+      <circle cy="222" r="4" fill="#dc2626">
+        <animate attributeName="cx" values="122;166;122" dur="1.6s" repeatCount="indefinite"/>
+      </circle>
+      <rect x="100" y="252" width="90" height="20" rx="4" fill="#dc2626"/>
+      <text x="145" y="266" text-anchor="middle" fill="#fff" font-size="9" font-weight="700">⚠ data_exfil</text>
+      <text x="220" y="266" fill="#dc2626" font-size="11" font-weight="700" opacity="0">
+        <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.455;0.51;0.53;1" dur="10s" repeatCount="indefinite"/>+1 critical</text>
+    </g>
+
+    <!-- Attack node -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.599;0.61;0.99;1" dur="10s" repeatCount="indefinite"/>
+      <path d="M 145 282 L 145 252" stroke="#dc2626" stroke-width="1.5" fill="none" stroke-dasharray="3 3"/>
+      <rect x="105" y="280" width="80" height="22" rx="4" fill="#fef2f2" stroke="#dc2626" stroke-width="1.5"/>
+      <text x="145" y="295" text-anchor="middle" fill="#7f1d1d" font-size="11" font-weight="700">🎯 exploit</text>
+    </g>
+
+    <!-- 1 CRITICAL hero badge -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.749;0.755;0.99;1" dur="10s" repeatCount="indefinite"/>
+      <rect x="430" y="230" width="200" height="56" rx="10" fill="#dc2626"/>
+      <text x="530" y="256" text-anchor="middle" fill="#fff" font-size="18" font-weight="800">⚠ 1 CRITICAL</text>
+      <text x="530" y="276" text-anchor="middle" fill="#fff" font-family="ui-monospace, SFMono-Regular, monospace" font-size="10">read_file → http_request</text>
+    </g>
+
+    <!-- 2 phases skipped tag -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.899;0.905;1" dur="10s" repeatCount="indefinite"/>
+      <rect x="430" y="60" width="200" height="22" rx="11" fill="#f0fdf4" stroke="#059669"/>
+      <text x="530" y="75" text-anchor="middle" fill="#059669" font-size="10" font-weight="700">2 phases skipped by graph state</text>
+    </g>
+  </g>
+
+  <!-- RIGHT PANEL: GRAPH STATE → NEXT PHASE -->
+  <g transform="translate(940, 60)" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif">
+    <rect width="220" height="300" rx="14" fill="#ffffff" stroke="#cbd5e1"/>
+    <text x="110" y="26" text-anchor="middle" fill="#64748b" font-size="10" font-weight="600" letter-spacing="2">GRAPH STATE  →  NEXT</text>
+
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.005;0.149;0.155" dur="10s" repeatCount="indefinite"/>
+      <text x="20" y="64" fill="#64748b" font-size="11">graph state:</text>
+      <text x="20" y="86" fill="#334155" font-size="11">• agent only</text>
+      <line x1="20" y1="120" x2="200" y2="120" stroke="#e2e8f0"/>
+      <text x="20" y="148" fill="#d97706" font-size="10" font-weight="700" letter-spacing="1">→ NEXT</text>
+      <text x="20" y="172" fill="#0f172a" font-size="14" font-weight="600">Reconnaissance</text>
+      <text x="20" y="194" fill="#64748b" font-size="10">map agent surface</text>
+    </g>
+
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.149;0.155;0.299;0.305" dur="10s" repeatCount="indefinite"/>
+      <text x="20" y="64" fill="#64748b" font-size="11">graph state:</text>
+      <text x="20" y="84" fill="#334155" font-size="11">• 3 capabilities</text>
+      <text x="20" y="102" fill="#64748b" font-size="11">• no auth surface</text>
+      <line x1="20" y1="118" x2="200" y2="118" stroke="#e2e8f0"/>
+      <text x="20" y="138" fill="#94a3b8" font-size="9" font-style="italic">↳ skip Trust Building</text>
+      <text x="20" y="160" fill="#d97706" font-size="10" font-weight="700" letter-spacing="1">→ NEXT</text>
+      <text x="20" y="182" fill="#0f172a" font-size="14" font-weight="600">Capability Map</text>
+      <text x="20" y="204" fill="#64748b" font-size="10">enumerate tools</text>
+    </g>
+
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.299;0.305;0.449;0.455" dur="10s" repeatCount="indefinite"/>
+      <text x="20" y="64" fill="#64748b" font-size="11">graph state:</text>
+      <text x="20" y="84" fill="#334155" font-size="11">• 3 tools mapped</text>
+      <text x="20" y="102" fill="#334155" font-size="11">• capability matrix</text>
+      <line x1="20" y1="120" x2="200" y2="120" stroke="#e2e8f0"/>
+      <text x="20" y="148" fill="#d97706" font-size="10" font-weight="700" letter-spacing="1">→ NEXT</text>
+      <text x="20" y="172" fill="#0f172a" font-size="14" font-weight="600">Vuln Discovery</text>
+      <text x="20" y="194" fill="#64748b" font-size="10">walk for chains</text>
+    </g>
+
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.449;0.455;0.599;0.605" dur="10s" repeatCount="indefinite"/>
+      <text x="20" y="64" fill="#64748b" font-size="11">graph state:</text>
+      <text x="20" y="84" fill="#dc2626" font-size="11" font-weight="700">⚠ critical chain</text>
+      <text x="20" y="102" fill="#dc2626" font-family="ui-monospace, SFMono-Regular, monospace" font-size="10">read_file→http_req</text>
+      <line x1="20" y1="120" x2="200" y2="120" stroke="#e2e8f0"/>
+      <text x="20" y="148" fill="#dc2626" font-size="10" font-weight="700" letter-spacing="1">→ NEXT</text>
+      <text x="20" y="172" fill="#0f172a" font-size="14" font-weight="600">Exploit Setup</text>
+      <text x="20" y="194" fill="#64748b" font-size="10">prime the chain</text>
+    </g>
+
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.599;0.605;0.749;0.755" dur="10s" repeatCount="indefinite"/>
+      <text x="20" y="64" fill="#64748b" font-size="11">graph state:</text>
+      <text x="20" y="84" fill="#dc2626" font-size="11">• exploit primed</text>
+      <text x="20" y="102" fill="#dc2626" font-size="11">• ready to fire</text>
+      <line x1="20" y1="120" x2="200" y2="120" stroke="#e2e8f0"/>
+      <text x="20" y="148" fill="#dc2626" font-size="10" font-weight="700" letter-spacing="1">→ NEXT</text>
+      <text x="20" y="172" fill="#0f172a" font-size="14" font-weight="600">Execute</text>
+      <text x="20" y="194" fill="#64748b" font-size="10">fire the exploit</text>
+    </g>
+
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.749;0.755;0.899;0.905" dur="10s" repeatCount="indefinite"/>
+      <text x="20" y="64" fill="#64748b" font-size="11">graph state:</text>
+      <text x="20" y="84" fill="#dc2626" font-size="11">• 1 critical fired</text>
+      <text x="20" y="102" fill="#64748b" font-size="11">• ephemeral target</text>
+      <line x1="20" y1="118" x2="200" y2="118" stroke="#e2e8f0"/>
+      <text x="20" y="138" fill="#94a3b8" font-size="9" font-style="italic">↳ skip Persistence</text>
+      <text x="20" y="160" fill="#dc2626" font-size="10" font-weight="700" letter-spacing="1">→ NEXT</text>
+      <text x="20" y="182" fill="#0f172a" font-size="14" font-weight="600">Exfiltrate</text>
+      <text x="20" y="204" fill="#64748b" font-size="10">extract findings</text>
+    </g>
+
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.899;0.905;1" dur="10s" repeatCount="indefinite"/>
+      <text x="20" y="64" fill="#64748b" font-size="11">graph state:</text>
+      <text x="20" y="84" fill="#dc2626" font-size="11">• 1 critical</text>
+      <text x="20" y="102" fill="#64748b" font-size="11">• 6 phases run · 2 skipped</text>
+      <line x1="20" y1="120" x2="200" y2="120" stroke="#e2e8f0"/>
+      <text x="20" y="148" fill="#059669" font-size="10" font-weight="700" letter-spacing="1">CAMPAIGN COMPLETE</text>
+      <text x="20" y="180" fill="#059669" font-size="22" font-weight="700">✓</text>
+      <text x="20" y="204" fill="#64748b" font-size="10">graph: final state</text>
+    </g>
+  </g>
+
+  <text x="600" y="372" text-anchor="middle" fill="#94a3b8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-style="italic">Each phase updates the graph; the graph picks the next phase. Trust Building & Persistence skipped because graph state made them irrelevant.</text>
+</svg>

--- a/docs/assets/adaptive-light.svg
+++ b/docs/assets/adaptive-light.svg
@@ -226,5 +226,5 @@
     </g>
   </g>
 
-  <text x="600" y="372" text-anchor="middle" fill="#94a3b8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-style="italic">Each phase updates the graph; the graph picks the next phase. Trust Building & Persistence skipped because graph state made them irrelevant.</text>
+  <text x="600" y="372" text-anchor="middle" fill="#94a3b8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-style="italic">Each phase updates the graph; the graph picks the next phase. Trust Building &amp; Persistence skipped because graph state made them irrelevant.</text>
 </svg>

--- a/docs/assets/hero-dark.svg
+++ b/docs/assets/hero-dark.svg
@@ -1,0 +1,131 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 320" role="img" aria-labelledby="ziran-hero-title ziran-hero-desc" preserveAspectRatio="xMidYMid meet">
+  <title id="ziran-hero-title">ZIRAN: AI agent security testing pipeline</title>
+  <desc id="ziran-hero-desc">Your AI agent (with tools, memory, and permissions) flows through the ZIRAN pipeline — discover, map, analyze, attack, report — into a ranked list of findings. The top finding "read_file to http_request" is highlighted as a critical data-exfiltration tool chain. Keywords: AI agent security, agent red team, tool chain analysis, knowledge graph, MCP, A2A, LangChain, CrewAI, prompt injection, side-effect detection.</desc>
+
+  <!-- background card -->
+  <rect width="1200" height="320" fill="#0f172a" rx="16"/>
+  <rect x="0.5" y="0.5" width="1199" height="319" fill="none" stroke="#1e293b" stroke-width="1" rx="16"/>
+
+  <!-- header strip -->
+  <text x="600" y="38" text-anchor="middle" fill="#64748b" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" letter-spacing="3">YOUR AGENT  ·  ZIRAN  ·  FINDINGS</text>
+
+  <!-- ============ AGENT PANEL ============ -->
+  <g transform="translate(60, 76)">
+    <rect width="240" height="216" rx="14" fill="#1e293b" stroke="#334155" stroke-width="1.5"/>
+    <text x="120" y="34" text-anchor="middle" fill="#f1f5f9" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="14" font-weight="600">Your Agent</text>
+
+    <g font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="13">
+      <rect x="20" y="58" width="200" height="40" rx="10" fill="#0f172a" stroke="#334155"/>
+      <text x="36" y="83" fill="#cbd5e1">🔧  Tools</text>
+
+      <rect x="20" y="108" width="200" height="40" rx="10" fill="#0f172a" stroke="#334155"/>
+      <text x="36" y="133" fill="#cbd5e1">🧠  Memory</text>
+
+      <rect x="20" y="158" width="200" height="40" rx="10" fill="#0f172a" stroke="#334155"/>
+      <text x="36" y="183" fill="#cbd5e1">🔑  Permissions</text>
+    </g>
+  </g>
+
+  <!-- arrow: agent → ziran -->
+  <line x1="312" y1="184" x2="426" y2="184" stroke="#334155" stroke-width="2" stroke-dasharray="5 6"/>
+  <polygon points="426,184 418,180 418,188" fill="#334155"/>
+
+  <!-- probe packets traveling right -->
+  <circle r="5" fill="#0ea5e9">
+    <animate attributeName="cx" values="312;426" dur="2.4s" begin="0s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="184;184" dur="2.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <circle r="5" fill="#0ea5e9">
+    <animate attributeName="cx" values="312;426" dur="2.4s" begin="1.2s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="184;184" dur="2.4s" begin="1.2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.4s" begin="1.2s" repeatCount="indefinite"/>
+  </circle>
+
+  <!-- ============ ZIRAN PIPELINE ============ -->
+  <g transform="translate(436, 76)">
+    <rect width="328" height="216" rx="14" fill="#1e293b" stroke="#e94560" stroke-width="1.5"/>
+    <text x="164" y="34" text-anchor="middle" fill="#f1f5f9" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="14" font-weight="600">⛩  ZIRAN Pipeline</text>
+
+    <!-- connecting line under nodes -->
+    <line x1="40" y1="124" x2="288" y2="124" stroke="#334155" stroke-width="1.5"/>
+
+    <!-- 5 phase nodes -->
+    <g font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" text-anchor="middle">
+      <circle cx="40"  cy="124" r="20" fill="#0f172a" stroke="#0ea5e9" stroke-width="2"/>
+      <text x="40"  y="129" fill="#0ea5e9" font-size="13" font-weight="700">D</text>
+      <text x="40"  y="166" fill="#94a3b8" font-size="10">discover</text>
+
+      <circle cx="102" cy="124" r="20" fill="#0f172a" stroke="#0ea5e9" stroke-width="2"/>
+      <text x="102" y="129" fill="#0ea5e9" font-size="13" font-weight="700">M</text>
+      <text x="102" y="166" fill="#94a3b8" font-size="10">map</text>
+
+      <circle cx="164" cy="124" r="20" fill="#0f172a" stroke="#0ea5e9" stroke-width="2"/>
+      <text x="164" y="129" fill="#0ea5e9" font-size="13" font-weight="700">A</text>
+      <text x="164" y="166" fill="#94a3b8" font-size="10">analyze</text>
+
+      <circle cx="226" cy="124" r="20" fill="#0f172a" stroke="#e94560" stroke-width="2"/>
+      <text x="226" y="129" fill="#e94560" font-size="13" font-weight="700">⚡</text>
+      <text x="226" y="166" fill="#94a3b8" font-size="10">attack</text>
+
+      <circle cx="288" cy="124" r="20" fill="#0f172a" stroke="#10b981" stroke-width="2"/>
+      <text x="288" y="129" fill="#10b981" font-size="13" font-weight="700">R</text>
+      <text x="288" y="166" fill="#94a3b8" font-size="10">report</text>
+    </g>
+
+    <!-- sweeping highlight ring -->
+    <circle cy="124" r="22" fill="none" stroke="#fbbf24" stroke-width="2.5">
+      <animate attributeName="cx" values="40;102;164;226;288;40" keyTimes="0;0.2;0.4;0.6;0.8;1" dur="5s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;1;1;1;1;1;0" keyTimes="0;0.05;0.2;0.4;0.6;0.95;1" dur="5s" repeatCount="indefinite"/>
+    </circle>
+
+    <!-- knowledge graph hint at bottom -->
+    <text x="164" y="196" text-anchor="middle" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10" font-style="italic">live knowledge graph drives next phase</text>
+  </g>
+
+  <!-- arrow: ziran → findings -->
+  <line x1="774" y1="184" x2="888" y2="184" stroke="#334155" stroke-width="2" stroke-dasharray="5 6"/>
+  <polygon points="888,184 880,180 880,188" fill="#334155"/>
+
+  <!-- finding packets traveling right (red, tagged critical) -->
+  <circle r="5" fill="#e94560">
+    <animate attributeName="cx" values="774;888" dur="2.4s" begin="0.6s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.4s" begin="0.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle r="5" fill="#f59e0b">
+    <animate attributeName="cx" values="774;888" dur="2.4s" begin="1.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.4s" begin="1.8s" repeatCount="indefinite"/>
+  </circle>
+
+  <!-- ============ FINDINGS PANEL ============ -->
+  <g transform="translate(900, 76)">
+    <rect width="240" height="216" rx="14" fill="#1e293b" stroke="#334155" stroke-width="1.5"/>
+    <text x="120" y="34" text-anchor="middle" fill="#f1f5f9" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="14" font-weight="600">Findings</text>
+
+    <!-- CRITICAL row (pulsing) -->
+    <g>
+      <rect x="20" y="58" width="200" height="40" rx="10" fill="#450a0a" stroke="#e94560" stroke-width="1.5">
+        <animate attributeName="stroke-width" values="1.5;3;1.5" dur="1.8s" repeatCount="indefinite"/>
+        <animate attributeName="fill" values="#450a0a;#7f1d1d;#450a0a" dur="1.8s" repeatCount="indefinite"/>
+      </rect>
+      <rect x="28" y="68" width="62" height="16" rx="3" fill="#e94560"/>
+      <text x="59" y="80" text-anchor="middle" fill="#fff" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9" font-weight="700">CRITICAL</text>
+      <text x="98" y="82" fill="#fecaca" font-family="ui-monospace, SFMono-Regular, monospace" font-size="10">read_file→http</text>
+    </g>
+
+    <!-- HIGH row -->
+    <rect x="20" y="108" width="200" height="40" rx="10" fill="#0f172a" stroke="#334155"/>
+    <rect x="28" y="118" width="38" height="16" rx="3" fill="#f59e0b"/>
+    <text x="47" y="130" text-anchor="middle" fill="#fff" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9" font-weight="700">HIGH</text>
+    <text x="74" y="132" fill="#cbd5e1" font-family="ui-monospace, SFMono-Regular, monospace" font-size="10">sql_query→exec</text>
+
+    <!-- MEDIUM row -->
+    <rect x="20" y="158" width="200" height="40" rx="10" fill="#0f172a" stroke="#334155"/>
+    <rect x="28" y="168" width="54" height="16" rx="3" fill="#0ea5e9"/>
+    <text x="55" y="180" text-anchor="middle" fill="#fff" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9" font-weight="700">MEDIUM</text>
+    <text x="90" y="182" fill="#cbd5e1" font-family="ui-monospace, SFMono-Regular, monospace" font-size="10">prompt_inject</text>
+  </g>
+
+  <!-- footer caption -->
+  <text x="600" y="304" text-anchor="middle" fill="#475569" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11">graph-based discovery  ·  execution-level side effects  ·  multi-phase adaptive campaigns</text>
+</svg>

--- a/docs/assets/hero-light.svg
+++ b/docs/assets/hero-light.svg
@@ -1,0 +1,131 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 320" role="img" aria-labelledby="ziran-hero-title ziran-hero-desc" preserveAspectRatio="xMidYMid meet">
+  <title id="ziran-hero-title">ZIRAN: AI agent security testing pipeline</title>
+  <desc id="ziran-hero-desc">Your AI agent (with tools, memory, and permissions) flows through the ZIRAN pipeline — discover, map, analyze, attack, report — into a ranked list of findings. The top finding "read_file to http_request" is highlighted as a critical data-exfiltration tool chain. Keywords: AI agent security, agent red team, tool chain analysis, knowledge graph, MCP, A2A, LangChain, CrewAI, prompt injection, side-effect detection.</desc>
+
+  <!-- background card -->
+  <rect width="1200" height="320" fill="#f8fafc" rx="16"/>
+  <rect x="0.5" y="0.5" width="1199" height="319" fill="none" stroke="#e2e8f0" stroke-width="1" rx="16"/>
+
+  <!-- header strip -->
+  <text x="600" y="38" text-anchor="middle" fill="#64748b" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" letter-spacing="3">YOUR AGENT  ·  ZIRAN  ·  FINDINGS</text>
+
+  <!-- ============ AGENT PANEL ============ -->
+  <g transform="translate(60, 76)">
+    <rect width="240" height="216" rx="14" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+    <text x="120" y="34" text-anchor="middle" fill="#0f172a" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="14" font-weight="600">Your Agent</text>
+
+    <g font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="13">
+      <rect x="20" y="58" width="200" height="40" rx="10" fill="#f1f5f9" stroke="#cbd5e1"/>
+      <text x="36" y="83" fill="#334155">🔧  Tools</text>
+
+      <rect x="20" y="108" width="200" height="40" rx="10" fill="#f1f5f9" stroke="#cbd5e1"/>
+      <text x="36" y="133" fill="#334155">🧠  Memory</text>
+
+      <rect x="20" y="158" width="200" height="40" rx="10" fill="#f1f5f9" stroke="#cbd5e1"/>
+      <text x="36" y="183" fill="#334155">🔑  Permissions</text>
+    </g>
+  </g>
+
+  <!-- arrow: agent → ziran -->
+  <line x1="312" y1="184" x2="426" y2="184" stroke="#cbd5e1" stroke-width="2" stroke-dasharray="5 6"/>
+  <polygon points="426,184 418,180 418,188" fill="#cbd5e1"/>
+
+  <!-- probe packets traveling right -->
+  <circle r="5" fill="#0284c7">
+    <animate attributeName="cx" values="312;426" dur="2.4s" begin="0s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="184;184" dur="2.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <circle r="5" fill="#0284c7">
+    <animate attributeName="cx" values="312;426" dur="2.4s" begin="1.2s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="184;184" dur="2.4s" begin="1.2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.4s" begin="1.2s" repeatCount="indefinite"/>
+  </circle>
+
+  <!-- ============ ZIRAN PIPELINE ============ -->
+  <g transform="translate(436, 76)">
+    <rect width="328" height="216" rx="14" fill="#ffffff" stroke="#dc2626" stroke-width="1.5"/>
+    <text x="164" y="34" text-anchor="middle" fill="#0f172a" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="14" font-weight="600">⛩  ZIRAN Pipeline</text>
+
+    <!-- connecting line under nodes -->
+    <line x1="40" y1="124" x2="288" y2="124" stroke="#cbd5e1" stroke-width="1.5"/>
+
+    <!-- 5 phase nodes -->
+    <g font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" text-anchor="middle">
+      <circle cx="40"  cy="124" r="20" fill="#f0f9ff" stroke="#0284c7" stroke-width="2"/>
+      <text x="40"  y="129" fill="#0284c7" font-size="13" font-weight="700">D</text>
+      <text x="40"  y="166" fill="#64748b" font-size="10">discover</text>
+
+      <circle cx="102" cy="124" r="20" fill="#f0f9ff" stroke="#0284c7" stroke-width="2"/>
+      <text x="102" y="129" fill="#0284c7" font-size="13" font-weight="700">M</text>
+      <text x="102" y="166" fill="#64748b" font-size="10">map</text>
+
+      <circle cx="164" cy="124" r="20" fill="#f0f9ff" stroke="#0284c7" stroke-width="2"/>
+      <text x="164" y="129" fill="#0284c7" font-size="13" font-weight="700">A</text>
+      <text x="164" y="166" fill="#64748b" font-size="10">analyze</text>
+
+      <circle cx="226" cy="124" r="20" fill="#fef2f2" stroke="#dc2626" stroke-width="2"/>
+      <text x="226" y="129" fill="#dc2626" font-size="13" font-weight="700">⚡</text>
+      <text x="226" y="166" fill="#64748b" font-size="10">attack</text>
+
+      <circle cx="288" cy="124" r="20" fill="#ecfdf5" stroke="#059669" stroke-width="2"/>
+      <text x="288" y="129" fill="#059669" font-size="13" font-weight="700">R</text>
+      <text x="288" y="166" fill="#64748b" font-size="10">report</text>
+    </g>
+
+    <!-- sweeping highlight ring -->
+    <circle cy="124" r="22" fill="none" stroke="#d97706" stroke-width="2.5">
+      <animate attributeName="cx" values="40;102;164;226;288;40" keyTimes="0;0.2;0.4;0.6;0.8;1" dur="5s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;1;1;1;1;1;0" keyTimes="0;0.05;0.2;0.4;0.6;0.95;1" dur="5s" repeatCount="indefinite"/>
+    </circle>
+
+    <!-- knowledge graph hint at bottom -->
+    <text x="164" y="196" text-anchor="middle" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10" font-style="italic">live knowledge graph drives next phase</text>
+  </g>
+
+  <!-- arrow: ziran → findings -->
+  <line x1="774" y1="184" x2="888" y2="184" stroke="#cbd5e1" stroke-width="2" stroke-dasharray="5 6"/>
+  <polygon points="888,184 880,180 880,188" fill="#cbd5e1"/>
+
+  <!-- finding packets traveling right -->
+  <circle r="5" fill="#dc2626">
+    <animate attributeName="cx" values="774;888" dur="2.4s" begin="0.6s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.4s" begin="0.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle r="5" fill="#d97706">
+    <animate attributeName="cx" values="774;888" dur="2.4s" begin="1.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.4s" begin="1.8s" repeatCount="indefinite"/>
+  </circle>
+
+  <!-- ============ FINDINGS PANEL ============ -->
+  <g transform="translate(900, 76)">
+    <rect width="240" height="216" rx="14" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+    <text x="120" y="34" text-anchor="middle" fill="#0f172a" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="14" font-weight="600">Findings</text>
+
+    <!-- CRITICAL row (pulsing) -->
+    <g>
+      <rect x="20" y="58" width="200" height="40" rx="10" fill="#fef2f2" stroke="#dc2626" stroke-width="1.5">
+        <animate attributeName="stroke-width" values="1.5;3;1.5" dur="1.8s" repeatCount="indefinite"/>
+        <animate attributeName="fill" values="#fef2f2;#fee2e2;#fef2f2" dur="1.8s" repeatCount="indefinite"/>
+      </rect>
+      <rect x="28" y="68" width="62" height="16" rx="3" fill="#dc2626"/>
+      <text x="59" y="80" text-anchor="middle" fill="#fff" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9" font-weight="700">CRITICAL</text>
+      <text x="98" y="82" fill="#7f1d1d" font-family="ui-monospace, SFMono-Regular, monospace" font-size="10">read_file→http</text>
+    </g>
+
+    <!-- HIGH row -->
+    <rect x="20" y="108" width="200" height="40" rx="10" fill="#fffbeb" stroke="#fde68a"/>
+    <rect x="28" y="118" width="38" height="16" rx="3" fill="#d97706"/>
+    <text x="47" y="130" text-anchor="middle" fill="#fff" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9" font-weight="700">HIGH</text>
+    <text x="74" y="132" fill="#78350f" font-family="ui-monospace, SFMono-Regular, monospace" font-size="10">sql_query→exec</text>
+
+    <!-- MEDIUM row -->
+    <rect x="20" y="158" width="200" height="40" rx="10" fill="#f0f9ff" stroke="#bae6fd"/>
+    <rect x="28" y="168" width="54" height="16" rx="3" fill="#0284c7"/>
+    <text x="55" y="180" text-anchor="middle" fill="#fff" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9" font-weight="700">MEDIUM</text>
+    <text x="90" y="182" fill="#0c4a6e" font-family="ui-monospace, SFMono-Regular, monospace" font-size="10">prompt_inject</text>
+  </g>
+
+  <!-- footer caption -->
+  <text x="600" y="304" text-anchor="middle" fill="#94a3b8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11">graph-based discovery  ·  execution-level side effects  ·  multi-phase adaptive campaigns</text>
+</svg>

--- a/docs/assets/pipeline-dark.svg
+++ b/docs/assets/pipeline-dark.svg
@@ -1,0 +1,129 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 360" role="img" aria-label="ZIRAN pipeline: your agent flows through five stages — discover, map, analyze, attack, report — and out into three formats: HTML, Markdown, JSON" preserveAspectRatio="xMidYMid meet">
+  <title>ZIRAN pipeline: adapter to outputs</title>
+  <desc>Your agent (with tools, memory, and permissions) connects through an adapter layer into the ZIRAN pipeline, which runs five sequential stages — DISCOVER (probe tools, permissions, data access), MAP (build a NetworkX MultiDiGraph), ANALYZE (walk the graph for dangerous chains across 30 plus patterns), ATTACK (run multi-phase exploits informed by the graph), and REPORT (emit scored findings with remediation guidance). Outputs land in three formats: HTML interactive graph, Markdown CI/CD tables, and JSON for programmatic consumption. Keywords: agent security pipeline, adapter, knowledge graph, dangerous tool chain, SARIF, HTML report, JSON.</desc>
+
+  <rect width="1200" height="360" fill="#0f172a" rx="16"/>
+  <rect x="0.5" y="0.5" width="1199" height="359" fill="none" stroke="#1e293b" rx="16"/>
+
+  <text x="600" y="32" text-anchor="middle" fill="#64748b" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" letter-spacing="3">HOW ZIRAN WORKS  ·  ADAPTER TO OUTPUTS</text>
+
+  <!-- ===== AGENT ===== -->
+  <g transform="translate(40, 60)" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif">
+    <rect width="190" height="260" rx="14" fill="#1e293b" stroke="#334155" stroke-width="1.5"/>
+    <text x="95" y="32" text-anchor="middle" fill="#f1f5f9" font-size="13" font-weight="600">Your Agent</text>
+    <rect x="20" y="60" width="150" height="42" rx="10" fill="#0f172a" stroke="#334155"/>
+    <text x="36" y="86" fill="#cbd5e1" font-size="13">🔧  Tools</text>
+    <rect x="20" y="116" width="150" height="42" rx="10" fill="#0f172a" stroke="#334155"/>
+    <text x="36" y="142" fill="#cbd5e1" font-size="13">🧠  Memory</text>
+    <rect x="20" y="172" width="150" height="42" rx="10" fill="#0f172a" stroke="#334155"/>
+    <text x="36" y="198" fill="#cbd5e1" font-size="13">🔑  Permissions</text>
+    <text x="95" y="240" text-anchor="middle" fill="#64748b" font-size="10" font-style="italic">in-process · HTTPS · MCP · A2A</text>
+  </g>
+
+  <!-- adapter arrow + traveling probe -->
+  <text x="260" y="170" text-anchor="middle" fill="#94a3b8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10" font-weight="600">adapter</text>
+  <line x1="232" y1="190" x2="288" y2="190" stroke="#475569" stroke-width="2" stroke-dasharray="4 4"/>
+  <polygon points="288,190 280,186 280,194" fill="#475569"/>
+  <circle cy="190" r="5" fill="#0ea5e9">
+    <animate attributeName="cx" values="232;288" dur="2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.1;0.9;1" dur="2s" repeatCount="indefinite"/>
+  </circle>
+
+  <!-- ===== ZIRAN PIPELINE ===== -->
+  <g transform="translate(295, 60)" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif">
+    <rect width="620" height="260" rx="14" fill="#1e293b" stroke="#e94560" stroke-width="1.5"/>
+    <text x="310" y="32" text-anchor="middle" fill="#f1f5f9" font-size="13" font-weight="600">⛩  ZIRAN Pipeline</text>
+
+    <!-- spine -->
+    <line x1="80" y1="124" x2="540" y2="124" stroke="#334155" stroke-width="2"/>
+
+    <!-- DISCOVER -->
+    <g text-anchor="middle">
+      <circle cx="80" cy="124" r="22" fill="#0f172a" stroke="#0ea5e9" stroke-width="2"/>
+      <text x="80" y="129" fill="#0ea5e9" font-size="14" font-weight="700">D</text>
+      <text x="80" y="170" fill="#cbd5e1" font-size="11" font-weight="600">DISCOVER</text>
+      <text x="80" y="186" fill="#94a3b8" font-size="9">probe tools,</text>
+      <text x="80" y="198" fill="#94a3b8" font-size="9">permissions,</text>
+      <text x="80" y="210" fill="#94a3b8" font-size="9">data access</text>
+    </g>
+
+    <!-- MAP -->
+    <g text-anchor="middle">
+      <circle cx="195" cy="124" r="22" fill="#0f172a" stroke="#0ea5e9" stroke-width="2"/>
+      <text x="195" y="129" fill="#0ea5e9" font-size="14" font-weight="700">M</text>
+      <text x="195" y="170" fill="#cbd5e1" font-size="11" font-weight="600">MAP</text>
+      <text x="195" y="186" fill="#94a3b8" font-size="9">build knowledge</text>
+      <text x="195" y="198" fill="#94a3b8" font-size="9">graph (NetworkX</text>
+      <text x="195" y="210" fill="#94a3b8" font-size="9">MultiDiGraph)</text>
+    </g>
+
+    <!-- ANALYZE -->
+    <g text-anchor="middle">
+      <circle cx="310" cy="124" r="22" fill="#0f172a" stroke="#0ea5e9" stroke-width="2"/>
+      <text x="310" y="129" fill="#0ea5e9" font-size="14" font-weight="700">A</text>
+      <text x="310" y="170" fill="#cbd5e1" font-size="11" font-weight="600">ANALYZE</text>
+      <text x="310" y="186" fill="#94a3b8" font-size="9">walk graph for</text>
+      <text x="310" y="198" fill="#94a3b8" font-size="9">dangerous chains</text>
+      <text x="310" y="210" fill="#94a3b8" font-size="9">(30+ patterns)</text>
+    </g>
+
+    <!-- ATTACK -->
+    <g text-anchor="middle">
+      <circle cx="425" cy="124" r="22" fill="#0f172a" stroke="#e94560" stroke-width="2"/>
+      <text x="425" y="129" fill="#e94560" font-size="14" font-weight="700">T</text>
+      <text x="425" y="170" fill="#fecaca" font-size="11" font-weight="600">ATTACK</text>
+      <text x="425" y="186" fill="#94a3b8" font-size="9">multi-phase</text>
+      <text x="425" y="198" fill="#94a3b8" font-size="9">exploits informed</text>
+      <text x="425" y="210" fill="#94a3b8" font-size="9">by the graph</text>
+    </g>
+
+    <!-- REPORT -->
+    <g text-anchor="middle">
+      <circle cx="540" cy="124" r="22" fill="#0f172a" stroke="#10b981" stroke-width="2"/>
+      <text x="540" y="129" fill="#10b981" font-size="14" font-weight="700">R</text>
+      <text x="540" y="170" fill="#a7f3d0" font-size="11" font-weight="600">REPORT</text>
+      <text x="540" y="186" fill="#94a3b8" font-size="9">scored findings</text>
+      <text x="540" y="198" fill="#94a3b8" font-size="9">with remediation</text>
+      <text x="540" y="210" fill="#94a3b8" font-size="9">guidance</text>
+    </g>
+
+    <!-- sweeping highlight ring -->
+    <circle cy="124" r="26" fill="none" stroke="#fbbf24" stroke-width="2.5">
+      <animate attributeName="cx" values="80;195;310;425;540;80" keyTimes="0;0.2;0.4;0.6;0.8;1" dur="5s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;1;1;1;1;1;0" keyTimes="0;0.05;0.2;0.4;0.6;0.95;1" dur="5s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+
+  <!-- output arrows -->
+  <line x1="918" y1="124" x2="970" y2="98" stroke="#475569" stroke-width="2" stroke-dasharray="4 4"/>
+  <polygon points="970,98 962,96 964,104" fill="#475569"/>
+  <line x1="918" y1="190" x2="970" y2="190" stroke="#475569" stroke-width="2" stroke-dasharray="4 4"/>
+  <polygon points="970,190 962,186 962,194" fill="#475569"/>
+  <line x1="918" y1="256" x2="970" y2="280" stroke="#475569" stroke-width="2" stroke-dasharray="4 4"/>
+  <polygon points="970,280 962,276 964,284" fill="#475569"/>
+
+  <!-- ===== OUTPUTS ===== -->
+  <g transform="translate(975, 60)" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif">
+    <rect width="190" height="260" rx="14" fill="#1e293b" stroke="#10b981" stroke-width="1.5"/>
+    <text x="95" y="32" text-anchor="middle" fill="#f1f5f9" font-size="13" font-weight="600">Outputs</text>
+
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.30;0.40;1" dur="5s" repeatCount="indefinite"/>
+      <rect x="20" y="50" width="150" height="50" rx="10" fill="#0f172a" stroke="#10b981" stroke-width="1.5"/>
+      <text x="36" y="74" fill="#a7f3d0" font-size="13" font-weight="600">📊  HTML</text>
+      <text x="36" y="92" fill="#94a3b8" font-size="9">interactive graph</text>
+    </g>
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.40;0.50;1" dur="5s" repeatCount="indefinite"/>
+      <rect x="20" y="116" width="150" height="50" rx="10" fill="#0f172a" stroke="#10b981" stroke-width="1.5"/>
+      <text x="36" y="140" fill="#a7f3d0" font-size="13" font-weight="600">📝  Markdown</text>
+      <text x="36" y="158" fill="#94a3b8" font-size="9">CI/CD tables</text>
+    </g>
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.50;0.60;1" dur="5s" repeatCount="indefinite"/>
+      <rect x="20" y="182" width="150" height="50" rx="10" fill="#0f172a" stroke="#10b981" stroke-width="1.5"/>
+      <text x="36" y="206" fill="#a7f3d0" font-size="13" font-weight="600">📦  JSON</text>
+      <text x="36" y="224" fill="#94a3b8" font-size="9">machine-parseable</text>
+    </g>
+  </g>
+</svg>

--- a/docs/assets/pipeline-light.svg
+++ b/docs/assets/pipeline-light.svg
@@ -1,0 +1,113 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 360" role="img" aria-label="ZIRAN pipeline: your agent flows through five stages — discover, map, analyze, attack, report — and out into three formats: HTML, Markdown, JSON" preserveAspectRatio="xMidYMid meet">
+  <title>ZIRAN pipeline: adapter to outputs</title>
+  <desc>Your agent (with tools, memory, and permissions) connects through an adapter layer into the ZIRAN pipeline, which runs five sequential stages — DISCOVER (probe tools, permissions, data access), MAP (build a NetworkX MultiDiGraph), ANALYZE (walk the graph for dangerous chains across 30 plus patterns), ATTACK (run multi-phase exploits informed by the graph), and REPORT (emit scored findings with remediation guidance). Outputs land in three formats: HTML interactive graph, Markdown CI/CD tables, and JSON for programmatic consumption. Keywords: agent security pipeline, adapter, knowledge graph, dangerous tool chain, SARIF, HTML report, JSON.</desc>
+
+  <rect width="1200" height="360" fill="#f8fafc" rx="16"/>
+  <rect x="0.5" y="0.5" width="1199" height="359" fill="none" stroke="#e2e8f0" rx="16"/>
+
+  <text x="600" y="32" text-anchor="middle" fill="#64748b" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" letter-spacing="3">HOW ZIRAN WORKS  ·  ADAPTER TO OUTPUTS</text>
+
+  <g transform="translate(40, 60)" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif">
+    <rect width="190" height="260" rx="14" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+    <text x="95" y="32" text-anchor="middle" fill="#0f172a" font-size="13" font-weight="600">Your Agent</text>
+    <rect x="20" y="60" width="150" height="42" rx="10" fill="#f1f5f9" stroke="#cbd5e1"/>
+    <text x="36" y="86" fill="#334155" font-size="13">🔧  Tools</text>
+    <rect x="20" y="116" width="150" height="42" rx="10" fill="#f1f5f9" stroke="#cbd5e1"/>
+    <text x="36" y="142" fill="#334155" font-size="13">🧠  Memory</text>
+    <rect x="20" y="172" width="150" height="42" rx="10" fill="#f1f5f9" stroke="#cbd5e1"/>
+    <text x="36" y="198" fill="#334155" font-size="13">🔑  Permissions</text>
+    <text x="95" y="240" text-anchor="middle" fill="#94a3b8" font-size="10" font-style="italic">in-process · HTTPS · MCP · A2A</text>
+  </g>
+
+  <text x="260" y="170" text-anchor="middle" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10" font-weight="600">adapter</text>
+  <line x1="232" y1="190" x2="288" y2="190" stroke="#cbd5e1" stroke-width="2" stroke-dasharray="4 4"/>
+  <polygon points="288,190 280,186 280,194" fill="#cbd5e1"/>
+  <circle cy="190" r="5" fill="#0284c7">
+    <animate attributeName="cx" values="232;288" dur="2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.1;0.9;1" dur="2s" repeatCount="indefinite"/>
+  </circle>
+
+  <g transform="translate(295, 60)" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif">
+    <rect width="620" height="260" rx="14" fill="#ffffff" stroke="#dc2626" stroke-width="1.5"/>
+    <text x="310" y="32" text-anchor="middle" fill="#0f172a" font-size="13" font-weight="600">⛩  ZIRAN Pipeline</text>
+
+    <line x1="80" y1="124" x2="540" y2="124" stroke="#cbd5e1" stroke-width="2"/>
+
+    <g text-anchor="middle">
+      <circle cx="80" cy="124" r="22" fill="#f0f9ff" stroke="#0284c7" stroke-width="2"/>
+      <text x="80" y="129" fill="#0284c7" font-size="14" font-weight="700">D</text>
+      <text x="80" y="170" fill="#0f172a" font-size="11" font-weight="600">DISCOVER</text>
+      <text x="80" y="186" fill="#64748b" font-size="9">probe tools,</text>
+      <text x="80" y="198" fill="#64748b" font-size="9">permissions,</text>
+      <text x="80" y="210" fill="#64748b" font-size="9">data access</text>
+    </g>
+    <g text-anchor="middle">
+      <circle cx="195" cy="124" r="22" fill="#f0f9ff" stroke="#0284c7" stroke-width="2"/>
+      <text x="195" y="129" fill="#0284c7" font-size="14" font-weight="700">M</text>
+      <text x="195" y="170" fill="#0f172a" font-size="11" font-weight="600">MAP</text>
+      <text x="195" y="186" fill="#64748b" font-size="9">build knowledge</text>
+      <text x="195" y="198" fill="#64748b" font-size="9">graph (NetworkX</text>
+      <text x="195" y="210" fill="#64748b" font-size="9">MultiDiGraph)</text>
+    </g>
+    <g text-anchor="middle">
+      <circle cx="310" cy="124" r="22" fill="#f0f9ff" stroke="#0284c7" stroke-width="2"/>
+      <text x="310" y="129" fill="#0284c7" font-size="14" font-weight="700">A</text>
+      <text x="310" y="170" fill="#0f172a" font-size="11" font-weight="600">ANALYZE</text>
+      <text x="310" y="186" fill="#64748b" font-size="9">walk graph for</text>
+      <text x="310" y="198" fill="#64748b" font-size="9">dangerous chains</text>
+      <text x="310" y="210" fill="#64748b" font-size="9">(30+ patterns)</text>
+    </g>
+    <g text-anchor="middle">
+      <circle cx="425" cy="124" r="22" fill="#fef2f2" stroke="#dc2626" stroke-width="2"/>
+      <text x="425" y="129" fill="#dc2626" font-size="14" font-weight="700">T</text>
+      <text x="425" y="170" fill="#7f1d1d" font-size="11" font-weight="600">ATTACK</text>
+      <text x="425" y="186" fill="#64748b" font-size="9">multi-phase</text>
+      <text x="425" y="198" fill="#64748b" font-size="9">exploits informed</text>
+      <text x="425" y="210" fill="#64748b" font-size="9">by the graph</text>
+    </g>
+    <g text-anchor="middle">
+      <circle cx="540" cy="124" r="22" fill="#ecfdf5" stroke="#059669" stroke-width="2"/>
+      <text x="540" y="129" fill="#059669" font-size="14" font-weight="700">R</text>
+      <text x="540" y="170" fill="#065f46" font-size="11" font-weight="600">REPORT</text>
+      <text x="540" y="186" fill="#64748b" font-size="9">scored findings</text>
+      <text x="540" y="198" fill="#64748b" font-size="9">with remediation</text>
+      <text x="540" y="210" fill="#64748b" font-size="9">guidance</text>
+    </g>
+
+    <circle cy="124" r="26" fill="none" stroke="#d97706" stroke-width="2.5">
+      <animate attributeName="cx" values="80;195;310;425;540;80" keyTimes="0;0.2;0.4;0.6;0.8;1" dur="5s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;1;1;1;1;1;0" keyTimes="0;0.05;0.2;0.4;0.6;0.95;1" dur="5s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+
+  <line x1="918" y1="124" x2="970" y2="98" stroke="#cbd5e1" stroke-width="2" stroke-dasharray="4 4"/>
+  <polygon points="970,98 962,96 964,104" fill="#cbd5e1"/>
+  <line x1="918" y1="190" x2="970" y2="190" stroke="#cbd5e1" stroke-width="2" stroke-dasharray="4 4"/>
+  <polygon points="970,190 962,186 962,194" fill="#cbd5e1"/>
+  <line x1="918" y1="256" x2="970" y2="280" stroke="#cbd5e1" stroke-width="2" stroke-dasharray="4 4"/>
+  <polygon points="970,280 962,276 964,284" fill="#cbd5e1"/>
+
+  <g transform="translate(975, 60)" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif">
+    <rect width="190" height="260" rx="14" fill="#ffffff" stroke="#059669" stroke-width="1.5"/>
+    <text x="95" y="32" text-anchor="middle" fill="#0f172a" font-size="13" font-weight="600">Outputs</text>
+
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.30;0.40;1" dur="5s" repeatCount="indefinite"/>
+      <rect x="20" y="50" width="150" height="50" rx="10" fill="#ecfdf5" stroke="#059669" stroke-width="1.5"/>
+      <text x="36" y="74" fill="#065f46" font-size="13" font-weight="600">📊  HTML</text>
+      <text x="36" y="92" fill="#64748b" font-size="9">interactive graph</text>
+    </g>
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.40;0.50;1" dur="5s" repeatCount="indefinite"/>
+      <rect x="20" y="116" width="150" height="50" rx="10" fill="#ecfdf5" stroke="#059669" stroke-width="1.5"/>
+      <text x="36" y="140" fill="#065f46" font-size="13" font-weight="600">📝  Markdown</text>
+      <text x="36" y="158" fill="#64748b" font-size="9">CI/CD tables</text>
+    </g>
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.50;0.60;1" dur="5s" repeatCount="indefinite"/>
+      <rect x="20" y="182" width="150" height="50" rx="10" fill="#ecfdf5" stroke="#059669" stroke-width="1.5"/>
+      <text x="36" y="206" fill="#065f46" font-size="13" font-weight="600">📦  JSON</text>
+      <text x="36" y="224" fill="#64748b" font-size="9">machine-parseable</text>
+    </g>
+  </g>
+</svg>

--- a/docs/assets/report-dark.svg
+++ b/docs/assets/report-dark.svg
@@ -1,0 +1,193 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 500" role="img" aria-label="ZIRAN HTML campaign report mock-up: header with target metadata, four severity counters (3 critical, 7 high, 12 medium, 28 low), a findings table on the left listing the top tool-chain vulnerabilities, and a live knowledge graph on the right with the critical data-exfiltration path read_file to http_request highlighted." preserveAspectRatio="xMidYMid meet">
+  <title>ZIRAN HTML Campaign Report</title>
+  <desc>Animated mock-up of a ZIRAN HTML report. The header strip shows the campaign target, phase count, vector count, and timestamp. A counter row lists 3 critical, 7 high, 12 medium, and 28 low findings — the critical count gently pulses to indicate live updates. The left pane is a findings table where rows fade in sequentially: read_file to http_request flagged as critical data exfiltration, sql_query to exec_code flagged as critical SQL-to-RCE, and additional high and medium findings. The right pane is a live knowledge graph showing the agent and its tools, with a pulsing red edge tracing the critical data-exfiltration path. Keywords: HTML report, security findings, severity counters, knowledge graph, attack path, tool chain.</desc>
+
+  <rect width="1200" height="500" fill="#0f172a" rx="16"/>
+  <rect x="0.5" y="0.5" width="1199" height="499" fill="none" stroke="#1e293b" rx="16"/>
+
+  <!-- ============ HEADER STRIP ============ -->
+  <rect x="0" y="0" width="1200" height="60" fill="#0c1220" rx="16"/>
+  <rect x="0" y="44" width="1200" height="16" fill="#0c1220"/>
+  <text x="40" y="38" fill="#f1f5f9" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="18" font-weight="700">📊  ZIRAN Campaign Report</text>
+  <text x="600" y="38" text-anchor="middle" fill="#94a3b8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11">target: my-agent  ·  8 phases  ·  42 vectors  ·  2026-05-02 14:32 UTC</text>
+  <text x="1160" y="38" text-anchor="end" fill="#64748b" font-family="ui-monospace, SFMono-Regular, monospace" font-size="11">v0.30.0</text>
+
+  <!-- ============ COUNTER ROW ============ -->
+  <g transform="translate(40, 78)" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif">
+    <!-- Critical -->
+    <rect x="0" y="0" width="270" height="80" rx="12" fill="#1e293b" stroke="#e94560" stroke-width="1.5">
+      <animate attributeName="stroke-width" values="1.5;3;1.5" dur="2s" repeatCount="indefinite"/>
+    </rect>
+    <text x="20" y="50" fill="#e94560" font-size="42" font-weight="800">3</text>
+    <text x="20" y="68" fill="#fecaca" font-size="11" font-weight="700" letter-spacing="2">CRITICAL</text>
+    <circle cx="246" cy="20" r="6" fill="#e94560">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="1.4s" repeatCount="indefinite"/>
+    </circle>
+
+    <!-- High -->
+    <rect x="290" y="0" width="270" height="80" rx="12" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
+    <text x="310" y="50" fill="#f59e0b" font-size="42" font-weight="800">7</text>
+    <text x="310" y="68" fill="#fde68a" font-size="11" font-weight="700" letter-spacing="2">HIGH</text>
+
+    <!-- Medium -->
+    <rect x="580" y="0" width="270" height="80" rx="12" fill="#1e293b" stroke="#0ea5e9" stroke-width="1.5"/>
+    <text x="600" y="50" fill="#0ea5e9" font-size="42" font-weight="800">12</text>
+    <text x="600" y="68" fill="#bae6fd" font-size="11" font-weight="700" letter-spacing="2">MEDIUM</text>
+
+    <!-- Low -->
+    <rect x="870" y="0" width="270" height="80" rx="12" fill="#1e293b" stroke="#10b981" stroke-width="1.5"/>
+    <text x="890" y="50" fill="#10b981" font-size="42" font-weight="800">28</text>
+    <text x="890" y="68" fill="#a7f3d0" font-size="11" font-weight="700" letter-spacing="2">LOW</text>
+  </g>
+
+  <!-- ============ FINDINGS TABLE (left) ============ -->
+  <g transform="translate(40, 180)" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif">
+    <rect width="720" height="280" rx="12" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+    <text x="20" y="28" fill="#f1f5f9" font-size="13" font-weight="700">Findings  <tspan fill="#64748b" font-weight="400">(top 5 of 50)</tspan></text>
+
+    <!-- table header -->
+    <rect x="12" y="42" width="696" height="26" rx="6" fill="#0f172a"/>
+    <text x="28"  y="59" fill="#64748b" font-size="9" font-weight="700" letter-spacing="1.5">SEVERITY</text>
+    <text x="120" y="59" fill="#64748b" font-size="9" font-weight="700" letter-spacing="1.5">TYPE</text>
+    <text x="280" y="59" fill="#64748b" font-size="9" font-weight="700" letter-spacing="1.5">TOOLS</text>
+    <text x="500" y="59" fill="#64748b" font-size="9" font-weight="700" letter-spacing="1.5">DESCRIPTION</text>
+
+    <!-- row 1 — CRITICAL · data_exfiltration -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.04;0.10;1" dur="6s" repeatCount="indefinite"/>
+      <rect x="12" y="76" width="696" height="34" rx="6" fill="#1a0e12" stroke="#e94560" stroke-width="1"/>
+      <rect x="24" y="84" width="62" height="18" rx="3" fill="#e94560"/>
+      <text x="55" y="97" text-anchor="middle" fill="#fff" font-size="9" font-weight="700">CRITICAL</text>
+      <text x="120" y="98" fill="#fecaca" font-size="11">data_exfiltration</text>
+      <text x="280" y="98" fill="#cbd5e1" font-family="ui-monospace, SFMono-Regular, monospace" font-size="10">read_file → http_request</text>
+      <text x="500" y="98" fill="#94a3b8" font-size="10">file contents sent to external server</text>
+    </g>
+
+    <!-- row 2 — CRITICAL · sql_to_rce -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.14;0.20;1" dur="6s" repeatCount="indefinite"/>
+      <rect x="12" y="118" width="696" height="34" rx="6" fill="#1a0e12" stroke="#e94560" stroke-width="1"/>
+      <rect x="24" y="126" width="62" height="18" rx="3" fill="#e94560"/>
+      <text x="55" y="139" text-anchor="middle" fill="#fff" font-size="9" font-weight="700">CRITICAL</text>
+      <text x="120" y="140" fill="#fecaca" font-size="11">sql_to_rce</text>
+      <text x="280" y="140" fill="#cbd5e1" font-family="ui-monospace, SFMono-Regular, monospace" font-size="10">sql_query → exec_code</text>
+      <text x="500" y="140" fill="#94a3b8" font-size="10">SQL results executed as code</text>
+    </g>
+
+    <!-- row 3 — HIGH · pii_leakage -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.24;0.30;1" dur="6s" repeatCount="indefinite"/>
+      <rect x="12" y="160" width="696" height="34" rx="6" fill="#1a1408" stroke="#f59e0b" stroke-width="1"/>
+      <rect x="24" y="168" width="42" height="18" rx="3" fill="#f59e0b"/>
+      <text x="45" y="181" text-anchor="middle" fill="#fff" font-size="9" font-weight="700">HIGH</text>
+      <text x="120" y="182" fill="#fde68a" font-size="11">pii_leakage</text>
+      <text x="280" y="182" fill="#cbd5e1" font-family="ui-monospace, SFMono-Regular, monospace" font-size="10">get_user_info → external_api</text>
+      <text x="500" y="182" fill="#94a3b8" font-size="10">user PII to third-party API</text>
+    </g>
+
+    <!-- row 4 — HIGH · prompt_injection -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.34;0.40;1" dur="6s" repeatCount="indefinite"/>
+      <rect x="12" y="202" width="696" height="34" rx="6" fill="#1a1408" stroke="#f59e0b" stroke-width="1"/>
+      <rect x="24" y="210" width="42" height="18" rx="3" fill="#f59e0b"/>
+      <text x="45" y="223" text-anchor="middle" fill="#fff" font-size="9" font-weight="700">HIGH</text>
+      <text x="120" y="224" fill="#fde68a" font-size="11">prompt_injection</text>
+      <text x="280" y="224" fill="#cbd5e1" font-family="ui-monospace, SFMono-Regular, monospace" font-size="10">memory + system_prompt</text>
+      <text x="500" y="224" fill="#94a3b8" font-size="10">system prompt extracted via memory</text>
+    </g>
+
+    <!-- row 5 — MEDIUM · trust_boundary -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.44;0.50;1" dur="6s" repeatCount="indefinite"/>
+      <rect x="12" y="244" width="696" height="34" rx="6" fill="#0a1620" stroke="#0ea5e9" stroke-width="1"/>
+      <rect x="24" y="252" width="58" height="18" rx="3" fill="#0ea5e9"/>
+      <text x="53" y="265" text-anchor="middle" fill="#fff" font-size="9" font-weight="700">MEDIUM</text>
+      <text x="120" y="266" fill="#bae6fd" font-size="11">trust_boundary</text>
+      <text x="280" y="266" fill="#cbd5e1" font-family="ui-monospace, SFMono-Regular, monospace" font-size="10">peer_message accepted</text>
+      <text x="500" y="266" fill="#94a3b8" font-size="10">no validation across multi-agent peers</text>
+    </g>
+  </g>
+
+  <!-- ============ KG VISUALIZATION (right) ============ -->
+  <g transform="translate(780, 180)" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif">
+    <rect width="380" height="280" rx="12" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+    <text x="20" y="28" fill="#f1f5f9" font-size="13" font-weight="700">Knowledge Graph  <tspan fill="#10b981" font-size="10">● live</tspan></text>
+
+    <!-- agent root -->
+    <g>
+      <circle cx="190" cy="64" r="22" fill="#0f172a" stroke="#0ea5e9" stroke-width="2"/>
+      <text x="190" y="68" text-anchor="middle" fill="#0ea5e9" font-family="ui-monospace, SFMono-Regular, monospace" font-size="10" font-weight="700">agent</text>
+    </g>
+
+    <!-- edges from agent to tools -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.10;0.20;1" dur="6s" repeatCount="indefinite"/>
+      <line x1="172" y1="80" x2="80"  y2="124" stroke="#475569" stroke-width="1.5"/>
+      <line x1="180" y1="86" x2="140" y2="124" stroke="#475569" stroke-width="1.5"/>
+      <line x1="200" y1="86" x2="240" y2="124" stroke="#475569" stroke-width="1.5"/>
+      <line x1="208" y1="80" x2="300" y2="124" stroke="#475569" stroke-width="1.5"/>
+    </g>
+
+    <!-- tool nodes -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.12;0.22;1" dur="6s" repeatCount="indefinite"/>
+      <circle cx="80"  cy="140" r="22" fill="#0f172a" stroke="#94a3b8" stroke-width="1.5"/>
+      <text x="80"  y="144" text-anchor="middle" fill="#cbd5e1" font-family="ui-monospace, SFMono-Regular, monospace" font-size="9">read_file</text>
+
+      <circle cx="140" cy="140" r="22" fill="#0f172a" stroke="#94a3b8" stroke-width="1.5"/>
+      <text x="140" y="144" text-anchor="middle" fill="#cbd5e1" font-family="ui-monospace, SFMono-Regular, monospace" font-size="9">http_req</text>
+
+      <circle cx="240" cy="140" r="22" fill="#0f172a" stroke="#94a3b8" stroke-width="1.5"/>
+      <text x="240" y="144" text-anchor="middle" fill="#cbd5e1" font-family="ui-monospace, SFMono-Regular, monospace" font-size="9">sql_query</text>
+
+      <circle cx="300" cy="140" r="22" fill="#0f172a" stroke="#94a3b8" stroke-width="1.5"/>
+      <text x="300" y="144" text-anchor="middle" fill="#cbd5e1" font-family="ui-monospace, SFMono-Regular, monospace" font-size="9">exec_code</text>
+    </g>
+
+    <!-- CRITICAL attack path: read_file → http_req -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.30;0.40;1" dur="6s" repeatCount="indefinite"/>
+      <line x1="102" y1="140" x2="118" y2="140" stroke="#e94560" stroke-width="3"/>
+      <polygon points="120,140 112,136 112,144" fill="#e94560"/>
+    </g>
+    <!-- packet -->
+    <circle cy="140" r="3.5" fill="#e94560" opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.30;0.40;1" dur="6s" repeatCount="indefinite"/>
+      <animate attributeName="cx" values="102;118;102" dur="1.4s" repeatCount="indefinite"/>
+    </circle>
+
+    <!-- CRITICAL attack path: sql_query → exec_code -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.42;0.50;1" dur="6s" repeatCount="indefinite"/>
+      <line x1="262" y1="140" x2="278" y2="140" stroke="#f59e0b" stroke-width="3"/>
+      <polygon points="280,140 272,136 272,144" fill="#f59e0b"/>
+    </g>
+    <circle cy="140" r="3.5" fill="#f59e0b" opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.42;0.50;1" dur="6s" repeatCount="indefinite"/>
+      <animate attributeName="cx" values="262;278;262" dur="1.4s" repeatCount="indefinite"/>
+    </circle>
+
+    <!-- attack path callouts -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.50;0.60;1" dur="6s" repeatCount="indefinite"/>
+      <rect x="50" y="178" width="120" height="22" rx="4" fill="#7f1d1d" stroke="#e94560"/>
+      <text x="110" y="192" text-anchor="middle" fill="#fff" font-size="9" font-weight="700">⚠ data_exfil</text>
+
+      <rect x="210" y="178" width="120" height="22" rx="4" fill="#78350f" stroke="#f59e0b"/>
+      <text x="270" y="192" text-anchor="middle" fill="#fff" font-size="9" font-weight="700">⚠ sql_to_rce</text>
+    </g>
+
+    <!-- summary line at bottom -->
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.60;0.70;1" dur="6s" repeatCount="indefinite"/>
+      <line x1="20" y1="220" x2="360" y2="220" stroke="#334155" stroke-width="1"/>
+      <text x="20" y="244" fill="#94a3b8" font-size="10">interactive: click a node to highlight its</text>
+      <text x="20" y="258" fill="#94a3b8" font-size="10">attack paths and remediation guidance</text>
+      <rect x="240" y="232" width="120" height="28" rx="6" fill="#0f172a" stroke="#10b981"/>
+      <text x="300" y="250" text-anchor="middle" fill="#10b981" font-size="11" font-weight="700">view full report →</text>
+    </g>
+  </g>
+
+  <!-- footer -->
+  <text x="600" y="486" text-anchor="middle" fill="#475569" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-style="italic">HTML  ·  Markdown  ·  JSON  ·  SARIF  —  generated to ./reports/campaign_2026-05-02T14-32_report.html</text>
+</svg>

--- a/docs/assets/report-light.svg
+++ b/docs/assets/report-light.svg
@@ -1,0 +1,170 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 500" role="img" aria-label="ZIRAN HTML campaign report mock-up: header with target metadata, four severity counters (3 critical, 7 high, 12 medium, 28 low), a findings table on the left listing the top tool-chain vulnerabilities, and a live knowledge graph on the right with the critical data-exfiltration path read_file to http_request highlighted." preserveAspectRatio="xMidYMid meet">
+  <title>ZIRAN HTML Campaign Report</title>
+  <desc>Animated mock-up of a ZIRAN HTML report. The header strip shows the campaign target, phase count, vector count, and timestamp. A counter row lists 3 critical, 7 high, 12 medium, and 28 low findings — the critical count gently pulses to indicate live updates. The left pane is a findings table where rows fade in sequentially: read_file to http_request flagged as critical data exfiltration, sql_query to exec_code flagged as critical SQL-to-RCE, and additional high and medium findings. The right pane is a live knowledge graph showing the agent and its tools, with a pulsing red edge tracing the critical data-exfiltration path. Keywords: HTML report, security findings, severity counters, knowledge graph, attack path, tool chain.</desc>
+
+  <rect width="1200" height="500" fill="#f8fafc" rx="16"/>
+  <rect x="0.5" y="0.5" width="1199" height="499" fill="none" stroke="#e2e8f0" rx="16"/>
+
+  <!-- HEADER STRIP -->
+  <rect x="0" y="0" width="1200" height="60" fill="#0f172a" rx="16"/>
+  <rect x="0" y="44" width="1200" height="16" fill="#0f172a"/>
+  <text x="40" y="38" fill="#f1f5f9" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="18" font-weight="700">📊  ZIRAN Campaign Report</text>
+  <text x="600" y="38" text-anchor="middle" fill="#94a3b8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11">target: my-agent  ·  8 phases  ·  42 vectors  ·  2026-05-02 14:32 UTC</text>
+  <text x="1160" y="38" text-anchor="end" fill="#64748b" font-family="ui-monospace, SFMono-Regular, monospace" font-size="11">v0.30.0</text>
+
+  <!-- COUNTER ROW -->
+  <g transform="translate(40, 78)" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif">
+    <rect x="0" y="0" width="270" height="80" rx="12" fill="#ffffff" stroke="#dc2626" stroke-width="1.5">
+      <animate attributeName="stroke-width" values="1.5;3;1.5" dur="2s" repeatCount="indefinite"/>
+    </rect>
+    <text x="20" y="50" fill="#dc2626" font-size="42" font-weight="800">3</text>
+    <text x="20" y="68" fill="#7f1d1d" font-size="11" font-weight="700" letter-spacing="2">CRITICAL</text>
+    <circle cx="246" cy="20" r="6" fill="#dc2626">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="1.4s" repeatCount="indefinite"/>
+    </circle>
+
+    <rect x="290" y="0" width="270" height="80" rx="12" fill="#ffffff" stroke="#d97706" stroke-width="1.5"/>
+    <text x="310" y="50" fill="#d97706" font-size="42" font-weight="800">7</text>
+    <text x="310" y="68" fill="#78350f" font-size="11" font-weight="700" letter-spacing="2">HIGH</text>
+
+    <rect x="580" y="0" width="270" height="80" rx="12" fill="#ffffff" stroke="#0284c7" stroke-width="1.5"/>
+    <text x="600" y="50" fill="#0284c7" font-size="42" font-weight="800">12</text>
+    <text x="600" y="68" fill="#0c4a6e" font-size="11" font-weight="700" letter-spacing="2">MEDIUM</text>
+
+    <rect x="870" y="0" width="270" height="80" rx="12" fill="#ffffff" stroke="#059669" stroke-width="1.5"/>
+    <text x="890" y="50" fill="#059669" font-size="42" font-weight="800">28</text>
+    <text x="890" y="68" fill="#065f46" font-size="11" font-weight="700" letter-spacing="2">LOW</text>
+  </g>
+
+  <!-- FINDINGS TABLE -->
+  <g transform="translate(40, 180)" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif">
+    <rect width="720" height="280" rx="12" fill="#ffffff" stroke="#cbd5e1" stroke-width="1"/>
+    <text x="20" y="28" fill="#0f172a" font-size="13" font-weight="700">Findings  <tspan fill="#94a3b8" font-weight="400">(top 5 of 50)</tspan></text>
+
+    <rect x="12" y="42" width="696" height="26" rx="6" fill="#f1f5f9"/>
+    <text x="28"  y="59" fill="#64748b" font-size="9" font-weight="700" letter-spacing="1.5">SEVERITY</text>
+    <text x="120" y="59" fill="#64748b" font-size="9" font-weight="700" letter-spacing="1.5">TYPE</text>
+    <text x="280" y="59" fill="#64748b" font-size="9" font-weight="700" letter-spacing="1.5">TOOLS</text>
+    <text x="500" y="59" fill="#64748b" font-size="9" font-weight="700" letter-spacing="1.5">DESCRIPTION</text>
+
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.04;0.10;1" dur="6s" repeatCount="indefinite"/>
+      <rect x="12" y="76" width="696" height="34" rx="6" fill="#fef2f2" stroke="#fecaca" stroke-width="1"/>
+      <rect x="24" y="84" width="62" height="18" rx="3" fill="#dc2626"/>
+      <text x="55" y="97" text-anchor="middle" fill="#fff" font-size="9" font-weight="700">CRITICAL</text>
+      <text x="120" y="98" fill="#7f1d1d" font-size="11">data_exfiltration</text>
+      <text x="280" y="98" fill="#334155" font-family="ui-monospace, SFMono-Regular, monospace" font-size="10">read_file → http_request</text>
+      <text x="500" y="98" fill="#64748b" font-size="10">file contents sent to external server</text>
+    </g>
+
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.14;0.20;1" dur="6s" repeatCount="indefinite"/>
+      <rect x="12" y="118" width="696" height="34" rx="6" fill="#fef2f2" stroke="#fecaca" stroke-width="1"/>
+      <rect x="24" y="126" width="62" height="18" rx="3" fill="#dc2626"/>
+      <text x="55" y="139" text-anchor="middle" fill="#fff" font-size="9" font-weight="700">CRITICAL</text>
+      <text x="120" y="140" fill="#7f1d1d" font-size="11">sql_to_rce</text>
+      <text x="280" y="140" fill="#334155" font-family="ui-monospace, SFMono-Regular, monospace" font-size="10">sql_query → exec_code</text>
+      <text x="500" y="140" fill="#64748b" font-size="10">SQL results executed as code</text>
+    </g>
+
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.24;0.30;1" dur="6s" repeatCount="indefinite"/>
+      <rect x="12" y="160" width="696" height="34" rx="6" fill="#fffbeb" stroke="#fde68a" stroke-width="1"/>
+      <rect x="24" y="168" width="42" height="18" rx="3" fill="#d97706"/>
+      <text x="45" y="181" text-anchor="middle" fill="#fff" font-size="9" font-weight="700">HIGH</text>
+      <text x="120" y="182" fill="#78350f" font-size="11">pii_leakage</text>
+      <text x="280" y="182" fill="#334155" font-family="ui-monospace, SFMono-Regular, monospace" font-size="10">get_user_info → external_api</text>
+      <text x="500" y="182" fill="#64748b" font-size="10">user PII to third-party API</text>
+    </g>
+
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.34;0.40;1" dur="6s" repeatCount="indefinite"/>
+      <rect x="12" y="202" width="696" height="34" rx="6" fill="#fffbeb" stroke="#fde68a" stroke-width="1"/>
+      <rect x="24" y="210" width="42" height="18" rx="3" fill="#d97706"/>
+      <text x="45" y="223" text-anchor="middle" fill="#fff" font-size="9" font-weight="700">HIGH</text>
+      <text x="120" y="224" fill="#78350f" font-size="11">prompt_injection</text>
+      <text x="280" y="224" fill="#334155" font-family="ui-monospace, SFMono-Regular, monospace" font-size="10">memory + system_prompt</text>
+      <text x="500" y="224" fill="#64748b" font-size="10">system prompt extracted via memory</text>
+    </g>
+
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.44;0.50;1" dur="6s" repeatCount="indefinite"/>
+      <rect x="12" y="244" width="696" height="34" rx="6" fill="#f0f9ff" stroke="#bae6fd" stroke-width="1"/>
+      <rect x="24" y="252" width="58" height="18" rx="3" fill="#0284c7"/>
+      <text x="53" y="265" text-anchor="middle" fill="#fff" font-size="9" font-weight="700">MEDIUM</text>
+      <text x="120" y="266" fill="#0c4a6e" font-size="11">trust_boundary</text>
+      <text x="280" y="266" fill="#334155" font-family="ui-monospace, SFMono-Regular, monospace" font-size="10">peer_message accepted</text>
+      <text x="500" y="266" fill="#64748b" font-size="10">no validation across multi-agent peers</text>
+    </g>
+  </g>
+
+  <!-- KG VISUALIZATION -->
+  <g transform="translate(780, 180)" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif">
+    <rect width="380" height="280" rx="12" fill="#ffffff" stroke="#cbd5e1" stroke-width="1"/>
+    <text x="20" y="28" fill="#0f172a" font-size="13" font-weight="700">Knowledge Graph  <tspan fill="#059669" font-size="10">● live</tspan></text>
+
+    <g>
+      <circle cx="190" cy="64" r="22" fill="#f0f9ff" stroke="#0284c7" stroke-width="2"/>
+      <text x="190" y="68" text-anchor="middle" fill="#0284c7" font-family="ui-monospace, SFMono-Regular, monospace" font-size="10" font-weight="700">agent</text>
+    </g>
+
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.10;0.20;1" dur="6s" repeatCount="indefinite"/>
+      <line x1="172" y1="80" x2="80"  y2="124" stroke="#cbd5e1" stroke-width="1.5"/>
+      <line x1="180" y1="86" x2="140" y2="124" stroke="#cbd5e1" stroke-width="1.5"/>
+      <line x1="200" y1="86" x2="240" y2="124" stroke="#cbd5e1" stroke-width="1.5"/>
+      <line x1="208" y1="80" x2="300" y2="124" stroke="#cbd5e1" stroke-width="1.5"/>
+    </g>
+
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.12;0.22;1" dur="6s" repeatCount="indefinite"/>
+      <circle cx="80"  cy="140" r="22" fill="#ffffff" stroke="#94a3b8" stroke-width="1.5"/>
+      <text x="80"  y="144" text-anchor="middle" fill="#334155" font-family="ui-monospace, SFMono-Regular, monospace" font-size="9">read_file</text>
+      <circle cx="140" cy="140" r="22" fill="#ffffff" stroke="#94a3b8" stroke-width="1.5"/>
+      <text x="140" y="144" text-anchor="middle" fill="#334155" font-family="ui-monospace, SFMono-Regular, monospace" font-size="9">http_req</text>
+      <circle cx="240" cy="140" r="22" fill="#ffffff" stroke="#94a3b8" stroke-width="1.5"/>
+      <text x="240" y="144" text-anchor="middle" fill="#334155" font-family="ui-monospace, SFMono-Regular, monospace" font-size="9">sql_query</text>
+      <circle cx="300" cy="140" r="22" fill="#ffffff" stroke="#94a3b8" stroke-width="1.5"/>
+      <text x="300" y="144" text-anchor="middle" fill="#334155" font-family="ui-monospace, SFMono-Regular, monospace" font-size="9">exec_code</text>
+    </g>
+
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.30;0.40;1" dur="6s" repeatCount="indefinite"/>
+      <line x1="102" y1="140" x2="118" y2="140" stroke="#dc2626" stroke-width="3"/>
+      <polygon points="120,140 112,136 112,144" fill="#dc2626"/>
+    </g>
+    <circle cy="140" r="3.5" fill="#dc2626" opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.30;0.40;1" dur="6s" repeatCount="indefinite"/>
+      <animate attributeName="cx" values="102;118;102" dur="1.4s" repeatCount="indefinite"/>
+    </circle>
+
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.42;0.50;1" dur="6s" repeatCount="indefinite"/>
+      <line x1="262" y1="140" x2="278" y2="140" stroke="#d97706" stroke-width="3"/>
+      <polygon points="280,140 272,136 272,144" fill="#d97706"/>
+    </g>
+    <circle cy="140" r="3.5" fill="#d97706" opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.42;0.50;1" dur="6s" repeatCount="indefinite"/>
+      <animate attributeName="cx" values="262;278;262" dur="1.4s" repeatCount="indefinite"/>
+    </circle>
+
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.50;0.60;1" dur="6s" repeatCount="indefinite"/>
+      <rect x="50" y="178" width="120" height="22" rx="4" fill="#dc2626"/>
+      <text x="110" y="192" text-anchor="middle" fill="#fff" font-size="9" font-weight="700">⚠ data_exfil</text>
+      <rect x="210" y="178" width="120" height="22" rx="4" fill="#d97706"/>
+      <text x="270" y="192" text-anchor="middle" fill="#fff" font-size="9" font-weight="700">⚠ sql_to_rce</text>
+    </g>
+
+    <g opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.60;0.70;1" dur="6s" repeatCount="indefinite"/>
+      <line x1="20" y1="220" x2="360" y2="220" stroke="#e2e8f0" stroke-width="1"/>
+      <text x="20" y="244" fill="#64748b" font-size="10">interactive: click a node to highlight its</text>
+      <text x="20" y="258" fill="#64748b" font-size="10">attack paths and remediation guidance</text>
+      <rect x="240" y="232" width="120" height="28" rx="6" fill="#f0fdf4" stroke="#059669"/>
+      <text x="300" y="250" text-anchor="middle" fill="#059669" font-size="11" font-weight="700">view full report →</text>
+    </g>
+  </g>
+
+  <text x="600" y="486" text-anchor="middle" fill="#94a3b8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-style="italic">HTML  ·  Markdown  ·  JSON  ·  SARIF  —  generated to ./reports/campaign_2026-05-02T14-32_report.html</text>
+</svg>

--- a/docs/assets/sideeffect-dark.svg
+++ b/docs/assets/sideeffect-dark.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 360" role="img" aria-labelledby="se-title se-desc" preserveAspectRatio="xMidYMid meet">
+  <title id="se-title">ZIRAN side-effect detection: chat is not the truth</title>
+  <desc id="se-desc">Two stacked layers showing the gap between an agent's text response and its actual execution. On the surface layer, the user asks "Delete user 42" and the agent replies "I'm sorry, I can't do that — request refused" — a chat-only scanner marks this as safe. On the execution layer below, ZIRAN intercepts the actual tool call: delete_user(id=42) was executed and a row was removed from the database. The mismatch is flagged as critical. Keywords: side-effect detection, execution-level monitoring, silent failure, tool call interception, agent honesty, refusal bypass.</desc>
+
+  <rect width="1200" height="360" fill="#0f172a" rx="16"/>
+  <rect x="0.5" y="0.5" width="1199" height="359" fill="none" stroke="#1e293b" rx="16"/>
+
+  <text x="600" y="36" text-anchor="middle" fill="#64748b" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" letter-spacing="3">SIDE-EFFECT DETECTION</text>
+
+  <!-- ===== SURFACE LAYER ===== -->
+  <text x="60" y="74" fill="#10b981" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" letter-spacing="2">SURFACE — what the agent says</text>
+
+  <!-- User message -->
+  <g transform="translate(60, 88)">
+    <rect width="260" height="56" rx="12" fill="#1e3a8a"/>
+    <text x="20" y="22" fill="#bfdbfe" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10" font-weight="700" letter-spacing="1">USER</text>
+    <text x="20" y="44" fill="#dbeafe" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14">Delete user 42</text>
+  </g>
+
+  <!-- arrow → -->
+  <line x1="328" y1="116" x2="368" y2="116" stroke="#475569" stroke-width="2" stroke-dasharray="3 3"/>
+  <polygon points="368,116 360,112 360,120" fill="#475569"/>
+
+  <!-- Agent text response (looks safe) -->
+  <g transform="translate(376, 88)">
+    <rect width="500" height="56" rx="12" fill="#064e3b"/>
+    <text x="20" y="22" fill="#a7f3d0" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10" font-weight="700" letter-spacing="1">🤖  AGENT TEXT</text>
+    <text x="20" y="44" fill="#d1fae5" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14">"I'm sorry, I can't do that — request refused."</text>
+  </g>
+
+  <!-- Verdict pill -->
+  <g transform="translate(900, 88)">
+    <rect width="240" height="56" rx="12" fill="#1e293b" stroke="#10b981" stroke-width="1.5"/>
+    <text x="20" y="22" fill="#10b981" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10" font-weight="700" letter-spacing="1">CHAT-ONLY VERDICT</text>
+    <text x="20" y="44" fill="#a7f3d0" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14">✓  refused — looks safe</text>
+  </g>
+
+  <!-- ===== DIVIDER ===== -->
+  <line x1="60" y1="184" x2="1140" y2="184" stroke="#334155" stroke-width="1" stroke-dasharray="2 4"/>
+  <g>
+    <rect x="430" y="172" width="340" height="22" rx="11" fill="#0f172a" stroke="#fbbf24" stroke-width="1"/>
+    <text x="600" y="187" text-anchor="middle" fill="#fbbf24" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10" font-weight="700" letter-spacing="2">↓  ZIRAN intercepts at execution layer  ↓</text>
+  </g>
+
+  <!-- ===== EXECUTION LAYER ===== -->
+  <text x="60" y="222" fill="#fca5a5" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" letter-spacing="2">EXECUTION — what actually fired</text>
+
+  <g transform="translate(60, 236)">
+    <rect width="1080" height="78" rx="12" fill="#450a0a" stroke="#e94560" stroke-width="1.5">
+      <animate attributeName="stroke-width" values="1.5;3;1.5" dur="1.8s" repeatCount="indefinite"/>
+    </rect>
+
+    <!-- code lines -->
+    <text x="20" y="28" fill="#fca5a5" font-family="ui-monospace, SFMono-Regular, monospace" font-size="13">▸ tool_call:  <tspan fill="#fff" font-weight="700">delete_user(id=42)</tspan></text>
+    <text x="20" y="50" fill="#fda4af" font-family="ui-monospace, SFMono-Regular, monospace" font-size="11">  └─ executed · row deleted from db · 0 errors raised to caller</text>
+    <text x="20" y="68" fill="#fca5a5" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10" font-style="italic">no chat-layer signal of this — the agent's text claimed refusal</text>
+
+    <!-- pulsing critical badge -->
+    <g transform="translate(900, 16)">
+      <rect width="160" height="46" rx="6" fill="#e94560">
+        <animate attributeName="opacity" values="0.75;1;0.75" dur="1.5s" repeatCount="indefinite"/>
+      </rect>
+      <text x="80" y="22" text-anchor="middle" fill="#fff" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700">⚠  CRITICAL</text>
+      <text x="80" y="38" text-anchor="middle" fill="#fff" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10">silent execution</text>
+    </g>
+  </g>
+
+  <text x="600" y="338" text-anchor="middle" fill="#475569" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-style="italic">Agents can refuse in text while still executing the dangerous call. Chat-only scanners miss this entirely.</text>
+</svg>

--- a/docs/assets/sideeffect-light.svg
+++ b/docs/assets/sideeffect-light.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 360" role="img" aria-labelledby="se-title se-desc" preserveAspectRatio="xMidYMid meet">
+  <title id="se-title">ZIRAN side-effect detection: chat is not the truth</title>
+  <desc id="se-desc">Two stacked layers showing the gap between an agent's text response and its actual execution. On the surface layer, the user asks "Delete user 42" and the agent replies "I'm sorry, I can't do that — request refused" — a chat-only scanner marks this as safe. On the execution layer below, ZIRAN intercepts the actual tool call: delete_user(id=42) was executed and a row was removed from the database. The mismatch is flagged as critical. Keywords: side-effect detection, execution-level monitoring, silent failure, tool call interception, agent honesty, refusal bypass.</desc>
+
+  <rect width="1200" height="360" fill="#f8fafc" rx="16"/>
+  <rect x="0.5" y="0.5" width="1199" height="359" fill="none" stroke="#e2e8f0" rx="16"/>
+
+  <text x="600" y="36" text-anchor="middle" fill="#64748b" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" letter-spacing="3">SIDE-EFFECT DETECTION</text>
+
+  <!-- ===== SURFACE LAYER ===== -->
+  <text x="60" y="74" fill="#059669" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" letter-spacing="2">SURFACE — what the agent says</text>
+
+  <!-- User message -->
+  <g transform="translate(60, 88)">
+    <rect width="260" height="56" rx="12" fill="#dbeafe" stroke="#bfdbfe"/>
+    <text x="20" y="22" fill="#1e40af" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10" font-weight="700" letter-spacing="1">USER</text>
+    <text x="20" y="44" fill="#1e3a8a" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14">Delete user 42</text>
+  </g>
+
+  <line x1="328" y1="116" x2="368" y2="116" stroke="#cbd5e1" stroke-width="2" stroke-dasharray="3 3"/>
+  <polygon points="368,116 360,112 360,120" fill="#cbd5e1"/>
+
+  <g transform="translate(376, 88)">
+    <rect width="500" height="56" rx="12" fill="#d1fae5" stroke="#a7f3d0"/>
+    <text x="20" y="22" fill="#065f46" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10" font-weight="700" letter-spacing="1">🤖  AGENT TEXT</text>
+    <text x="20" y="44" fill="#064e3b" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14">"I'm sorry, I can't do that — request refused."</text>
+  </g>
+
+  <g transform="translate(900, 88)">
+    <rect width="240" height="56" rx="12" fill="#ffffff" stroke="#059669" stroke-width="1.5"/>
+    <text x="20" y="22" fill="#059669" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10" font-weight="700" letter-spacing="1">CHAT-ONLY VERDICT</text>
+    <text x="20" y="44" fill="#065f46" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14">✓  refused — looks safe</text>
+  </g>
+
+  <!-- ===== DIVIDER ===== -->
+  <line x1="60" y1="184" x2="1140" y2="184" stroke="#cbd5e1" stroke-width="1" stroke-dasharray="2 4"/>
+  <rect x="430" y="172" width="340" height="22" rx="11" fill="#fffbeb" stroke="#d97706" stroke-width="1"/>
+  <text x="600" y="187" text-anchor="middle" fill="#d97706" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10" font-weight="700" letter-spacing="2">↓  ZIRAN intercepts at execution layer  ↓</text>
+
+  <!-- ===== EXECUTION LAYER ===== -->
+  <text x="60" y="222" fill="#dc2626" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" letter-spacing="2">EXECUTION — what actually fired</text>
+
+  <g transform="translate(60, 236)">
+    <rect width="1080" height="78" rx="12" fill="#fef2f2" stroke="#dc2626" stroke-width="1.5">
+      <animate attributeName="stroke-width" values="1.5;3;1.5" dur="1.8s" repeatCount="indefinite"/>
+    </rect>
+
+    <text x="20" y="28" fill="#7f1d1d" font-family="ui-monospace, SFMono-Regular, monospace" font-size="13">▸ tool_call:  <tspan fill="#450a0a" font-weight="700">delete_user(id=42)</tspan></text>
+    <text x="20" y="50" fill="#991b1b" font-family="ui-monospace, SFMono-Regular, monospace" font-size="11">  └─ executed · row deleted from db · 0 errors raised to caller</text>
+    <text x="20" y="68" fill="#b91c1c" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10" font-style="italic">no chat-layer signal of this — the agent's text claimed refusal</text>
+
+    <g transform="translate(900, 16)">
+      <rect width="160" height="46" rx="6" fill="#dc2626">
+        <animate attributeName="opacity" values="0.75;1;0.75" dur="1.5s" repeatCount="indefinite"/>
+      </rect>
+      <text x="80" y="22" text-anchor="middle" fill="#fff" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700">⚠  CRITICAL</text>
+      <text x="80" y="38" text-anchor="middle" fill="#fff" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10">silent execution</text>
+    </g>
+  </g>
+
+  <text x="600" y="338" text-anchor="middle" fill="#94a3b8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-style="italic">Agents can refuse in text while still executing the dangerous call. Chat-only scanners miss this entirely.</text>
+</svg>

--- a/docs/assets/star-btn-dark.svg
+++ b/docs/assets/star-btn-dark.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 36" role="img" aria-labelledby="star-title" preserveAspectRatio="xMidYMid meet">
+  <title id="star-title">Star ZIRAN on GitHub</title>
+
+  <!-- button body -->
+  <rect x="0.5" y="0.5" width="159" height="35" rx="8" fill="#1e293b" stroke="#475569" stroke-width="1"/>
+
+  <!-- subtle hover shimmer overlay -->
+  <rect x="0.5" y="0.5" width="159" height="35" rx="8" fill="#fbbf24" opacity="0">
+    <animate attributeName="opacity" values="0;0.08;0" dur="3s" repeatCount="indefinite"/>
+  </rect>
+
+  <!-- star icon (fills yellow on a loop) -->
+  <g transform="translate(14, 6)">
+    <path d="M 12 0 L 14.7 8.3 L 23.4 8.3 L 16.4 13.4 L 19.1 21.7 L 12 16.6 L 4.9 21.7 L 7.6 13.4 L 0.6 8.3 L 9.3 8.3 Z"
+          fill="#475569" stroke="#fbbf24" stroke-width="1" stroke-linejoin="round">
+      <animate attributeName="fill"
+               values="#475569;#fbbf24;#fbbf24;#fbbf24;#475569"
+               keyTimes="0;0.25;0.5;0.75;1"
+               dur="3s" repeatCount="indefinite"/>
+    </path>
+    <!-- twinkle sparkle (top-right of star) -->
+    <circle cx="22" cy="2" r="1.2" fill="#fbbf24" opacity="0">
+      <animate attributeName="opacity" values="0;1;0" keyTimes="0;0.3;0.6" dur="3s" repeatCount="indefinite"/>
+      <animate attributeName="r" values="0.5;1.6;0.5" keyTimes="0;0.3;0.6" dur="3s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+
+  <!-- label -->
+  <text x="48" y="23" fill="#f1f5f9" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">Star on GitHub</text>
+</svg>

--- a/docs/assets/star-btn-light.svg
+++ b/docs/assets/star-btn-light.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 36" role="img" aria-labelledby="star-title" preserveAspectRatio="xMidYMid meet">
+  <title id="star-title">Star ZIRAN on GitHub</title>
+
+  <!-- button body -->
+  <rect x="0.5" y="0.5" width="159" height="35" rx="8" fill="#ffffff" stroke="#cbd5e1" stroke-width="1"/>
+
+  <!-- subtle hover shimmer overlay -->
+  <rect x="0.5" y="0.5" width="159" height="35" rx="8" fill="#fbbf24" opacity="0">
+    <animate attributeName="opacity" values="0;0.10;0" dur="3s" repeatCount="indefinite"/>
+  </rect>
+
+  <!-- star icon (fills yellow on a loop) -->
+  <g transform="translate(14, 6)">
+    <path d="M 12 0 L 14.7 8.3 L 23.4 8.3 L 16.4 13.4 L 19.1 21.7 L 12 16.6 L 4.9 21.7 L 7.6 13.4 L 0.6 8.3 L 9.3 8.3 Z"
+          fill="#e2e8f0" stroke="#d97706" stroke-width="1" stroke-linejoin="round">
+      <animate attributeName="fill"
+               values="#e2e8f0;#fbbf24;#fbbf24;#fbbf24;#e2e8f0"
+               keyTimes="0;0.25;0.5;0.75;1"
+               dur="3s" repeatCount="indefinite"/>
+    </path>
+    <!-- twinkle sparkle -->
+    <circle cx="22" cy="2" r="1.2" fill="#d97706" opacity="0">
+      <animate attributeName="opacity" values="0;1;0" keyTimes="0;0.3;0.6" dur="3s" repeatCount="indefinite"/>
+      <animate attributeName="r" values="0.5;1.6;0.5" keyTimes="0;0.3;0.6" dur="3s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+
+  <!-- label -->
+  <text x="48" y="23" fill="#0f172a" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">Star on GitHub</text>
+</svg>

--- a/docs/assets/toolchain-dark.svg
+++ b/docs/assets/toolchain-dark.svg
@@ -1,0 +1,95 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 340" role="img" aria-labelledby="tc-title tc-desc" preserveAspectRatio="xMidYMid meet">
+  <title id="tc-title">ZIRAN tool-chain discovery: graph beats list</title>
+  <desc id="tc-desc">A side-by-side comparison. On the left, a list-based scanner sees four individually-safe tools (read_file, http_request, sql_query, exec_code) and reports no findings. On the right, ZIRAN walks the capability graph and surfaces dangerous transitive compositions: read_file flows to http_request as a critical data exfiltration chain, and sql_query flows to exec_code as a high-severity SQL-to-RCE chain. Keywords: tool chain analysis, capability graph, transitive attack path, data exfiltration, SQL injection, remote code execution, agent security.</desc>
+
+  <rect width="1200" height="340" fill="#0f172a" rx="16"/>
+  <rect x="0.5" y="0.5" width="1199" height="339" fill="none" stroke="#1e293b" rx="16"/>
+
+  <text x="600" y="36" text-anchor="middle" fill="#64748b" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" letter-spacing="3">TOOL-CHAIN DISCOVERY</text>
+
+  <!-- ===== LEFT: list view ===== -->
+  <g transform="translate(40, 64)">
+    <text x="240" y="16" text-anchor="middle" fill="#94a3b8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="600">List-based scanners see 4 safe tools</text>
+
+    <g font-family="ui-monospace, SFMono-Regular, monospace" font-size="12">
+      <rect x="20" y="36" width="200" height="38" rx="8" fill="#1e293b" stroke="#334155"/>
+      <circle cx="36" cy="55" r="5" fill="#10b981"/>
+      <text x="50" y="60" fill="#cbd5e1">read_file()</text>
+      <text x="200" y="60" text-anchor="end" fill="#10b981" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10">✓ safe</text>
+
+      <rect x="240" y="36" width="200" height="38" rx="8" fill="#1e293b" stroke="#334155"/>
+      <circle cx="256" cy="55" r="5" fill="#10b981"/>
+      <text x="270" y="60" fill="#cbd5e1">http_request()</text>
+      <text x="420" y="60" text-anchor="end" fill="#10b981" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10">✓ safe</text>
+
+      <rect x="20" y="86" width="200" height="38" rx="8" fill="#1e293b" stroke="#334155"/>
+      <circle cx="36" cy="105" r="5" fill="#10b981"/>
+      <text x="50" y="110" fill="#cbd5e1">sql_query()</text>
+      <text x="200" y="110" text-anchor="end" fill="#10b981" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10">✓ safe</text>
+
+      <rect x="240" y="86" width="200" height="38" rx="8" fill="#1e293b" stroke="#334155"/>
+      <circle cx="256" cy="105" r="5" fill="#10b981"/>
+      <text x="270" y="110" fill="#cbd5e1">exec_code()</text>
+      <text x="420" y="110" text-anchor="end" fill="#10b981" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10">✓ safe</text>
+    </g>
+
+    <text x="240" y="170" text-anchor="middle" fill="#475569" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-style="italic">→ no findings</text>
+  </g>
+
+  <!-- ===== DIVIDER with arrow ===== -->
+  <g transform="translate(540, 184)">
+    <text x="60" y="-12" text-anchor="middle" fill="#fbbf24" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" letter-spacing="2">ZIRAN walks the graph</text>
+    <line x1="0" y1="0" x2="116" y2="0" stroke="#475569" stroke-width="2" stroke-dasharray="5 5"/>
+    <polygon points="120,0 110,-5 110,5" fill="#475569"/>
+    <circle r="4" fill="#fbbf24">
+      <animate attributeName="cx" values="0;116" dur="2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+
+  <!-- ===== RIGHT: graph view ===== -->
+  <g transform="translate(680, 64)">
+    <text x="240" y="16" text-anchor="middle" fill="#94a3b8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="600">ZIRAN finds dangerous compositions</text>
+
+    <!-- nodes -->
+    <g font-family="ui-monospace, SFMono-Regular, monospace" font-size="10" text-anchor="middle">
+      <circle cx="60"  cy="60" r="32" fill="#1e293b" stroke="#e94560" stroke-width="2"/>
+      <text x="60"  y="64" fill="#fecaca">read_file</text>
+
+      <circle cx="420" cy="60" r="32" fill="#1e293b" stroke="#e94560" stroke-width="2"/>
+      <text x="420" y="64" fill="#fecaca">http_req</text>
+
+      <circle cx="60"  cy="160" r="32" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
+      <text x="60"  y="164" fill="#fde68a">sql_query</text>
+
+      <circle cx="420" cy="160" r="32" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
+      <text x="420" y="164" fill="#fde68a">exec_code</text>
+    </g>
+
+    <!-- CRITICAL edge: read_file → http_req -->
+    <line x1="92" y1="60" x2="384" y2="60" stroke="#e94560" stroke-width="2.5">
+      <animate attributeName="stroke-width" values="2;4;2" dur="1.8s" repeatCount="indefinite"/>
+    </line>
+    <polygon points="388,60 378,55 378,65" fill="#e94560"/>
+    <circle cy="60" r="5" fill="#e94560">
+      <animate attributeName="cx" values="92;384" dur="1.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <rect x="170" y="34" width="140" height="20" rx="4" fill="#7f1d1d" stroke="#e94560"/>
+    <text x="240" y="48" text-anchor="middle" fill="#fff" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9" font-weight="700">CRITICAL · data_exfil</text>
+
+    <!-- HIGH edge: sql_query → exec_code -->
+    <line x1="92" y1="160" x2="384" y2="160" stroke="#f59e0b" stroke-width="2.5">
+      <animate attributeName="stroke-width" values="2;4;2" dur="1.8s" begin="0.9s" repeatCount="indefinite"/>
+    </line>
+    <polygon points="388,160 378,155 378,165" fill="#f59e0b"/>
+    <circle cy="160" r="5" fill="#f59e0b">
+      <animate attributeName="cx" values="92;384" dur="1.8s" begin="0.9s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="1.8s" begin="0.9s" repeatCount="indefinite"/>
+    </circle>
+    <rect x="170" y="134" width="140" height="20" rx="4" fill="#78350f" stroke="#f59e0b"/>
+    <text x="240" y="148" text-anchor="middle" fill="#fff" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9" font-weight="700">HIGH · sql_to_rce</text>
+  </g>
+
+  <text x="600" y="318" text-anchor="middle" fill="#475569" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-style="italic">Individually-safe tools form attack paths when chained — graph analysis surfaces them.</text>
+</svg>

--- a/docs/assets/toolchain-light.svg
+++ b/docs/assets/toolchain-light.svg
@@ -1,0 +1,95 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 340" role="img" aria-labelledby="tc-title tc-desc" preserveAspectRatio="xMidYMid meet">
+  <title id="tc-title">ZIRAN tool-chain discovery: graph beats list</title>
+  <desc id="tc-desc">A side-by-side comparison. On the left, a list-based scanner sees four individually-safe tools (read_file, http_request, sql_query, exec_code) and reports no findings. On the right, ZIRAN walks the capability graph and surfaces dangerous transitive compositions: read_file flows to http_request as a critical data exfiltration chain, and sql_query flows to exec_code as a high-severity SQL-to-RCE chain. Keywords: tool chain analysis, capability graph, transitive attack path, data exfiltration, SQL injection, remote code execution, agent security.</desc>
+
+  <rect width="1200" height="340" fill="#f8fafc" rx="16"/>
+  <rect x="0.5" y="0.5" width="1199" height="339" fill="none" stroke="#e2e8f0" rx="16"/>
+
+  <text x="600" y="36" text-anchor="middle" fill="#64748b" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" letter-spacing="3">TOOL-CHAIN DISCOVERY</text>
+
+  <!-- ===== LEFT: list view ===== -->
+  <g transform="translate(40, 64)">
+    <text x="240" y="16" text-anchor="middle" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="600">List-based scanners see 4 safe tools</text>
+
+    <g font-family="ui-monospace, SFMono-Regular, monospace" font-size="12">
+      <rect x="20" y="36" width="200" height="38" rx="8" fill="#ffffff" stroke="#cbd5e1"/>
+      <circle cx="36" cy="55" r="5" fill="#059669"/>
+      <text x="50" y="60" fill="#334155">read_file()</text>
+      <text x="200" y="60" text-anchor="end" fill="#059669" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10">✓ safe</text>
+
+      <rect x="240" y="36" width="200" height="38" rx="8" fill="#ffffff" stroke="#cbd5e1"/>
+      <circle cx="256" cy="55" r="5" fill="#059669"/>
+      <text x="270" y="60" fill="#334155">http_request()</text>
+      <text x="420" y="60" text-anchor="end" fill="#059669" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10">✓ safe</text>
+
+      <rect x="20" y="86" width="200" height="38" rx="8" fill="#ffffff" stroke="#cbd5e1"/>
+      <circle cx="36" cy="105" r="5" fill="#059669"/>
+      <text x="50" y="110" fill="#334155">sql_query()</text>
+      <text x="200" y="110" text-anchor="end" fill="#059669" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10">✓ safe</text>
+
+      <rect x="240" y="86" width="200" height="38" rx="8" fill="#ffffff" stroke="#cbd5e1"/>
+      <circle cx="256" cy="105" r="5" fill="#059669"/>
+      <text x="270" y="110" fill="#334155">exec_code()</text>
+      <text x="420" y="110" text-anchor="end" fill="#059669" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10">✓ safe</text>
+    </g>
+
+    <text x="240" y="170" text-anchor="middle" fill="#94a3b8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-style="italic">→ no findings</text>
+  </g>
+
+  <!-- ===== DIVIDER with arrow ===== -->
+  <g transform="translate(540, 184)">
+    <text x="60" y="-12" text-anchor="middle" fill="#d97706" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" letter-spacing="2">ZIRAN walks the graph</text>
+    <line x1="0" y1="0" x2="116" y2="0" stroke="#cbd5e1" stroke-width="2" stroke-dasharray="5 5"/>
+    <polygon points="120,0 110,-5 110,5" fill="#cbd5e1"/>
+    <circle r="4" fill="#d97706">
+      <animate attributeName="cx" values="0;116" dur="2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+
+  <!-- ===== RIGHT: graph view ===== -->
+  <g transform="translate(680, 64)">
+    <text x="240" y="16" text-anchor="middle" fill="#64748b" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="600">ZIRAN finds dangerous compositions</text>
+
+    <!-- nodes -->
+    <g font-family="ui-monospace, SFMono-Regular, monospace" font-size="10" text-anchor="middle">
+      <circle cx="60"  cy="60" r="32" fill="#fef2f2" stroke="#dc2626" stroke-width="2"/>
+      <text x="60"  y="64" fill="#7f1d1d">read_file</text>
+
+      <circle cx="420" cy="60" r="32" fill="#fef2f2" stroke="#dc2626" stroke-width="2"/>
+      <text x="420" y="64" fill="#7f1d1d">http_req</text>
+
+      <circle cx="60"  cy="160" r="32" fill="#fffbeb" stroke="#d97706" stroke-width="2"/>
+      <text x="60"  y="164" fill="#78350f">sql_query</text>
+
+      <circle cx="420" cy="160" r="32" fill="#fffbeb" stroke="#d97706" stroke-width="2"/>
+      <text x="420" y="164" fill="#78350f">exec_code</text>
+    </g>
+
+    <!-- CRITICAL edge -->
+    <line x1="92" y1="60" x2="384" y2="60" stroke="#dc2626" stroke-width="2.5">
+      <animate attributeName="stroke-width" values="2;4;2" dur="1.8s" repeatCount="indefinite"/>
+    </line>
+    <polygon points="388,60 378,55 378,65" fill="#dc2626"/>
+    <circle cy="60" r="5" fill="#dc2626">
+      <animate attributeName="cx" values="92;384" dur="1.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <rect x="170" y="34" width="140" height="20" rx="4" fill="#dc2626"/>
+    <text x="240" y="48" text-anchor="middle" fill="#fff" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9" font-weight="700">CRITICAL · data_exfil</text>
+
+    <!-- HIGH edge -->
+    <line x1="92" y1="160" x2="384" y2="160" stroke="#d97706" stroke-width="2.5">
+      <animate attributeName="stroke-width" values="2;4;2" dur="1.8s" begin="0.9s" repeatCount="indefinite"/>
+    </line>
+    <polygon points="388,160 378,155 378,165" fill="#d97706"/>
+    <circle cy="160" r="5" fill="#d97706">
+      <animate attributeName="cx" values="92;384" dur="1.8s" begin="0.9s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="1.8s" begin="0.9s" repeatCount="indefinite"/>
+    </circle>
+    <rect x="170" y="134" width="140" height="20" rx="4" fill="#d97706"/>
+    <text x="240" y="148" text-anchor="middle" fill="#fff" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9" font-weight="700">HIGH · sql_to_rce</text>
+  </g>
+
+  <text x="600" y="318" text-anchor="middle" fill="#94a3b8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-style="italic">Individually-safe tools form attack paths when chained — graph analysis surfaces them.</text>
+</svg>


### PR DESCRIPTION
## Summary

Restructures the README top section in a hero-style layout (cocoindex-inspired) and illustrates ZIRAN's three core differentiators with hand-authored SMIL-animated SVGs hosted in-repo.

**Top of README** — full-width animated hero, "Star us ❤️ →" CTA row with animated star button, Docs / Examples / PyPI / Issues links, tagline, three-bullet feature line, badge wall (added a stars badge), nav row, then the existing dashboard screenshot.

**"Why ZIRAN?" section** — the three feature bullets are now SVG-illustrated subsections sitting above their captions. Remaining bullets (Multi-Agent, A2A/MCP, Framework Agnostic) survive under an "And…" subhead.

## Assets added (10 files in `docs/assets/`)

| Asset | Purpose |
|---|---|
| `hero-{light,dark}.svg` | Agent → ZIRAN pipeline → Findings flow, with probe/finding packets and a sweeping phase highlight |
| `star-btn-{light,dark}.svg` | Inline "Star on GitHub" button — star fills yellow on a 3s loop |
| `toolchain-{light,dark}.svg` | List-based scanner sees 4 safe tools vs. ZIRAN's graph surfacing `read_file→http_request` (critical) and `sql_query→exec_code` (high) |
| `sideeffect-{light,dark}.svg` | Surface vs. execution layer — agent text refuses while `delete_user(id=42)` silently fires |
| `adaptive-{light,dark}.svg` | Live knowledge graph grows phase by phase; right panel narrates how each new graph state picks the next phase (Trust Building & Persistence skipped because graph state made them irrelevant) |

## Implementation notes

- **Hosting**: repo-relative paths under `docs/assets/`, matching the existing `ui-dashboard.png` pattern. GitHub serves SVGs with `image/svg+xml` so SMIL animations play inside `<img>`/`<picture>` tags. Also picked up automatically by the MkDocs site at `taoq-ai.github.io/ziran/` if needed later.
- **Light/dark**: each illustration ships as a `<picture>` with `prefers-color-scheme` source switching.
- **Animations**: pure SMIL (`<animate>` opacity/cx/stroke-width with keyTimes) — no JS, no external dependencies. Fade-in groups gate visibility against a single 10s cycle (adaptive SVG) or shorter loops.
- **Total weight**: ~78 KB across 10 files.

## Test plan

- [ ] Open the PR diff on GitHub — verify the README renders with the hero SVG visible at top
- [ ] Toggle GitHub light/dark theme — verify both variants display correctly
- [ ] Hard-refresh after first load — confirm SMIL animations play (probe packets, sweeping highlight, growing graph, fading narration text)
- [ ] Spot-check on mobile width — `width="100%"` should keep the SVGs responsive
- [ ] Verify alt text is present and descriptive on all `<img>` tags (accessibility / SEO)