### PR TITLE
ci: adopt git flow branching model

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -2,14 +2,14 @@ name: Action Self-Test
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - "action.yml"
       - "ziran/**"
       - ".github/workflows/action-test.yml"
       - "tests/fixtures/sample_campaign_result.json"
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - "action.yml"
       - "ziran/**"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,13 +2,13 @@ name: Benchmark Coverage
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - "ziran/application/attacks/vectors/**"
       - "ziran/domain/entities/attack.py"
       - "benchmarks/**"
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - "ziran/application/attacks/vectors/**"
       - "ziran/domain/entities/attack.py"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 permissions:
   contents: read

--- a/.github/workflows/lint-ci-templates.yml
+++ b/.github/workflows/lint-ci-templates.yml
@@ -2,12 +2,12 @@ name: Lint CI Templates
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - "examples/07-cicd-quality-gate/**"
       - ".github/workflows/lint-ci-templates.yml"
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - "examples/07-cicd-quality-gate/**"
       - ".github/workflows/lint-ci-templates.yml"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,7 +11,40 @@ permissions:
   pull-requests: write
 
 jobs:
+  check-source-branch:
+    runs-on: ubuntu-latest
+    outputs:
+      is-release-merge: ${{ steps.check.outputs.is-release-merge }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+      - name: Check if merge is from release or hotfix branch
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Manual dispatch always triggers release-please
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "is-release-merge=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Look up the PR that produced this merge commit
+          HEAD_REF=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+            --jq '.[0].head.ref // ""')
+          echo "Merged branch: $HEAD_REF"
+
+          if echo "$HEAD_REF" | grep -qE '^(release/|hotfix/)'; then
+            echo "is-release-merge=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Skipping — not a release or hotfix merge"
+            echo "is-release-merge=false" >> "$GITHUB_OUTPUT"
+          fi
+
   release-please:
+    needs: [check-source-branch]
+    if: needs.check-source-branch.outputs.is-release-merge == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,9 @@
 name: Tests
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   test:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,12 +81,24 @@ Add support for new agent frameworks:
 - Add examples and guides
 - Improve docstrings
 
+## Branching Model
+
+This project uses **Git Flow**:
+
+- **`main`** — production branch, always releasable. Only receives merges from `release/*` and `hotfix/*` branches.
+- **`develop`** — integration branch. All feature PRs target `develop`.
+- **`feat/*`, `fix/*`, `docs/*`** — branch from `develop`, PR back to `develop`.
+- **`release/vX.Y.Z`** — cut from `develop` when ready for release. Only bugfixes allowed. Merged to both `main` and `develop`.
+- **`hotfix/*`** — emergency fixes branched from `main`, merged to both `main` and `develop`.
+
 ## Development Workflow
 
 1. **Fork** the repository
-2. **Create a branch** from `main`:
+2. **Create a branch** from `develop`:
    ```bash
-   git checkout -b feature/my-feature
+   git checkout develop
+   git pull origin develop
+   git checkout -b feat/my-feature
    ```
 3. **Make changes** and add tests
 4. **Ensure all checks pass**:
@@ -98,7 +110,26 @@ Add support for new agent frameworks:
    ```
 5. **Commit** with a clear message
 6. **Push** to your fork
-7. **Open a Pull Request** against `main`
+7. **Open a Pull Request** against `develop`
+
+### Creating a release
+
+```bash
+git checkout develop && git pull origin develop
+git checkout -b release/v0.31.0
+# Only bugfixes allowed on this branch
+# Open PR targeting main
+# After merge to main, also merge release/v0.31.0 into develop
+```
+
+### Hotfixes
+
+```bash
+git checkout main && git pull origin main
+git checkout -b hotfix/critical-fix
+# Open PR targeting main
+# After merge, also merge hotfix/critical-fix into develop
+```
 
 ## Code Style
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "target-branch": "main",
   "packages": {
     ".": {
       "release-type": "simple",


### PR DESCRIPTION
## Summary

- Gate release-please to only trigger on `release/*` or `hotfix/*` merges to `main` (stops every feature merge from creating a new version)
- Add `develop` to CI/test/benchmark/action-test/lint workflow triggers so PRs to `develop` get the same checks
- Add explicit `target-branch: main` to `release-please-config.json`
- Document the Git Flow branching model in CONTRIBUTING.md

## Post-merge steps

After merging this PR:

1. Create `develop` branch from `main`:
   ```bash
   git checkout main && git pull
   git checkout -b develop && git push -u origin develop
   ```
2. Set `develop` as default branch on GitHub (Settings > Branches)
3. Retarget any open feature PRs from `main` to `develop`

## Test plan

- [ ] CI workflows trigger on PRs to `develop`
- [ ] release-please skips non-release merges to `main`
- [ ] release-please triggers on `release/*` branch merges to `main`
- [ ] `workflow_dispatch` still triggers release-please manually