### PR TITLE
fix(readme): hero packets cy=184 so ziran→findings dots follow the line

### DIFF
--- a/docs/assets/hero-dark.svg
+++ b/docs/assets/hero-dark.svg
@@ -88,11 +88,11 @@
   <polygon points="888,184 880,180 880,188" fill="#334155"/>
 
   <!-- finding packets traveling right (red, tagged critical) -->
-  <circle r="5" fill="#e94560">
+  <circle cy="184" r="5" fill="#e94560">
     <animate attributeName="cx" values="774;888" dur="2.4s" begin="0.6s" repeatCount="indefinite"/>
     <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.4s" begin="0.6s" repeatCount="indefinite"/>
   </circle>
-  <circle r="5" fill="#f59e0b">
+  <circle cy="184" r="5" fill="#f59e0b">
     <animate attributeName="cx" values="774;888" dur="2.4s" begin="1.8s" repeatCount="indefinite"/>
     <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.4s" begin="1.8s" repeatCount="indefinite"/>
   </circle>

--- a/docs/assets/hero-light.svg
+++ b/docs/assets/hero-light.svg
@@ -88,11 +88,11 @@
   <polygon points="888,184 880,180 880,188" fill="#cbd5e1"/>
 
   <!-- finding packets traveling right -->
-  <circle r="5" fill="#dc2626">
+  <circle cy="184" r="5" fill="#dc2626">
     <animate attributeName="cx" values="774;888" dur="2.4s" begin="0.6s" repeatCount="indefinite"/>
     <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.4s" begin="0.6s" repeatCount="indefinite"/>
   </circle>
-  <circle r="5" fill="#d97706">
+  <circle cy="184" r="5" fill="#d97706">
     <animate attributeName="cx" values="774;888" dur="2.4s" begin="1.8s" repeatCount="indefinite"/>
     <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.4s" begin="1.8s" repeatCount="indefinite"/>
   </circle>


### PR DESCRIPTION
## Summary

The two packet circles between the ZIRAN pipeline panel and the Findings panel in the hero SVG had `<animate cx>` but no `cy` attribute and no `<animate cy>`. SVG defaults `cy=0` when omitted, so the dots rendered at the top edge of the canvas instead of along the connector at y=184.

The agent→ZIRAN packets next to them had a no-op `<animate cy values="184;184">` that masked the same defaulting behavior — the second pair was simply missing that animation.

## Fix

Set `cy="184"` as a static attribute on all four affected circles in `hero-{dark,light}.svg`. Same fix in both variants.

```diff
-  <circle r="5" fill="#e94560">
+  <circle cy="184" r="5" fill="#e94560">
     <animate attributeName="cx" values="774;888" dur="2.4s" begin="0.6s" repeatCount="indefinite"/>
     ...
   </circle>
```

## Test plan

- [x] `xmllint --noout` validates both SVGs
- [ ] Open the rendered hero on the README — confirm the red and amber packets travel along the same horizontal line as the cyan ones on the left

## Notes

Spotted post-merge from #295. Audited the other 12 SVGs — they all set `cy` either statically or via a non-trivial animation, so this is the only place affected.