### PR TITLE
feat(adapters): add native Anthropic SDK adapter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ agentcore = [
     "bedrock-agentcore>=1.0,<2",
     "boto3>=1.28,<2",
 ]
+anthropic = [
+    "anthropic>=0.39,<1",
+]
 llm = [
     "litellm>=1.40,<2",
 ]
@@ -80,7 +83,7 @@ ui = [
     "alembic>=1.13,<2",
 ]
 all = [
-    "ziran[langchain,crewai,a2a,bedrock,agentcore,llm,pentest,browser,promptfoo,otel,ui,langfuse]",
+    "ziran[langchain,crewai,a2a,bedrock,agentcore,anthropic,llm,pentest,browser,promptfoo,otel,ui,langfuse]",
 ]
 
 [project.scripts]

--- a/specs/015-anthropic-adapter/spec.md
+++ b/specs/015-anthropic-adapter/spec.md
@@ -1,0 +1,56 @@
+# Feature Specification: Anthropic SDK Native Adapter
+
+**Feature Branch**: `015-anthropic-adapter`
+**Created**: 2026-05-22
+**Status**: Draft
+**Input**: "Add native Anthropic SDK adapter for direct Claude scanning without LangChain wrapping."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Scan a Claude agent directly (Priority: P1)
+
+A security tester has a Claude-based agent built with the Anthropic SDK. They run `ziran scan --framework anthropic --agent-path ./my_claude_agent.py` to scan it directly, without needing LangChain as an intermediary.
+
+**Why this priority**: Core value — enables scanning the most popular frontier model natively.
+
+**Independent Test**: Create an AnthropicAdapter with a mocked client, invoke it, verify AgentResponse is returned.
+
+**Acceptance Scenarios**:
+
+1. **Given** an Anthropic client and model, **When** `invoke()` is called, **Then** the response is returned as a standardized `AgentResponse` with content and tool calls.
+2. **Given** an Anthropic adapter with tools, **When** `discover_capabilities()` is called, **Then** all tool definitions are returned as `AgentCapability` objects.
+3. **Given** a conversation, **When** `get_state()` is called, **Then** the conversation history is returned. **When** `reset_state()` is called, **Then** history is cleared.
+
+### User Story 2 - CLI framework option (Priority: P1)
+
+The `--framework anthropic` option appears in the `scan` and `discover` CLI commands.
+
+**Acceptance Scenarios**:
+
+1. **Given** the CLI, **When** `--framework anthropic` is used, **Then** the AnthropicAdapter is loaded.
+2. **Given** the anthropic package is not installed, **When** the adapter is loaded, **Then** a clear error tells the user how to install it.
+
+### Edge Cases
+
+- Tool calls extracted from `tool_use` content blocks
+- Sync client wrapped with `asyncio.to_thread`
+- Token usage from Anthropic `usage` field
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Implement all `BaseAgentAdapter` abstract methods
+- **FR-002**: Register `"anthropic"` in CLI `--framework` Choice
+- **FR-003**: Add to adapter factory with lazy import
+- **FR-004**: `anthropic` as optional dependency group in `pyproject.toml`
+- **FR-005**: Extract tool calls from `tool_use` content blocks
+- **FR-006**: Extract token usage from response `usage` field
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `ziran scan --framework anthropic` loads successfully
+- **SC-002**: All BaseAgentAdapter methods work with mocked client
+- **SC-003**: All existing tests pass unchanged

--- a/tests/unit/test_anthropic_adapter.py
+++ b/tests/unit/test_anthropic_adapter.py
@@ -1,0 +1,198 @@
+"""Unit tests for the native Anthropic SDK adapter."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from ziran.domain.entities.capability import CapabilityType
+from ziran.infrastructure.adapters.anthropic_adapter import AnthropicAdapter
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _make_text_block(text: str) -> MagicMock:
+    block = MagicMock()
+    block.type = "text"
+    block.text = text
+    return block
+
+
+def _make_tool_block(name: str, tool_input: dict[str, Any], block_id: str = "call_1") -> MagicMock:
+    block = MagicMock()
+    block.type = "tool_use"
+    block.name = name
+    block.input = tool_input
+    block.id = block_id
+    return block
+
+
+def _make_usage(input_tokens: int = 10, output_tokens: int = 20) -> MagicMock:
+    usage = MagicMock()
+    usage.input_tokens = input_tokens
+    usage.output_tokens = output_tokens
+    return usage
+
+
+def _make_response(
+    content_blocks: list[MagicMock],
+    model: str = "claude-sonnet-4-20250514",
+    stop_reason: str = "end_turn",
+    usage: MagicMock | None = None,
+) -> MagicMock:
+    resp = MagicMock()
+    resp.content = content_blocks
+    resp.model = model
+    resp.stop_reason = stop_reason
+    resp.usage = usage or _make_usage()
+    return resp
+
+
+def _make_sync_client(response: MagicMock) -> MagicMock:
+    client = MagicMock()
+    client.messages.create.return_value = response
+    return client
+
+
+# ── Tests ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestAnthropicAdapterInvoke:
+    """US1: invoke() returns standardized AgentResponse."""
+
+    @pytest.mark.asyncio
+    async def test_text_response(self) -> None:
+        response = _make_response([_make_text_block("Hello!")])
+        client = _make_sync_client(response)
+        adapter = AnthropicAdapter(client=client, model="claude-sonnet-4-20250514")
+
+        result = await adapter.invoke("Hi")
+
+        assert result.content == "Hello!"
+        assert result.tool_calls == []
+        assert result.prompt_tokens == 10
+        assert result.completion_tokens == 20
+        assert result.total_tokens == 30
+        assert result.metadata["model"] == "claude-sonnet-4-20250514"
+
+    @pytest.mark.asyncio
+    async def test_tool_call_response(self) -> None:
+        blocks = [
+            _make_text_block("Let me check the weather."),
+            _make_tool_block("get_weather", {"location": "London"}, "call_123"),
+        ]
+        response = _make_response(blocks)
+        client = _make_sync_client(response)
+        adapter = AnthropicAdapter(client=client)
+
+        result = await adapter.invoke("What's the weather?")
+
+        assert result.content == "Let me check the weather."
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["tool_name"] == "get_weather"
+        assert result.tool_calls[0]["tool_input"] == {"location": "London"}
+        assert result.tool_calls[0]["tool_call_id"] == "call_123"
+
+    @pytest.mark.asyncio
+    async def test_conversation_history_tracked(self) -> None:
+        response = _make_response([_make_text_block("I'm Claude.")])
+        client = _make_sync_client(response)
+        adapter = AnthropicAdapter(client=client)
+
+        await adapter.invoke("Who are you?")
+
+        state = adapter.get_state()
+        assert len(state.conversation_history) == 2
+        assert state.conversation_history[0]["role"] == "user"
+        assert state.conversation_history[1]["role"] == "assistant"
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_passed(self) -> None:
+        response = _make_response([_make_text_block("OK")])
+        client = _make_sync_client(response)
+        adapter = AnthropicAdapter(client=client, system_prompt="You are a helpful assistant.")
+
+        await adapter.invoke("Hello")
+
+        call_kwargs = client.messages.create.call_args
+        assert call_kwargs.kwargs.get("system") == "You are a helpful assistant."
+
+    @pytest.mark.asyncio
+    async def test_tools_passed(self) -> None:
+        response = _make_response([_make_text_block("OK")])
+        client = _make_sync_client(response)
+        tools = [{"name": "read_file", "description": "Read a file", "input_schema": {}}]
+        adapter = AnthropicAdapter(client=client, tools=tools)
+
+        await adapter.invoke("Hello")
+
+        call_kwargs = client.messages.create.call_args
+        assert call_kwargs.kwargs.get("tools") == tools
+
+
+@pytest.mark.unit
+class TestAnthropicAdapterCapabilities:
+    """US1: discover_capabilities() extracts tools."""
+
+    @pytest.mark.asyncio
+    async def test_discover_tools(self) -> None:
+        client = MagicMock()
+        tools = [
+            {
+                "name": "get_weather",
+                "description": "Get weather for a location",
+                "input_schema": {"type": "object"},
+            },
+            {
+                "name": "read_file",
+                "description": "Read file contents",
+                "input_schema": {"type": "object"},
+            },
+        ]
+        adapter = AnthropicAdapter(client=client, tools=tools)
+
+        caps = await adapter.discover_capabilities()
+
+        assert len(caps) == 2
+        assert caps[0].name == "get_weather"
+        assert caps[0].type == CapabilityType.TOOL
+        assert caps[1].name == "read_file"
+
+    @pytest.mark.asyncio
+    async def test_no_tools(self) -> None:
+        client = MagicMock()
+        adapter = AnthropicAdapter(client=client)
+
+        caps = await adapter.discover_capabilities()
+
+        assert caps == []
+
+
+@pytest.mark.unit
+class TestAnthropicAdapterState:
+    """US1: State management."""
+
+    def test_reset_state(self) -> None:
+        client = MagicMock()
+        adapter = AnthropicAdapter(client=client)
+        adapter._conversation_history.append({"role": "user", "content": "hi"})
+        adapter._observed_tool_calls.append({"tool_name": "x", "inputs": {}, "outputs": None})
+
+        adapter.reset_state()
+
+        state = adapter.get_state()
+        assert state.conversation_history == []
+        assert state.memory["observed_tool_calls"] == []
+
+    def test_observe_tool_call(self) -> None:
+        client = MagicMock()
+        adapter = AnthropicAdapter(client=client)
+
+        adapter.observe_tool_call("read_file", {"path": "/etc/passwd"}, "secret data")
+
+        state = adapter.get_state()
+        assert len(state.memory["observed_tool_calls"]) == 1
+        assert state.memory["observed_tool_calls"][0]["tool_name"] == "read_file"

--- a/ziran/application/factories.py
+++ b/ziran/application/factories.py
@@ -241,6 +241,24 @@ def load_agent_adapter(framework: str, agent_path: str) -> Any:
             app = _load_python_object(agent_path, "app")
         return AgentCoreAdapter(entrypoint, app=app)
 
+    if framework == "anthropic":
+        try:
+            from ziran.infrastructure.adapters.anthropic_adapter import AnthropicAdapter
+        except ImportError as e:
+            raise ImportError(
+                f"anthropic not installed. Run: uv sync --extra anthropic\n{e}"
+            ) from e
+
+        # Load the agent module and look for client + tools
+        agent_module = _load_python_object(agent_path, "client")
+        tools: list[Any] = []
+        model = "claude-sonnet-4-20250514"
+        with contextlib.suppress(FileNotFoundError, ImportError, ValueError):
+            tools = _load_python_object(agent_path, "tools")
+        with contextlib.suppress(FileNotFoundError, ImportError, ValueError):
+            model = _load_python_object(agent_path, "model")
+        return AnthropicAdapter(client=agent_module, model=model, tools=tools)
+
     raise ValueError(f"Unsupported framework: {framework}")
 
 

--- a/ziran/application/factories.py
+++ b/ziran/application/factories.py
@@ -252,11 +252,12 @@ def load_agent_adapter(framework: str, agent_path: str) -> Any:
         # Load the agent module and look for client + tools
         agent_module = _load_python_object(agent_path, "client")
         tools: list[Any] = []
-        model = "claude-sonnet-4-20250514"
         with contextlib.suppress(FileNotFoundError, ImportError, ValueError):
             tools = _load_python_object(agent_path, "tools")
-        with contextlib.suppress(FileNotFoundError, ImportError, ValueError):
+        try:
             model = _load_python_object(agent_path, "model")
+        except (FileNotFoundError, ImportError, ValueError):
+            model = "claude-sonnet-4-20250514"
         return AnthropicAdapter(client=agent_module, model=model, tools=tools)
 
     raise ValueError(f"Unsupported framework: {framework}")

--- a/ziran/infrastructure/adapters/anthropic_adapter.py
+++ b/ziran/infrastructure/adapters/anthropic_adapter.py
@@ -1,0 +1,202 @@
+"""Native Anthropic SDK adapter.
+
+Wraps ``anthropic.Anthropic`` or ``anthropic.AsyncAnthropic`` to
+implement the ZIRAN BaseAgentAdapter interface, enabling direct
+security scanning of Claude-based agents without LangChain.
+
+Requires the ``anthropic`` extra::
+
+    uv sync --extra anthropic
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from typing import TYPE_CHECKING, Any
+
+from ziran.domain.entities.capability import AgentCapability, CapabilityType
+from ziran.domain.interfaces.adapter import AgentResponse, AgentState, BaseAgentAdapter
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from ziran.domain.entities.streaming import AgentResponseChunk
+
+logger = logging.getLogger(__name__)
+
+
+class AnthropicAdapter(BaseAgentAdapter):
+    """Adapter for agents built with the Anthropic Python SDK.
+
+    Wraps an ``anthropic.Anthropic`` (sync) or
+    ``anthropic.AsyncAnthropic`` (async) client to implement the
+    ZIRAN scanning interface.
+
+    Example::
+
+        import anthropic
+        from ziran.infrastructure.adapters.anthropic_adapter import (
+            AnthropicAdapter,
+        )
+
+        client = anthropic.Anthropic()
+        adapter = AnthropicAdapter(
+            client=client,
+            model="claude-sonnet-4-20250514",
+            tools=[{
+                "name": "get_weather",
+                "description": "Get weather for a location",
+                "input_schema": {"type": "object", "properties": {...}},
+            }],
+        )
+        response = await adapter.invoke("What's the weather in London?")
+    """
+
+    def __init__(
+        self,
+        client: Any,
+        *,
+        model: str = "claude-sonnet-4-20250514",
+        system_prompt: str | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        max_tokens: int = 4096,
+    ) -> None:
+        """Initialize the Anthropic adapter.
+
+        Args:
+            client: An ``anthropic.Anthropic`` or
+                ``anthropic.AsyncAnthropic`` instance.
+            model: Model identifier (e.g. ``claude-sonnet-4-20250514``).
+            system_prompt: Optional system prompt prepended to every
+                request.
+            tools: List of Anthropic tool definitions (dicts with
+                ``name``, ``description``, ``input_schema``).
+            max_tokens: Maximum tokens for the response.
+        """
+        self._client = client
+        self._model = model
+        self._system_prompt = system_prompt
+        self._tools = tools or []
+        self._max_tokens = max_tokens
+        self._conversation_history: list[dict[str, str]] = []
+        self._observed_tool_calls: list[dict[str, Any]] = []
+
+        # Detect if client is async or sync.
+        self._is_async = hasattr(client, "messages") and asyncio.iscoroutinefunction(
+            getattr(client.messages, "create", None)
+        )
+
+    async def invoke(self, message: str, **kwargs: Any) -> AgentResponse:
+        """Send a message to Claude and return the response."""
+        self._conversation_history.append({"role": "user", "content": message})
+
+        # Build request kwargs.
+        req_kwargs: dict[str, Any] = {
+            "model": self._model,
+            "max_tokens": self._max_tokens,
+            "messages": [
+                {"role": m["role"], "content": m["content"]} for m in self._conversation_history
+            ],
+        }
+        if self._system_prompt:
+            req_kwargs["system"] = self._system_prompt
+        if self._tools:
+            req_kwargs["tools"] = self._tools
+
+        # Call the API (async or sync via thread).
+        if self._is_async:
+            response = await self._client.messages.create(**req_kwargs)
+        else:
+            response = await asyncio.to_thread(self._client.messages.create, **req_kwargs)
+
+        # Extract text and tool calls from content blocks.
+        text_parts: list[str] = []
+        tool_calls: list[dict[str, Any]] = []
+
+        for block in response.content:
+            if block.type == "text":
+                text_parts.append(block.text)
+            elif block.type == "tool_use":
+                tool_calls.append(
+                    {
+                        "tool_name": block.name,
+                        "tool_input": block.input,
+                        "tool_call_id": block.id,
+                    }
+                )
+
+        content = "\n".join(text_parts)
+        self._conversation_history.append({"role": "assistant", "content": content})
+
+        # Extract token usage.
+        usage = getattr(response, "usage", None)
+        prompt_tokens = getattr(usage, "input_tokens", 0) if usage else 0
+        completion_tokens = getattr(usage, "output_tokens", 0) if usage else 0
+
+        return AgentResponse(
+            content=content,
+            tool_calls=tool_calls,
+            metadata={
+                "model": response.model,
+                "stop_reason": response.stop_reason,
+            },
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=prompt_tokens + completion_tokens,
+        )
+
+    async def discover_capabilities(self) -> list[AgentCapability]:
+        """Discover capabilities from the tool definitions."""
+        capabilities: list[AgentCapability] = []
+        for tool in self._tools:
+            name = tool.get("name", "unknown")
+            description = tool.get("description", "")
+            capabilities.append(
+                AgentCapability(
+                    id=f"anthropic_tool_{name}",
+                    name=name,
+                    type=CapabilityType.TOOL,
+                    description=description,
+                    parameters=tool.get("input_schema", {}),
+                )
+            )
+        return capabilities
+
+    def get_state(self) -> AgentState:
+        """Return current conversation state."""
+        return AgentState(
+            session_id=str(uuid.uuid4()),
+            conversation_history=list(self._conversation_history),
+            memory={"observed_tool_calls": list(self._observed_tool_calls)},
+        )
+
+    def reset_state(self) -> None:
+        """Clear conversation history and observed tool calls."""
+        self._conversation_history.clear()
+        self._observed_tool_calls.clear()
+
+    async def stream(self, message: str, **kwargs: Any) -> AsyncIterator[AgentResponseChunk]:
+        """Stream a response from Claude.
+
+        Falls back to the base class single-chunk implementation.
+        Override if native streaming is needed.
+        """
+        async for chunk in super().stream(message, **kwargs):
+            yield chunk
+
+    def observe_tool_call(
+        self,
+        tool_name: str,
+        inputs: dict[str, Any],
+        outputs: Any,
+    ) -> None:
+        """Record an observed tool call."""
+        self._observed_tool_calls.append(
+            {
+                "tool_name": tool_name,
+                "inputs": inputs,
+                "outputs": outputs,
+            }
+        )

--- a/ziran/interfaces/cli/main.py
+++ b/ziran/interfaces/cli/main.py
@@ -86,7 +86,7 @@ def cli(ctx: click.Context, verbose: bool, log_file: str | None) -> None:
 @cli.command()
 @click.option(
     "--framework",
-    type=click.Choice(["langchain", "crewai", "bedrock", "agentcore"], case_sensitive=False),
+    type=click.Choice(["langchain", "crewai", "bedrock", "agentcore", "anthropic"], case_sensitive=False),
     default=None,
     help="Agent framework to test (for in-process scanning).",
 )
@@ -513,7 +513,7 @@ def scan(
 @cli.command()
 @click.option(
     "--framework",
-    type=click.Choice(["langchain", "crewai", "bedrock", "agentcore"], case_sensitive=False),
+    type=click.Choice(["langchain", "crewai", "bedrock", "agentcore", "anthropic"], case_sensitive=False),
     default=None,
     help="Agent framework (for in-process discovery).",
 )
@@ -1829,7 +1829,7 @@ def multi_agent_scan(
 @cli.command()
 @click.option(
     "--framework",
-    type=click.Choice(["langchain", "crewai", "bedrock", "agentcore"], case_sensitive=False),
+    type=click.Choice(["langchain", "crewai", "bedrock", "agentcore", "anthropic"], case_sensitive=False),
     default=None,
     help="Agent framework to test (for in-process scanning).",
 )

--- a/ziran/interfaces/cli/main.py
+++ b/ziran/interfaces/cli/main.py
@@ -86,7 +86,9 @@ def cli(ctx: click.Context, verbose: bool, log_file: str | None) -> None:
 @cli.command()
 @click.option(
     "--framework",
-    type=click.Choice(["langchain", "crewai", "bedrock", "agentcore", "anthropic"], case_sensitive=False),
+    type=click.Choice(
+        ["langchain", "crewai", "bedrock", "agentcore", "anthropic"], case_sensitive=False
+    ),
     default=None,
     help="Agent framework to test (for in-process scanning).",
 )
@@ -513,7 +515,9 @@ def scan(
 @cli.command()
 @click.option(
     "--framework",
-    type=click.Choice(["langchain", "crewai", "bedrock", "agentcore", "anthropic"], case_sensitive=False),
+    type=click.Choice(
+        ["langchain", "crewai", "bedrock", "agentcore", "anthropic"], case_sensitive=False
+    ),
     default=None,
     help="Agent framework (for in-process discovery).",
 )
@@ -1829,7 +1833,9 @@ def multi_agent_scan(
 @cli.command()
 @click.option(
     "--framework",
-    type=click.Choice(["langchain", "crewai", "bedrock", "agentcore", "anthropic"], case_sensitive=False),
+    type=click.Choice(
+        ["langchain", "crewai", "bedrock", "agentcore", "anthropic"], case_sensitive=False
+    ),
     default=None,
     help="Agent framework to test (for in-process scanning).",
 )


### PR DESCRIPTION
## Summary

- Add `AnthropicAdapter` implementing `BaseAgentAdapter` for direct Claude scanning
- Wraps `anthropic.Anthropic` or `anthropic.AsyncAnthropic` — no LangChain required
- Extracts tool calls from `tool_use` content blocks, token usage from `usage` field
- Sync client automatically wrapped with `asyncio.to_thread`
- Add `--framework anthropic` to CLI scan/discover commands
- Add `anthropic` optional dependency group in pyproject.toml
- Add to adapter factory with lazy import and clear error messages

Closes #286

## Test plan

- [x] 9 unit tests in `tests/unit/test_anthropic_adapter.py` — all pass
- [x] ruff check — zero violations
- [x] mypy — zero errors
- [x] Follows existing adapter pattern (AgentCoreAdapter, LangChainAdapter)