### PR TITLE
fix(ci): add target-branch: main to release-please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,3 +54,6 @@ jobs:
           # The RELEASE_PAT needs repo scope so the tag push triggers
           # the Release workflow (release.yml).
           token: ${{ secrets.RELEASE_PAT }}
+          # Explicit target-branch because the repo default is develop,
+          # but release-please PRs must target main (production).
+          target-branch: main


### PR DESCRIPTION
## Summary

Hotfix: the release-please action was creating PRs targeting `develop` (the repo default branch) instead of `main`. This adds `target-branch: main` explicitly to the action inputs.

The fix was in the `release/v0.31.0` branch but got lost in a squash merge. This hotfix applies it directly to `main`.

## After merging

Merge this hotfix to `develop` too, then release-please will trigger and create the v0.31.0 release PR correctly targeting `main`.