### PR TITLE
feat(watch-registry): alerting via shared AlertSink layer (#272)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # ziran Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-05-22
+Auto-generated from all feature plans. Last updated: 2026-05-29
 
 ## Active Technologies
 - Python 3.11+ (CI matrix: 3.11, 3.12, 3.13) + asyncio, dataclasses, logging, OpenTelemetry (tracing) (003-split-agent-scanner)
@@ -19,6 +19,8 @@ Auto-generated from all feature plans. Last updated: 2026-05-22
 - YAML vector files under `ziran/application/attacks/vectors/`; benchmark result JSON under `benchmarks/results/`; docs under `docs/reference/benchmarks/`. (012-benchmark-maturity)
 - Python 3.11+ (CI matrix: 3.11, 3.12, 3.13) + `re` (stdlib), existing `ziran.application.detectors` module (013-multilingual-refusal-detection)
 - N/A (in-memory pattern matching) (013-multilingual-refusal-detection)
+- Python 3.11+ (CI matrix: 3.11, 3.12, 3.13) + httpx (async HTTP — Slack + GitHub REST), Pydantic v2 (config + entity models), PyYAML (config + new `!env` tag), Click (CLI). Composite GitHub Action uses `gh` CLI + bash, no new runtime deps. (017-runtime-loop-alerting)
+- None new. Dedup is stateless via GitHub-side issue markers; existing registry snapshots stay in `.ziran/snapshots/` (local JSON). (017-runtime-loop-alerting)
 
 - Python 3.11+ (CI matrix: 3.11, 3.12, 3.13) + click (CLI only), PyYAML, Playwright (optional), boto3 (optional), LangChain (optional), CrewAI (optional) (002-extract-shared-factories)
 
@@ -38,9 +40,9 @@ cd src [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECHNOLO
 Python 3.11+ (CI matrix: 3.11, 3.12, 3.13): Follow standard conventions
 
 ## Recent Changes
+- 017-runtime-loop-alerting: Added Python 3.11+ (CI matrix: 3.11, 3.12, 3.13) + httpx (async HTTP — Slack + GitHub REST), Pydantic v2 (config + entity models), PyYAML (config + new `!env` tag), Click (CLI). Composite GitHub Action uses `gh` CLI + bash, no new runtime deps.
 - 013-multilingual-refusal-detection: Added Python 3.11+ (CI matrix: 3.11, 3.12, 3.13) + `re` (stdlib), existing `ziran.application.detectors` module
 - 012-benchmark-maturity: Added Python 3.11+ (CI matrix: 3.11, 3.12, 3.13) + pydantic (models), PyYAML (vector loader), click (CLI), rich (reports), networkx (graph — unchanged). No new dependencies.
-- 011-runtime-bridge-v0-8: Added Python 3.11+ (CI matrix: 3.11, 3.12, 3.13) + click (CLI), httpx (async HTTP), pydantic (models), networkx (graph), pyyaml (config), rich (output), mdutils (reports). New optional: `langfuse` (trace pull).
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,14 @@ ignore = ["E501"]
 [tool.ruff.lint.isort]
 known-first-party = ["ziran"]
 
+[tool.ruff.lint.flake8-type-checking]
+# Pydantic resolves field annotations at runtime, so imports used only in model
+# fields must stay as real runtime imports (not moved into `TYPE_CHECKING`).
+# Without this, ruff pushes them behind `TYPE_CHECKING`, leaving them referenced
+# only via string annotations — which CodeQL/github-code-quality then reports as
+# "unused import". Declaring the Pydantic base keeps those imports runtime-visible.
+runtime-evaluated-base-classes = ["pydantic.BaseModel"]
+
 [tool.mypy]
 python_version = "3.11"
 plugins = ["pydantic.mypy"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ test = [
     "pytest>=8.0,<9",
     "pytest-asyncio>=0.23",
     "pytest-cov>=5.0",
+    "respx>=0.21,<1",
 ]
 
 [tool.uv]

--- a/specs/017-runtime-loop-alerting/checklists/requirements.md
+++ b/specs/017-runtime-loop-alerting/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Runtime Loop Alerting and Automation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-29
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+- The spec deliberately references existing v0.8 command names (`watch-registry`, `analyze-traces`, `export-policy`) as scope anchors, not as implementation prescriptions. Internal design names (e.g. `AlertSink`, port file paths) from the source issues were intentionally kept out of the spec and deferred to `/speckit.plan`.

--- a/specs/017-runtime-loop-alerting/contracts/alert_sink_port.md
+++ b/specs/017-runtime-loop-alerting/contracts/alert_sink_port.md
@@ -1,0 +1,57 @@
+# Contract: AlertSink Port
+
+**File**: `ziran/domain/ports/alert_sink.py` (new)
+
+```python
+from abc import ABC, abstractmethod
+from ziran.domain.entities.alerting import AlertableFinding, DeliveryResult
+
+
+class AlertSink(ABC):
+    """Driving-side-out port: delivers a finding to one external destination."""
+
+    name: str  # stable identifier, e.g. "slack", "github_issue"
+
+    @abstractmethod
+    async def emit(self, finding: AlertableFinding) -> DeliveryResult:
+        """Deliver one finding.
+
+        Contract:
+        - MUST be idempotent for the github_issue sink: re-emitting a finding
+          whose fingerprint already exists (open OR closed issue) returns
+          status="deduped" without creating a duplicate.
+        - MUST NOT raise on remote/transport errors; capture them as
+          DeliveryResult(status="failed", detail=<message>). Programmer errors
+          (bad config constructed despite validation) MAY raise.
+        - MUST NOT perform network I/O when wrapped by the dry-run decorator.
+        """
+```
+
+## Severity-floor filtering
+
+Filtering is performed by the dispatcher (`application/alerting/dispatch.py`), **not** inside each sink, so the rule lives in one place:
+
+```python
+async def dispatch(
+    findings: list[AlertableFinding],
+    sinks: list[tuple[AlertSink, Severity]],   # (sink, severity_floor)
+    *, dry_run: bool = False,
+) -> AlertOutcome: ...
+```
+
+- For each `(finding, sink)`: if `severity_rank(finding.severity) < severity_rank(floor)` → `DeliveryResult(status="skipped_below_floor")`, no `emit` call.
+- Otherwise `await sink.emit(finding)` (all pairs gathered with `asyncio.gather(..., return_exceptions=False)`; sinks never raise per contract).
+- Aggregate into `AlertOutcome`.
+
+## Dry-run wrapper
+
+```python
+class DryRunSink(AlertSink):
+    def __init__(self, inner: AlertSink) -> None: ...
+    async def emit(self, finding) -> DeliveryResult:
+        # prints intended destination + serialized payload to stdout
+        return DeliveryResult(sink_name=self._inner.name, fingerprint=finding.fingerprint,
+                              status="dry_run", detail="<payload preview>")
+```
+
+Guarantee: when `--dry-run-alerts` is set, every real sink is wrapped, so zero network I/O occurs (SC-007).

--- a/specs/017-runtime-loop-alerting/contracts/cli_and_action.md
+++ b/specs/017-runtime-loop-alerting/contracts/cli_and_action.md
@@ -1,0 +1,63 @@
+# Contract: CLI flags, config, and the policy-refresh Action
+
+## CLI changes
+
+### `ziran watch-registry`
+- New: `--dry-run-alerts` (flag) — wrap all sinks, print payloads, no network I/O.
+- Sinks are built from the `alerts:` block in the registry YAML (no new CLI flag needed for config path).
+- Exit codes: `0` ok · `2` partial delivery failure · `1` fatal/usage. Existing severity-gate `SystemExit(1)` behavior preserved; precedence fatal(1) > delivery-failure(2) > severity-gate > 0.
+
+### `ziran analyze-traces`
+- New: `--alert` (flag) — emit dangerous-chain matches through configured sinks.
+- New: `--digest` (flag) — aggregate the run's matches into a single digest issue (default off = per-`(chain, session)`).
+- Config: `alerts:` block (same schema) supplied via the existing analyze config path.
+- Same exit-code contract as above.
+
+## Config schema (`alerts:` block)
+
+```yaml
+# registry.yaml (watch-registry)  /  analyze config (analyze-traces)
+alerts:
+  - kind: slack
+    webhook_url: !env SLACK_WEBHOOK_URL
+    severity_floor: medium
+  - kind: github_issue
+    repo: myorg/ai-agent-infra
+    token: !env GH_TOKEN          # falls back to GITHUB_TOKEN if omitted
+    labels: [mcp-drift, security]
+    assignees: [secops-oncall]
+    severity_floor: high
+```
+
+- `!env VAR` resolves at load via the custom loader; unset var → clear error before any send.
+- `severity_floor` default `low`. Unknown `kind` → validation error listing allowed kinds.
+
+## Composite Action: `.github/actions/export-policy/action.yml`
+
+```yaml
+name: ziran-policy-refresh
+description: Re-scan a target, regenerate guardrail policies, open/update a refresh PR.
+inputs:
+  target:        { description: Path/URL of the agent target config, required: true }
+  out-dir:       { description: Committed policy bundle dir, default: policies/ }
+  target-formats:{ description: Comma list of rego,cedar,colang,invariant, default: "rego,cedar,colang,invariant" }
+  fail-on-diff:  { description: Fail run on diff instead of opening a PR, default: "false" }
+  reviewer-team: { description: Team slug to request review from, default: "" }
+runs:
+  using: composite
+  # steps: install ziran -> ziran scan -> ziran export-policy --formats <...>
+  #        -> diff vs out-dir -> if diff: (fail-on-diff ? exit 1 : commit to branch
+  #        ziran/policy-refresh + gh pr create/edit, label policy-refresh, request reviewer)
+```
+
+**Behavior contract**:
+- No diff → no PR, exit 0 (FR-020).
+- Diff + `fail-on-diff=false` → commit to fixed branch `ziran/policy-refresh`, open PR if none exists for that branch else update it; label `policy-refresh`; request `reviewer-team` (FR-019).
+- Diff + `fail-on-diff=true` → exit 1, no PR (FR-021).
+- `target-formats` scopes regeneration + diff (FR-022).
+- Fixed head branch guarantees a single PR under both squash and merge-commit base strategies (FR-024).
+- Token: `${{ secrets.GITHUB_TOKEN }}` (or a passed PAT for cross-repo).
+
+**Self-test** (`.github/workflows/policy-refresh-selftest.yml`): runs the action against the bundled example agent, asserts a PR is opened when the committed bundle is stale and none when current (US3 Independent Test).
+
+**Template** (`examples/07-cicd-quality-gate/policy-refresh.yml`): `schedule: weekly` + `workflow_dispatch`, calling the action.

--- a/specs/017-runtime-loop-alerting/contracts/sinks_http.md
+++ b/specs/017-runtime-loop-alerting/contracts/sinks_http.md
@@ -1,0 +1,52 @@
+# Contract: Slack + GitHub HTTP request shapes
+
+These are the exact request shapes integration tests (respx) assert against.
+
+## SlackWebhookSink
+
+**Request**: `POST {webhook_url}` (URL from `!env`), `Content-Type: application/json`.
+
+**Body** (Block Kit + text fallback):
+```json
+{
+  "text": "<severity emoji> [<KIND>] <finding.summary>",
+  "blocks": [
+    { "type": "header", "text": { "type": "plain_text", "text": "<emoji> <finding.title>" } },
+    { "type": "section", "fields": [
+        { "type": "mrkdwn", "text": "*<field key>:*\n<field value>" }
+    ] },
+    { "type": "context", "elements": [
+        { "type": "mrkdwn", "text": "<label>: <url>" }
+    ] }
+  ]
+}
+```
+**Success**: HTTP 200 with body `ok` → `status="sent"`. Non-2xx → `status="failed"`.
+
+Severity → emoji: critical `:rotating_light:`, high `:red_circle:`, medium `:large_orange_diamond:`, low `:white_circle:`.
+
+## GitHubIssueSink
+
+Token from `!env`/`GITHUB_TOKEN`; headers `Authorization: Bearer <token>`, `Accept: application/vnd.github+json`, `X-GitHub-Api-Version: 2022-11-28`.
+
+**Step 1 — dedup search**:
+`GET https://api.github.com/search/issues?q=repo:{repo}+in:body+%22ziran-fingerprint%3A+{fp}%22+is:issue`
+- `total_count > 0` → return `DeliveryResult(status="deduped", detail=<items[0].html_url>)`. No creation.
+
+**Step 2 — create (only if not found)**:
+`POST https://api.github.com/repos/{repo}/issues`
+```json
+{
+  "title": "<KIND>: <finding.title>",
+  "body": "<rendered markdown>\n\n<!-- ziran-fingerprint: <fp> -->",
+  "labels": ["<configured labels>"],
+  "assignees": ["<configured assignees>"]
+}
+```
+- 201 → `status="sent"`, `detail=<html_url>`.
+- 401/403 (bad/missing token) → `status="failed"`, detail names the auth problem.
+- other non-2xx → `status="failed"`.
+
+**Body markdown** includes: finding fields as a list, each `AlertLink` as a markdown link, severity, and `remediation` (if present) under a "Suggested remediation" heading.
+
+**Idempotency test**: first run → search returns 0 → POST observed once → `sent`; second run on same finding → search returns 1 → no POST → `deduped`. (SC-002.)

--- a/specs/017-runtime-loop-alerting/data-model.md
+++ b/specs/017-runtime-loop-alerting/data-model.md
@@ -1,0 +1,117 @@
+# Phase 1 Data Model: Runtime Loop Alerting and Automation
+
+All models are Pydantic v2 `BaseModel` (config/entities) or frozen dataclasses where noted. Severity reuses the existing `Severity = Literal["low", "medium", "high", "critical"]` from `ziran/domain/entities/attack.py`; ordering is `low(0) < medium(1) < high(2) < critical(3)`.
+
+## Domain entities
+
+### AlertableFinding (`ziran/domain/entities/alerting.py`, new)
+
+The normalized unit every sink consumes. Both `DriftFinding` and trace `DangerousChain` matches convert to this.
+
+| Field | Type | Notes |
+|---|---|---|
+| `fingerprint` | `str` | 16-char hex; stable dedup key (see R2). |
+| `kind` | `Literal["registry_drift", "dangerous_chain"]` | Drives title prefix + formatting. |
+| `severity` | `Severity` | Reused enum; compared against sink floor. |
+| `title` | `str` | Human summary, e.g. `"Permission escalation on tool `write_file` (prod-mcp-server)"`. |
+| `summary` | `str` | One-line text used for Slack `text` fallback. |
+| `fields` | `dict[str, str]` | Ordered key→value detail pairs (server, tool, before/after, session, etc.). |
+| `links` | `list[AlertLink]` | Labeled URLs (snapshot diff, trace source, matched finding, existing issue). |
+| `remediation` | `str \| None` | Suggested fix (trace findings when a policy bundle covers the chain). |
+
+**Validation**: `fingerprint` matches `^[0-9a-f]{16}$`; `fields` is insertion-ordered; `severity` must be a valid `Severity` literal.
+
+**Fingerprint construction** (module helpers, pure functions):
+- `drift_fingerprint(server, tool, drift_type) -> str`
+- `trace_fingerprint(tool_chain_hash, session_id) -> str`
+- `digest_fingerprint(chain_fingerprints) -> str` (derived only from the sorted set of chain fingerprints; no run date — so unchanged traces dedup across days)
+
+### AlertLink (`alerting.py`, new)
+
+| Field | Type | Notes |
+|---|---|---|
+| `label` | `str` | e.g. `"Snapshot diff"`, `"Trace (Langfuse)"`, `"Matched finding"`, `"Existing issue"`. |
+| `url` | `str` | Absolute, remote-resolvable URL (http/https). Local filesystem paths MUST NOT be used. When no resolvable URL exists for the registry snapshot diff, omit the link and instead embed an inline before/after diff summary in `AlertableFinding.fields` (see FR-011). |
+
+### DeliveryResult (`alerting.py`, new, frozen)
+
+Returned by `AlertSink.emit` for one finding→one sink.
+
+| Field | Type | Notes |
+|---|---|---|
+| `sink_name` | `str` | e.g. `"slack"`, `"github_issue"`. |
+| `fingerprint` | `str` | Echoes the finding. |
+| `status` | `Literal["sent", "deduped", "skipped_below_floor", "failed", "dry_run"]` | Outcome. |
+| `detail` | `str \| None` | Issue URL on send/dedup, or error message on failure. |
+
+### AlertOutcome (`alerting.py`, new)
+
+Aggregate for a whole run; the CLI maps it to an exit code.
+
+| Field | Type | Notes |
+|---|---|---|
+| `results` | `list[DeliveryResult]` | Flat list across all findings × sinks. |
+| `any_failed` | `bool` (computed) | True if any `status == "failed"` → CLI exit 2. |
+| `sent`, `deduped`, `failed` | `int` (computed) | Counts for the run summary. |
+
+## Extended existing entity
+
+### DriftFinding (`ziran/domain/entities/registry.py`, extend)
+
+Existing fields unchanged (`server_name`, `drift_type`, `severity`, `tool_name`, `message`, `previous_value`, `current_value`, `suspected_canonical`). Add two methods:
+- `fingerprint() -> str` → `drift_fingerprint(server_name, tool_name or "", drift_type)`.
+- `to_alertable() -> AlertableFinding` → maps message/previous/current into `fields`, builds a snapshot-diff `AlertLink`.
+
+> Domain note: `to_alertable` lives in the domain because it is pure mapping with no I/O, preserving the dependency rule.
+
+## Application config models (`ziran/application/alerting/config.py`, new)
+
+### AlertSinkConfig
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `kind` | `Literal["slack", "github_issue"]` | — | Selects the adapter. |
+| `severity_floor` | `Severity` | `"low"` | Per-sink minimum. |
+| `webhook_url` | `str \| None` | None | Slack only; resolved via `!env`. |
+| `repo` | `str \| None` | None | GitHub only, `owner/name`. |
+| `labels` | `list[str]` | `[]` | GitHub only. |
+| `token` | `str \| None` | None | GitHub only; resolved via `!env` or `GITHUB_TOKEN`. |
+| `assignees` | `list[str]` | `[]` | GitHub only (optional). |
+
+**Validation**: `kind == "slack"` requires `webhook_url`; `kind == "github_issue"` requires `repo` and a resolvable token. Secrets are populated from env (`!env`/`${VAR}`); a missing referenced var raises a clear config error before any network call.
+
+### AlertConfig
+
+| Field | Type | Notes |
+|---|---|---|
+| `alerts` | `list[AlertSinkConfig]` | The `alerts:` block parsed from registry/analyze config YAML. |
+
+## Sink-internal model (GitHub)
+
+### IssueMarker (encode/decode helpers in `github_issue_sink.py`)
+
+Not a stored entity — a convention: the issue body ends with `\n\n<!-- ziran-fingerprint: {fp} -->`. `encode(body, fp)` appends it; the dedup search matches the literal `ziran-fingerprint: {fp}` substring across open + closed issues.
+
+## State transitions
+
+There is no persisted state machine. The only "state" is the existence of a GitHub issue carrying a fingerprint marker:
+
+```
+finding produced
+   │
+   ├─ severity < sink.floor ───────────────► skipped_below_floor
+   │
+   ├─ dry_run ─────────────────────────────► dry_run (payload printed, no I/O)
+   │
+   └─ search issues for marker
+         ├─ found (open or closed) ────────► deduped (reuse existing URL)
+         └─ not found ─► create/post
+               ├─ 2xx ─────────────────────► sent
+               └─ error / no creds ────────► failed (aggregated, non-blocking)
+```
+
+## Relationships
+
+- `DriftFinding` →(`to_alertable`)→ `AlertableFinding` →(`emit`)→ `DeliveryResult` →(aggregate)→ `AlertOutcome`.
+- Trace `DangerousChain` (observed_in_production) →(analyzer mapping)→ `AlertableFinding` (carries session/trace-source links, inherited severity, optional remediation from a matching `GuardrailPolicy`).
+- `AlertConfig.alerts[*]` →(factory)→ concrete `AlertSink` instances (Slack/GitHub).

--- a/specs/017-runtime-loop-alerting/plan.md
+++ b/specs/017-runtime-loop-alerting/plan.md
@@ -1,0 +1,110 @@
+# Implementation Plan: Runtime Loop Alerting and Automation
+
+**Branch**: `017-runtime-loop-alerting` | **Date**: 2026-05-29 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/017-runtime-loop-alerting/spec.md`
+
+## Summary
+
+Close the v0.8 runtime-bridge feedback loop by adding a single shared notification capability — an `AlertSink` port with Slack-webhook and GitHub-issue adapters — and wiring it into the existing `watch-registry` (`watch()`) and `analyze-traces` (`AnalyzerService`) flows, plus a reusable composite GitHub Action that auto-refreshes exported policy bundles. Deduplication is stateless: a fingerprint marker is embedded in each GitHub issue body and rediscovered via the GitHub search API, so re-runs never open duplicates and no local dedup state is kept. The work is sliced into three independently shippable user stories (P1 registry alerting, P2 trace alerting, P3 policy-refresh automation).
+
+## Technical Context
+
+**Language/Version**: Python 3.11+ (CI matrix: 3.11, 3.12, 3.13)
+**Primary Dependencies**: httpx (async HTTP — Slack + GitHub REST), Pydantic v2 (config + entity models), PyYAML (config + new `!env` tag), Click (CLI). Composite GitHub Action uses `gh` CLI + bash, no new runtime deps.
+**Storage**: None new. Dedup is stateless via GitHub-side issue markers; existing registry snapshots stay in `.ziran/snapshots/` (local JSON).
+**Testing**: pytest with `@pytest.mark.unit` / `@pytest.mark.integration`; new dev dependency **respx** to mock httpx requests and assert request shape for both sinks (no real server, httpx-native). Action validated by a workflow under `.github/workflows/`.
+**Target Platform**: Linux/macOS CLI; GitHub Actions Ubuntu runner for the composite action.
+**Project Type**: Single-project hexagonal CLI (`ziran/` package).
+**Performance Goals**: Not latency-sensitive; sinks fan out concurrently via `asyncio.gather` so total alert time ≈ slowest single sink, not the sum.
+**Constraints**: No secrets in committed config (env-only, incl. `!env VAR_NAME`); dry-run contacts zero external services; partial-delivery failures exit with a distinct non-zero code separate from fatal errors.
+**Scale/Scope**: Tens of findings per run; GitHub search-API dedup is one query per finding (acceptable at this volume).
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. Hexagonal Architecture | PASS | New `AlertSink` ABC in `domain/ports/alert_sink.py`; Slack + GitHub adapters in `infrastructure/alert_sinks/`. Application services (`watch()`, `AnalyzerService`) depend only on the port. Domain stays dependency-free. |
+| II. Type Safety | PASS | All new code fully annotated; `AlertSink` is an ABC; findings and sink config are Pydantic models. mypy strict must stay green. |
+| III. Test Coverage | PASS | Unit tests for fingerprinting, severity-floor filtering, dry-run, digest grouping; integration tests with respx asserting Slack + GitHub request shape and dedup idempotency. Target ≥85%. |
+| IV. Async-First | PASS | `AlertSink.emit` is `async`; sinks use `httpx.AsyncClient`; fan-out via `asyncio.gather`. Sync only at the Click entry points (existing pattern). |
+| V. Extensibility via Adapters | PASS | New sinks are added by implementing `AlertSink`; no core changes needed. Matches existing port/adapter style (`PolicyRenderer`, `TraceIngestor`). |
+| VI. Simplicity | PASS (1 justified dep) | One shared port reused by two services (no duplication). One new **dev** dependency, respx — justified below. No new runtime deps; the Action reuses the `gh` CLI already present on runners. |
+
+**New dependency justification (respx)**: The spec requires "integration tests with a mock HTTP server verifying request shape for both sinks." respx intercepts httpx at the transport layer, letting tests assert exact request URL/headers/body without standing up a real server — lighter and more precise than pytest-httpserver, and httpx-native (matches the project's HTTP convention). Dev-only; no runtime impact.
+
+No violations requiring Complexity Tracking.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/017-runtime-loop-alerting/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (port + sink + action contracts)
+└── tasks.md             # Phase 2 output (/speckit.tasks — not created here)
+```
+
+### Source Code (repository root)
+
+```text
+ziran/
+├── domain/
+│   ├── ports/
+│   │   └── alert_sink.py            # NEW: AlertSink(ABC) — async emit(finding) -> DeliveryResult
+│   └── entities/
+│       ├── alerting.py              # NEW: AlertableFinding, DeliveryResult, AlertOutcome, fingerprint helpers
+│       └── registry.py              # EXTEND: DriftFinding gains fingerprint()/to_alertable()
+├── application/
+│   ├── registry_watch/
+│   │   └── watcher_service.py       # EXTEND: watch(..., alert_sinks, dry_run_alerts)
+│   ├── trace_analysis/
+│   │   └── analyzer_service.py      # EXTEND: AnalyzerService.emit_findings(sinks, digest=...)
+│   └── alerting/
+│       ├── __init__.py
+│       ├── dispatch.py              # NEW: fan-out (asyncio.gather), severity-floor filter, dry-run, partial-failure aggregation
+│       └── config.py                # NEW: AlertConfig / AlertSinkConfig Pydantic models
+├── infrastructure/
+│   ├── alert_sinks/
+│   │   ├── __init__.py
+│   │   ├── slack_sink.py            # NEW: SlackWebhookSink (httpx)
+│   │   ├── github_issue_sink.py     # NEW: GitHubIssueSink (httpx REST, marker-based dedup)
+│   │   └── dry_run_sink.py          # NEW: decorator/wrapper printing intended payload
+│   └── config/
+│       └── env_yaml.py              # NEW: `!env VAR_NAME` YAML loader/constructor
+└── interfaces/cli/
+    ├── watch_registry.py            # EXTEND: build sinks from config, --dry-run-alerts, exit-code contract
+    └── analyze_traces.py            # EXTEND: --alert / --digest flags, exit-code contract
+
+.github/actions/export-policy/
+└── action.yml                       # NEW: composite action (gh CLI + python entry calling ziran)
+.github/workflows/
+└── policy-refresh-selftest.yml      # NEW: e2e test running the action against the example agent
+examples/07-cicd-quality-gate/
+└── policy-refresh.yml               # NEW: copyable workflow template
+docs/guides/
+├── analyze-traces.md                # EXTEND: "Alerting" section
+└── policy-refresh-automation.md     # NEW guide
+
+tests/
+├── unit/
+│   ├── test_alert_fingerprint.py
+│   ├── test_alert_dispatch.py       # severity floor, dry-run, partial-failure aggregation/exit
+│   └── test_env_yaml.py
+└── integration/
+    ├── test_slack_sink.py           # respx: request shape
+    ├── test_github_issue_sink.py    # respx: create + marker-search dedup idempotency
+    ├── test_watch_registry_alerting.py
+    └── test_analyze_traces_alerting.py
+```
+
+**Structure Decision**: Single-project hexagonal layout (the only structure in this repo). The shared notification logic is split across the three layers: the contract (`domain/ports/alert_sink.py`) and finding shape (`domain/entities/alerting.py`) in the domain; orchestration (fan-out, filtering, dry-run, failure aggregation) in a new `application/alerting/` package reused by both services; concrete Slack/GitHub adapters and the `!env` YAML loader in infrastructure. The policy-refresh automation is repository tooling (a composite Action + workflow template) that invokes the existing `ziran scan` / `ziran export-policy` commands rather than new library code.
+
+## Complexity Tracking
+
+> No constitution violations. Section intentionally empty.

--- a/specs/017-runtime-loop-alerting/quickstart.md
+++ b/specs/017-runtime-loop-alerting/quickstart.md
@@ -1,0 +1,80 @@
+# Quickstart: Runtime Loop Alerting and Automation
+
+## 1. Alert on MCP registry drift (US1 / #272)
+
+```yaml
+# registry.yaml
+servers:
+  - name: prod-mcp-server
+    url: https://mcp.prod.example.com
+alerts:
+  - kind: slack
+    webhook_url: !env SLACK_WEBHOOK_URL
+    severity_floor: medium
+  - kind: github_issue
+    repo: myorg/ai-agent-infra
+    token: !env GH_TOKEN
+    labels: [mcp-drift, security]
+    severity_floor: high
+```
+
+```bash
+export SLACK_WEBHOOK_URL=...    # never committed
+export GH_TOKEN=...
+ziran watch-registry --config registry.yaml             # alerts fire on drift
+ziran watch-registry --config registry.yaml --dry-run-alerts   # preview, no sends
+```
+
+Re-running produces **no duplicate** GitHub issues (stateless fingerprint marker).
+
+## 2. File issues from dangerous production traces (US2 / #274)
+
+```bash
+ziran analyze-traces traces.jsonl --config analyze.yaml --alert            # one issue per (chain, session)
+ziran analyze-traces traces.jsonl --config analyze.yaml --alert --digest   # one aggregated issue per run
+```
+
+Each issue includes the observed tool sequence, a link to the matching pre-deploy finding (and existing issue if any), session ID, trace source link, inherited severity, and remediation when a policy bundle covers the chain.
+
+## 3. Keep exported policies fresh (US3 / #273)
+
+```yaml
+# .github/workflows/policy-refresh.yml  (copied from examples/07-cicd-quality-gate/)
+on:
+  schedule: [{ cron: "0 6 * * 1" }]   # weekly
+  workflow_dispatch:
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    permissions: { contents: write, pull-requests: write }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/export-policy
+        with:
+          target: examples/01-langchain-agent/agent.yaml
+          out-dir: policies/
+          target-formats: rego,cedar
+          reviewer-team: secops
+```
+
+Stale bundle → a single `ziran/policy-refresh` PR is opened/updated. Current bundle → no PR. Set `fail-on-diff: "true"` to hard-block instead.
+
+## Exit codes (scheduling)
+
+| Code | Meaning |
+|---|---|
+| 0 | All eligible findings delivered (or nothing eligible). |
+| 2 | Partial delivery failure — detection ran, ≥1 sink failed. |
+| 1 | Fatal/usage error (bad config, unset `!env` var) **or** the pre-existing `watch-registry` severity gate (critical/high drift present). |
+
+> Note: exit `1` is overloaded on `watch-registry` — it signals both a fatal error and the existing "critical/high findings present" severity gate. Schedulers that need to distinguish a crash from a severity gate should parse the run output, not rely on the code alone. Precedence: fatal(1) > delivery-failure(2) > severity-gate(1) > 0.
+
+## Verify locally
+
+```bash
+uv run ruff check . && uv run ruff format --check .
+uv run mypy ziran/
+uv run pytest -m "unit or integration" --cov=ziran
+```
+
+Integration tests use respx — no real Slack/GitHub calls.

--- a/specs/017-runtime-loop-alerting/research.md
+++ b/specs/017-runtime-loop-alerting/research.md
@@ -1,0 +1,84 @@
+# Phase 0 Research: Runtime Loop Alerting and Automation
+
+All `/speckit.clarify` questions were resolved in the spec's Clarifications section. The items below are the remaining design decisions that were deferred to planning (digest cadence, refresh-PR identity, Slack format) plus the technology choices introduced by this plan.
+
+## R1 — Stateless GitHub-issue deduplication
+
+**Decision**: Embed a hidden HTML-comment marker `<!-- ziran-fingerprint: <fp> -->` at the end of each created issue body. To dedup before creating, query the GitHub Search API: `GET /search/issues?q=repo:{owner}/{repo}+in:body+"ziran-fingerprint: {fp}"+is:issue` (no `is:open` qualifier, so closed issues match too). If any result is found, skip creation and reuse that issue's URL (also used to satisfy FR-014's "link to existing issue").
+
+**Rationale**: Confirmed by clarify Q1 (Option A). Stateless, survives across machines/CI runners, and the same query gives both dedup and the existing-issue link. Avoids a local state file that could diverge.
+
+**Alternatives considered**: Local `.ziran/alerts/state.json` map (rejected — state loss/divergence across runners); unique label per fingerprint (rejected — pollutes the label namespace, 50-label cap per issue).
+
+**Caveats**: GitHub Search API is eventually consistent (seconds) and rate-limited (30 req/min authenticated). At the expected volume (tens of findings/run) this is fine; if a future high-volume need arises, batch the search. Marker must be a stable, collision-resistant string (see R3).
+
+## R2 — Fingerprint composition
+
+**Decision**:
+- Drift finding fingerprint = `sha256("drift|" + server_name + "|" + tool_name + "|" + drift_type)[:16]` (clarify Q2, Option A — excludes `current_value`).
+- Trace finding fingerprint = `sha256("trace|" + tool_chain_hash + "|" + session_id)[:16]` (FR-016). `tool_chain_hash` is the ordered tool-name sequence of the `DangerousChain`.
+
+**Rationale**: Matches clarify decisions. A short hex digest is human-skimmable in the marker and stable across runs. The `drift|`/`trace|` prefix prevents cross-type collisions.
+
+**Alternatives considered**: Including changed value in drift fp (rejected per Q2 — noisy); raw concatenation without hashing (rejected — leaks long values into markers and search queries).
+
+## R3 — Partial-delivery exit-code contract
+
+**Decision**: Define an exit-code convention for the alerting-capable commands:
+- `0` — success (all eligible findings delivered, or nothing eligible).
+- `2` — partial delivery failure (detection succeeded, ≥1 sink delivery failed).
+- `1` — fatal/usage error (config invalid, unhandled exception), consistent with existing CLI behavior.
+
+The dispatcher returns an aggregated `AlertOutcome` (per-sink success/failure); the CLI maps "any delivery failed" → exit 2.
+
+**Rationale**: Clarify Q3 (Option A). Distinct code lets schedulers alert on delivery problems without conflating them with crashes. Note: existing `watch-registry` already uses `SystemExit(1)` to signal "critical/high findings present"; that severity-gate exit is orthogonal and preserved — delivery-failure (2) is evaluated only when the run otherwise completes. Documented precedence: fatal(1) > delivery-failure(2) > severity-gate(existing) > 0.
+
+**Alternatives considered**: single generic non-zero (rejected — Q3 B); always exit 0 (rejected — Q3 C, masks failures).
+
+## R4 — `!env VAR_NAME` YAML tag
+
+**Decision**: Register a custom PyYAML constructor for the `!env` tag on a dedicated SafeLoader subclass in `infrastructure/config/env_yaml.py`: `!env SLACK_WEBHOOK_URL` resolves to `os.environ["SLACK_WEBHOOK_URL"]` at load time, raising a clear error if the var is unset. Also accept plain `${VAR}` interpolation for parity with the existing `browser_adapter.py` convention.
+
+**Rationale**: No `!env` tag exists yet (confirmed in exploration). A scoped loader keeps the tag out of the global `yaml.safe_load` used elsewhere. Resolving at load time keeps secrets out of committed config (FR-005, SC-006).
+
+**Alternatives considered**: Pydantic `SecretStr` + manual env lookup in each model (rejected — repetitive, doesn't support inline `!env` in arbitrary fields); environment-variable-only with no YAML tag (rejected — spec explicitly calls for `!env VAR_NAME`).
+
+## R5 — Slack message format
+
+**Decision**: Post Slack Block Kit JSON (a `blocks` array: a header block with severity emoji + finding kind, a section with fields for server/tool/before-after or tool-sequence/session, and a context block linking the snapshot diff or trace). Fall back to a `text` summary field for notification previews.
+
+**Rationale**: Block Kit renders structured, scannable alerts and is the Slack-recommended webhook payload. The `text` fallback guarantees a useful mobile/notification preview.
+
+**Alternatives considered**: Plain `text` only (rejected — poor scannability for multi-field findings).
+
+## R6 — GitHub issue creation transport
+
+**Decision**: The runtime **issue sink** calls the GitHub REST API directly via `httpx.AsyncClient` (`POST /repos/{owner}/{repo}/issues`, `GET /search/issues`) with a bearer token from env. The **policy-refresh composite Action** (#273) instead shells out to the `gh` CLI for scan/export/PR operations.
+
+**Rationale**: The sink runs inside async ZIRAN flows where httpx is the established convention and respx makes request-shape testing clean. The Action runs on a GitHub runner where `gh` is pre-installed and idiomatic for PR creation; using it keeps the Action dependency-free (#273 "no new runtime deps").
+
+**Alternatives considered**: shelling `gh` from the sink (rejected — not async, harder to unit-test, adds a CLI dependency to the library path); using a REST client inside the Action (rejected — reinvents `gh`).
+
+## R7 — Trace digest mode
+
+**Decision**: `AnalyzerService.emit_findings(sinks, digest=False)`. When `digest=True`, group all dangerous-chain matches from the run into one aggregated GitHub issue (table of chains, sessions, severities) with a digest-level fingerprint = `sha256("trace-digest|" + "|".join(sorted(chain_fingerprints)))[:16]`. The run date is deliberately excluded so re-running on unchanged traces (even on a later day) reuses the same digest issue rather than filing a duplicate (SC-002). If the set of chains changes, the fingerprint changes and a new digest issue is opened — the desired signal that the production picture changed. When `False` (default), emit one finding per `(chain, session)`.
+
+**Rationale**: Per the spec's "digest window = analyzer run" assumption, kept consistent with SC-002's sequential no-duplicate guarantee. Keeps dedup uniform (digest issue also carries a marker).
+
+**Alternatives considered**: time-windowed scheduler (rejected — out of scope per Assumptions); per-session always (rejected — high-traffic agents flood issues).
+
+## R8 — Single long-lived refresh PR
+
+**Decision**: The Action commits regenerated policies to a fixed branch `ziran/policy-refresh` and uses `gh pr create` if no open PR for that branch exists, else `gh pr edit`/push to update it. The branch acts as the stable identity, so squash vs merge-commit strategy on the base branch doesn't spawn duplicates (FR-024).
+
+**Rationale**: A fixed head branch is the simplest stable PR identity and is how `peter-evans/create-pull-request` and similar patterns achieve idempotent refresh PRs.
+
+**Alternatives considered**: PR title/label search to locate the PR (rejected — fragile vs renamed titles); new branch per run (rejected — spawns duplicate PRs, violates FR-024).
+
+## R9 — respx for sink integration tests
+
+**Decision**: Add `respx` as a dev dependency; integration tests register routes for the Slack webhook URL and GitHub REST/search endpoints, then assert the recorded request method/URL/headers/JSON body and simulate dedup by returning a search hit on the second call.
+
+**Rationale**: httpx-native, no real server, precise request-shape assertions (spec acceptance). Lighter than pytest-httpserver.
+
+**Alternatives considered**: pytest-httpserver (rejected — heavier, spins a real WSGI server); `unittest.mock` on the client (rejected — doesn't verify real serialization/request shape, which the acceptance criteria require).

--- a/specs/017-runtime-loop-alerting/spec.md
+++ b/specs/017-runtime-loop-alerting/spec.md
@@ -1,0 +1,161 @@
+# Feature Specification: Runtime Loop Alerting and Automation
+
+**Feature Branch**: `017-runtime-loop-alerting`  
+**Created**: 2026-05-29  
+**Status**: Draft  
+**Input**: User description: "Close the pre-deploy→runtime→observability feedback loop from the v0.8 runtime bridge (spec 011) by making three existing one-shot commands actively notify humans and repos: watch-registry alerting (#272), analyze-traces alerting (#274), and a policy-export auto-refresh GitHub Action (#273)."
+
+## Overview
+
+The v0.8 runtime bridge (spec 011) shipped three commands that each produce findings but stop at writing a file or printing to stdout: `watch-registry` (MCP drift detection), `analyze-traces` (production trace analysis), and `export-policy` (guardrail policy generation). A scheduled watcher, a trace analyzer, and a policy exporter only deliver value if their output reaches the humans and systems that can act on it. This feature closes the loop by routing findings to people (Slack), to tracking systems (GitHub issues), and to source control (policy-refresh pull requests) — with deduplication so repeated runs do not generate noise.
+
+## Clarifications
+
+### Session 2026-05-29
+
+- Q: How should the GitHub issue sink know a finding was already filed (dedup mechanism)? → A: GitHub-side marker — embed the fingerprint as a hidden marker in the issue body and dedup by searching open + closed issues via the GitHub API (stateless; no local state file).
+- Q: What composes the fingerprint for a registry drift finding? → A: `(server, tool, drift-kind)` — the same kind of drift on the same tool is one finding regardless of the specific new value.
+- Q: What exit status should a run return when detection succeeds but at least one delivery fails? → A: A distinct non-zero exit code for partial delivery failure, separate from the fatal-crash code.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Registry drift reaches a human (Priority: P1)
+
+A security engineer runs `watch-registry` on a schedule against production MCP servers. When the watcher detects drift — a newly added tool, a changed tool description, a permission escalation, or a suspected typosquat — the finding is delivered to a configured Slack channel and/or filed as a GitHub issue, instead of disappearing into a log file nobody reads.
+
+**Why this priority**: This is the foundational slice. It introduces the shared notification capability (the "alert sink" concept) that the other stories reuse, and it delivers immediate standalone value: scheduled watchers become actionable. Without it, the other two stories have nothing to build on.
+
+**Independent Test**: Configure a watcher with a Slack sink and a GitHub issue sink pointed at test endpoints, introduce a drift event in a mock registry snapshot, run the watcher, and confirm a correctly-formatted Slack message and a GitHub issue are produced. Re-run with no new drift and confirm nothing new is sent.
+
+**Acceptance Scenarios**:
+
+1. **Given** a watcher configured with a Slack sink and a drift event of severity at or above the sink's floor, **When** the watcher runs, **Then** a formatted message describing the drift (kind, server, before/after, severity) is delivered to the configured channel.
+2. **Given** a watcher configured with a GitHub issue sink, **When** a new drift event is detected, **Then** an issue is opened in the configured repository with the configured labels, pre-filled context, and a link to the registry snapshot diff.
+3. **Given** a drift event below a sink's configured severity floor, **When** the watcher runs, **Then** that sink does not emit anything for that event.
+4. **Given** the same drift event has already produced a GitHub issue, **When** the watcher runs again, **Then** no duplicate issue is opened.
+5. **Given** the operator passes a dry-run option, **When** the watcher runs, **Then** the system prints what each sink would send without contacting any external service.
+6. **Given** a sink's credential is missing or the external service rejects the request, **When** the watcher runs, **Then** the failure is reported clearly and does not prevent other sinks or other findings from being processed.
+
+---
+
+### User Story 2 - Dangerous production behavior files a tracked issue (Priority: P2)
+
+An operator runs `analyze-traces` against exported production traces (OTel JSONL or Langfuse). When a reconstructed tool-call sequence matches a dangerous chain that ZIRAN flagged during a pre-deploy scan, the system opens a GitHub issue routing the finding to whoever can fix it — including the observed tool sequence, the matching pre-deploy finding, the trace source link, the inherited severity, and suggested remediation when available.
+
+**Why this priority**: This closes the observability half of the loop and reuses the notification capability from Story 1, so it is lower risk and naturally sequenced after P1. It depends on Story 1's sink concept existing.
+
+**Independent Test**: Feed synthetic trace fixtures containing one novel dangerous-chain execution to the analyzer with a GitHub issue sink, and confirm exactly one issue is opened with the required content. Re-run on the same fixtures and confirm zero new issues.
+
+**Acceptance Scenarios**:
+
+1. **Given** a trace that matches a dangerous chain from a prior scan, **When** `analyze-traces` runs with a GitHub issue sink, **Then** an issue is opened containing the exact tool sequence, a link to the matching pre-deploy finding (and the existing issue if one exists), the session ID and trace source link, and the severity copied from the matched finding.
+2. **Given** an exported policy bundle covers the matched chain, **When** the issue is filed, **Then** the issue includes the suggested remediation derived from that bundle.
+3. **Given** the same dangerous chain in the same session has already been filed, **When** `analyze-traces` is re-run on the same traces, **Then** no duplicate issue is created.
+4. **Given** the operator selects aggregated digest mode, **When** multiple dangerous chains are detected in a run, **Then** they are combined into a single periodic digest rather than one issue per session.
+
+---
+
+### User Story 3 - Exported policies stay fresh automatically (Priority: P3)
+
+A platform team wires a reusable automation into their repository so that exported guardrail policies do not silently go stale as the attack library or target agent configuration changes. On a weekly schedule (or manual trigger), the automation re-scans the target, regenerates the policy bundle, and — if the generated policies differ from what is committed — opens or updates a pull request with the refreshed files for review.
+
+**Why this priority**: This is valuable but independent of the sink work and the heaviest to validate end-to-end (it runs real commands in CI and manipulates pull requests), so it is sequenced last. It can ship separately without blocking Stories 1 and 2.
+
+**Independent Test**: Run the automation against the bundled example agent in a test repository, confirm a pull request with regenerated policy files is opened when the committed bundle is stale, and confirm no pull request is opened when the bundle is already current.
+
+**Acceptance Scenarios**:
+
+1. **Given** the committed policy bundle is out of date relative to a fresh scan, **When** the automation runs, **Then** a pull request is opened (or the existing refresh PR is updated) with the regenerated policy files, labeled for policy refresh and assigned to a reviewer team.
+2. **Given** the committed policy bundle already matches a fresh scan, **When** the automation runs, **Then** no pull request is created.
+3. **Given** the team configures hard enforcement instead of pull requests, **When** the generated policies differ from the committed bundle, **Then** the automation fails the run so the difference blocks the pipeline.
+4. **Given** the team scopes the automation to a subset of policy formats, **When** it runs, **Then** only the selected formats are regenerated and diffed.
+5. **Given** either a squash or a merge-commit pull request strategy, **When** the refresh runs across iterations, **Then** it continues to update a single refresh pull request rather than spawning duplicates.
+
+---
+
+### Edge Cases
+
+- **External service outage**: A sink endpoint is unreachable or returns an error — the run records the failure, continues with remaining sinks/findings, and exits with a status that signals partial delivery rather than silent success.
+- **Missing credentials**: A configured sink has no available secret — the system reports the misconfiguration clearly before attempting delivery rather than failing mid-send.
+- **Severity floor excludes everything**: All findings fall below every sink's floor — the run completes cleanly and reports that nothing was eligible to send.
+- **Fingerprint collisions vs. genuine recurrence**: Two genuinely distinct findings must not share a fingerprint; the same finding recurring must reuse its fingerprint so it dedups.
+- **Reopened/closed issues**: A previously filed issue was manually closed — re-detection must not silently reopen or spam; behavior here is defined in Assumptions.
+- **Concurrent automation runs**: Two scheduled policy-refresh runs overlap — they must not open competing pull requests for the same refresh.
+- **Empty inputs**: No registry snapshot history yet, or no traces in the input — the commands complete without error and emit nothing.
+- **Dry-run with real credentials present**: Dry-run must never contact external services even when credentials are configured.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Shared notification capability
+
+- **FR-001**: The system MUST provide a single notification abstraction that accepts a finding and delivers it to an external destination, reusable across the registry watcher and the trace analyzer.
+- **FR-002**: The system MUST support delivering findings to a Slack channel via webhook and to a GitHub repository as an issue.
+- **FR-003**: The system MUST allow multiple notification destinations to be configured simultaneously, and MUST attempt delivery to every configured destination for each eligible finding.
+- **FR-004**: Each notification destination MUST support a configurable minimum severity (severity floor); findings below the floor MUST NOT be delivered to that destination.
+- **FR-005**: The system MUST source destination credentials (webhook URLs, access tokens) from environment variables, including via an `!env VAR_NAME` reference in YAML configuration, and MUST NOT require secrets to be written inline in committed configuration.
+- **FR-006**: The GitHub issue destination MUST deduplicate by a stable finding fingerprint so that re-running does not open duplicate issues for the same finding. Deduplication MUST be stateless: the fingerprint is embedded as a hidden marker in the issue body, and the destination checks for an existing issue by searching open and closed issues via the GitHub API (no local dedup-state file).
+- **FR-007**: The system MUST provide a dry-run mode that prints what each destination would send without contacting any external service.
+- **FR-008**: A delivery failure to one destination MUST NOT prevent delivery attempts to other destinations or processing of other findings; failures MUST be surfaced to the operator. When detection succeeds but one or more deliveries fail, the run MUST exit with a distinct non-zero status code that is separate from the code used for a fatal/crash error, so schedulers can distinguish partial-delivery failures from hard failures.
+
+#### Registry drift alerting (`watch-registry`)
+
+- **FR-009**: The registry watcher MUST emit every detected drift finding (added tool, changed description, permission escalation, suspected typosquat) to each configured notification destination. A drift finding's dedup fingerprint MUST be composed of `(server, tool, drift-kind)`, so a recurring drift of the same kind on the same tool reuses one issue regardless of the specific changed value.
+- **FR-010**: Slack drift messages MUST include the drift kind, affected server, the relevant before/after detail, and severity.
+- **FR-011**: GitHub drift issues MUST include configured labels, pre-filled context, and a representation of the registry snapshot diff: a resolvable URL when one is available (e.g. a CI-published snapshot artifact), otherwise an inline diff summary (the changed before/after values) embedded directly in the issue body. A bare local filesystem path MUST NOT be used as the link, since it is not resolvable by a remote reader.
+- **FR-012**: Notification configuration for the watcher MUST be expressible in YAML alongside the existing registry configuration.
+
+#### Production trace alerting (`analyze-traces`)
+
+- **FR-013**: When the trace analyzer identifies a dangerous-chain execution in production traces, it MUST be able to deliver that finding through the shared notification capability.
+- **FR-014**: A trace-derived GitHub issue MUST include the observed tool sequence, a link to the matching pre-deploy finding (and to the existing issue for that finding if one exists, located via the same embedded-marker search used for deduplication), the session identifier, the trace source link (e.g., Langfuse URL or OTel trace identifier), and the severity copied from the matched pre-deploy finding.
+- **FR-015**: When an exported policy bundle covers the matched chain, the issue MUST include the corresponding suggested remediation.
+- **FR-016**: Trace findings MUST be deduplicated by a fingerprint combining the tool-chain identity and the session, so re-running on the same traces produces no new issues.
+- **FR-017**: The trace analyzer MUST support both per-session issues and an aggregated periodic digest mode.
+
+#### Policy-export automation (`export-policy`)
+
+- **FR-018**: The system MUST provide a reusable repository automation that scans a configured target, regenerates the policy bundle, and compares the result against the committed bundle.
+- **FR-019**: When the regenerated bundle differs from the committed bundle, the automation MUST open or update a single pull request containing the refreshed files, apply a policy-refresh label, and assign a reviewer team.
+- **FR-020**: When the regenerated bundle matches the committed bundle, the automation MUST make no change and open no pull request.
+- **FR-021**: The automation MUST support a hard-enforcement option that fails the run on any difference instead of opening a pull request.
+- **FR-022**: The automation MUST support scoping to a subset of the supported policy formats (OPA/Rego, Cedar, NeMo Colang, Invariant Labs), defaulting to all formats.
+- **FR-023**: The automation MUST support both scheduled (e.g., weekly) and manual invocation.
+- **FR-024**: The automation MUST function under both squash and merge-commit pull request strategies without producing duplicate refresh pull requests.
+- **FR-025**: The system MUST provide a documented, copyable workflow template demonstrating the automation.
+
+#### Documentation
+
+- **FR-026**: The trace-analysis guide MUST gain a section describing alerting configuration and behavior.
+- **FR-027**: A new guide MUST document the policy-refresh automation end to end.
+
+### Key Entities *(include if feature involves data)*
+
+- **Finding**: A normalized unit of information eligible for delivery — carries a kind, a severity, descriptive context, and a stable fingerprint used for deduplication. The fingerprint is embedded as a hidden marker in any GitHub issue created for the finding. Specializations include a registry drift finding (fingerprint = `(server, tool, drift-kind)`) and a dangerous-chain trace finding (fingerprint = tool-chain identity + session).
+- **Notification Destination**: A configured target that can receive findings (Slack channel via webhook, or GitHub repository as issues), with its own severity floor and credentials.
+- **Drift Event**: A change between two registry snapshots (added tool, description change, permission escalation, suspected typosquat), with affected server and before/after detail.
+- **Dangerous-Chain Match**: A reconstructed production tool-call sequence that matches a pre-deploy finding, carrying the session identity, trace source link, inherited severity, and optional remediation reference.
+- **Policy Bundle**: The set of exported guardrail policy files (across one or more formats) that the automation compares against the committed version to decide whether a refresh is needed.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A drift event detected by the watcher reaches every configured destination at or above its severity floor in a single run, with zero manual steps after configuration.
+- **SC-002**: Re-running the watcher or the trace analyzer sequentially on unchanged input produces zero duplicate GitHub issues. Deduplication is best-effort under concurrent runs (the GitHub search index is eventually consistent); strict no-duplicate guarantees apply to sequential re-runs, not to two runs racing within the index-propagation window.
+- **SC-003**: A dangerous-chain match in production traces results in a tracked issue containing all required context (tool sequence, matched finding link, session, trace link, severity) in 100% of matches.
+- **SC-004**: When the committed policy bundle is stale, the automation surfaces the difference as a reviewable pull request (or a failed run under hard enforcement) on every scheduled run, and produces no pull request when the bundle is current.
+- **SC-005**: A failure delivering to one destination never blocks delivery to other destinations or processing of other findings, and is always reported to the operator.
+- **SC-006**: No secret value is ever required in committed configuration; all credentials resolve from the environment.
+- **SC-007**: Dry-run mode contacts zero external services while still showing the operator exactly what would be sent.
+
+## Assumptions
+
+- **Reused commands**: `watch-registry`, `analyze-traces`, and `export-policy` already exist (shipped in the v0.8 runtime bridge, spec 011) and produce the findings this feature routes; this feature adds delivery and automation, not the underlying detection.
+- **Scope boundary**: The NeMo Guardrails DefenceProfile evaluator (issue #271) is explicitly out of scope — it has been moved to the Ziran Cloud repository. Where this feature mentions NeMo Colang, that refers only to the existing policy-export output format, not a guardrail evaluator.
+- **Closed/reopened issues**: Deduplication searches both open and closed issues for the embedded fingerprint marker; a manually closed issue is treated as already-filed and is not reopened. This conservative default avoids spam and can be revisited.
+- **GitHub as the issue backend**: "Issue" destinations target GitHub repositories; other trackers are out of scope for this release.
+- **Severity model**: Findings carry a severity comparable against a configured floor using the project's existing severity ordering; no new severity scheme is introduced.
+- **Digest cadence**: Aggregated digest mode groups findings per analyzer run (treated as the digest window); a finer-grained scheduler is out of scope. The digest's dedup fingerprint is derived solely from the set of contained chain fingerprints (NOT the run date), so re-running on unchanged traces — even on a later day — reuses the same digest issue rather than filing a new one, consistent with SC-002.
+- **Single refresh PR**: The policy-refresh automation maintains one long-lived refresh pull request per repository/target, identified by a stable branch or marker, rather than one PR per run.

--- a/specs/017-runtime-loop-alerting/tasks.md
+++ b/specs/017-runtime-loop-alerting/tasks.md
@@ -1,0 +1,196 @@
+---
+description: "Task list for Runtime Loop Alerting and Automation"
+---
+
+# Tasks: Runtime Loop Alerting and Automation
+
+**Input**: Design documents from `/specs/017-runtime-loop-alerting/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: INCLUDED — the spec's acceptance criteria explicitly require integration tests with a mock HTTP server (respx) and dedup/idempotency tests.
+
+**Organization**: Tasks grouped by user story. The shared notification capability (port, entities, dispatcher, sinks, `!env` loader) is foundational because both US1 and US2 depend on it; US3 is fully independent.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: US1 / US2 / US3 (Setup/Foundational/Polish have no story label)
+
+## Path Conventions
+
+Single-project hexagonal layout: code in `ziran/`, tests in `tests/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Project scaffolding for the alerting feature
+
+- [X] T001 Add `respx` as a dev dependency in `pyproject.toml` (test group) and create the new package directories with `__init__.py`: `ziran/application/alerting/`, `ziran/infrastructure/alert_sinks/`, `ziran/infrastructure/config/`
+- [X] T002 [P] Add shared respx + asyncio test fixtures (httpx transport mock, fake Slack webhook URL, fake GitHub API base) to `tests/conftest.py` or `tests/fixtures/alerting.py`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The shared `AlertSink` notification capability reused by US1 and US2
+
+**⚠️ CRITICAL**: US1 and US2 cannot begin until this phase is complete. (US3 is independent and may proceed in parallel.)
+
+- [X] T003 [P] Create alerting domain entities (`AlertableFinding`, `AlertLink`, `DeliveryResult`, `AlertOutcome`) and pure fingerprint helpers (`drift_fingerprint`, `trace_fingerprint`, `digest_fingerprint`) in `ziran/domain/entities/alerting.py` per data-model.md
+- [X] T004 [P] Define the `AlertSink` ABC (`name`, `async emit(finding) -> DeliveryResult`) in `ziran/domain/ports/alert_sink.py` per contracts/alert_sink_port.md
+- [X] T005 [P] Implement the `!env VAR_NAME` YAML loader/constructor (plus `${VAR}` interpolation) in `ziran/infrastructure/config/env_yaml.py`, raising a clear error on unset vars (research R4)
+- [X] T006 [P] Implement `AlertSinkConfig` and `AlertConfig` Pydantic models (with kind-conditional validation) in `ziran/application/alerting/config.py` per data-model.md
+- [X] T007 Implement the dispatcher in `ziran/application/alerting/dispatch.py`: severity-floor filtering, `asyncio.gather` fan-out, partial-failure aggregation into `AlertOutcome` (depends on T003, T004)
+- [X] T008 [P] Implement the `DryRunSink` wrapper in `ziran/infrastructure/alert_sinks/dry_run_sink.py` (prints payload, zero I/O) (depends on T004)
+- [X] T009 Implement `SlackWebhookSink` in `ziran/infrastructure/alert_sinks/slack_sink.py` (httpx, Block Kit + text fallback) per contracts/sinks_http.md (depends on T003, T004)
+- [X] T010 Implement `GitHubIssueSink` in `ziran/infrastructure/alert_sinks/github_issue_sink.py` (httpx REST: marker-search dedup → create, fingerprint marker in body) per contracts/sinks_http.md (depends on T003, T004)
+- [X] T011 Implement the sink factory (`AlertConfig` → list of concrete sinks, wrapping in `DryRunSink` when dry-run) in `ziran/application/alerting/factory.py` (depends on T006, T008, T009, T010)
+- [X] T012 [P] Unit tests for fingerprint helpers + severity-floor/dry-run/partial-failure aggregation in `tests/unit/test_alert_fingerprint.py` and `tests/unit/test_alert_dispatch.py`
+- [X] T013 [P] Unit tests for the `!env` loader (resolve, unset-var error, `${VAR}`) in `tests/unit/test_env_yaml.py`
+- [X] T014 [P] Integration test (respx) asserting Slack request shape in `tests/integration/test_slack_sink.py`
+- [X] T015 [P] Integration test (respx) asserting GitHub create + marker-search dedup idempotency (zero duplicate POST on re-run) in `tests/integration/test_github_issue_sink.py`
+
+**Checkpoint**: Shared notification capability complete and tested — US1/US2 can begin.
+
+---
+
+## Phase 3: User Story 1 - Registry drift reaches a human (Priority: P1) 🎯 MVP
+
+**Goal**: `watch-registry` delivers every drift finding to configured Slack/GitHub sinks, with severity floors, dry-run, and stateless dedup.
+
+**Independent Test**: Configure a watcher with both sinks against respx endpoints, introduce a drift event in a mock snapshot, run the watcher → assert a formatted Slack message and one GitHub issue; re-run with no new drift → nothing new sent.
+
+### Tests for User Story 1
+
+- [X] T016 [P] [US1] Integration test (respx) for `watch-registry` end-to-end alerting + dedup on re-run in `tests/integration/test_watch_registry_alerting.py`
+- [X] T017 [P] [US1] Unit test for `DriftFinding.fingerprint()` = `(server, tool, drift-kind)` and `to_alertable()` mapping in `tests/unit/test_drift_alertable.py`
+
+### Implementation for User Story 1
+
+- [X] T018 [US1] Add `fingerprint()` and `to_alertable()` to `DriftFinding` in `ziran/domain/entities/registry.py`: emit before/after values as inline `fields`, and add a snapshot-diff `AlertLink` only when a remote-resolvable URL exists (else rely on the inline summary, per FR-011) (depends on T003)
+- [X] T019 [US1] Extend the registry config model + loader to parse the `alerts:` block using the `!env` loader in `ziran/application/registry_watch/` config + `ziran/infrastructure/config/env_yaml.py` (depends on T005, T006)
+- [X] T020 [US1] Extend `watch(...)` to accept `alert_sinks` + `dry_run_alerts`, map findings via `to_alertable()`, and dispatch in `ziran/application/registry_watch/watcher_service.py` (depends on T007, T018)
+- [X] T021 [US1] Wire the `watch-registry` CLI: build sinks from config via factory, add `--dry-run-alerts`, map `AlertOutcome` to the exit-code contract (0/2/1, preserving the existing severity-gate) in `ziran/interfaces/cli/watch_registry.py` (depends on T011, T020)
+
+**Checkpoint**: US1 fully functional and independently testable — MVP ready.
+
+---
+
+## Phase 4: User Story 2 - Dangerous production behavior files a tracked issue (Priority: P2)
+
+**Goal**: `analyze-traces` opens (deduped) GitHub issues for dangerous chains observed in production, with full context, optional remediation, and a digest mode.
+
+**Independent Test**: Feed synthetic trace fixtures with one novel dangerous-chain execution + a GitHub sink → assert exactly one issue with required content; re-run → zero new issues.
+
+### Tests for User Story 2
+
+- [ ] T022 [P] [US2] Integration test (respx) for `analyze-traces` per-session issue + dedup on re-run in `tests/integration/test_analyze_traces_alerting.py`
+- [ ] T023 [P] [US2] Unit test for trace fingerprint `(tool_chain_hash + session_id)` and digest grouping/fingerprint (assert the digest fingerprint excludes the run date, so unchanged traces dedup across days) in `tests/unit/test_trace_alertable.py`
+
+### Implementation for User Story 2
+
+- [ ] T024 [US2] Implement `DangerousChain` (observed-in-production) → `AlertableFinding` mapping: tool sequence, matched-finding link, existing-issue link via marker search, session ID, trace source link, inherited severity, remediation from a covering `GuardrailPolicy`, in `ziran/application/trace_analysis/` (new mapping module) (depends on T003)
+- [ ] T025 [US2] Implement `AnalyzerService.emit_findings(sinks, digest=False)` with per-`(chain, session)` and aggregated-digest modes in `ziran/application/trace_analysis/analyzer_service.py` (depends on T007, T024)
+- [ ] T026 [US2] Extend the analyze config loader to parse the `alerts:` block (`!env`) in `ziran/application/trace_analysis/` config (depends on T005, T006)
+- [ ] T027 [US2] Wire the `analyze-traces` CLI: `--alert` / `--digest` flags, build sinks via factory, map `AlertOutcome` to exit codes in `ziran/interfaces/cli/analyze_traces.py` (depends on T011, T025, T026)
+
+**Checkpoint**: US1 and US2 both work independently.
+
+---
+
+## Phase 5: User Story 3 - Exported policies stay fresh automatically (Priority: P3)
+
+**Goal**: A reusable composite GitHub Action re-scans, regenerates policies, and opens/updates a single refresh PR (or fails on diff). Independent of the sink work.
+
+**Independent Test**: Run the action against the bundled example agent in a test repo → PR opened when committed bundle is stale, no PR when current.
+
+### Tests for User Story 3
+
+- [ ] T028 [US3] Self-test workflow `.github/workflows/policy-refresh-selftest.yml` that runs the action against the example agent and asserts PR-opened-when-stale / no-PR-when-current
+
+### Implementation for User Story 3
+
+- [ ] T029 [P] [US3] Author the composite action `.github/actions/export-policy/action.yml` (inputs: target, out-dir, target-formats, fail-on-diff, reviewer-team; steps: install → `ziran scan` → `ziran export-policy --formats` → diff → fixed-branch `ziran/policy-refresh` PR via `gh`, label `policy-refresh`, request reviewer) per contracts/cli_and_action.md
+- [ ] T030 [P] [US3] Add the copyable workflow template `examples/07-cicd-quality-gate/policy-refresh.yml` (weekly schedule + `workflow_dispatch`), including a `concurrency: { group: ziran-policy-refresh, cancel-in-progress: true }` block so overlapping scheduled runs cannot open competing PRs (spec "Concurrent automation runs" edge case, FR-024)
+- [ ] T031 [P] [US3] Verify `ziran export-policy` accepts a `--formats` scoping option; add it in `ziran/interfaces/cli/export_policy.py` if missing (FR-022)
+
+**Checkpoint**: All three user stories independently functional.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [ ] T032 [P] Add the "Alerting" section to `docs/guides/analyze-traces.md` (FR-026)
+- [ ] T033 [P] Write the new guide `docs/guides/policy-refresh-automation.md` (FR-027)
+- [ ] T034 Run quickstart.md validation end-to-end (config samples, exit codes)
+- [ ] T035 Run quality gates: `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy ziran/`, `uv run pytest --cov=ziran` (≥85%)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no dependencies.
+- **Foundational (Phase 2)**: depends on Setup. BLOCKS US1 and US2.
+- **US1 (Phase 3)** and **US2 (Phase 4)**: depend on Foundational. US2 reuses the GitHub sink but is independently testable.
+- **US3 (Phase 5)**: depends only on Setup — can run fully in parallel with Foundational/US1/US2.
+- **Polish (Phase 6)**: after the targeted stories are complete.
+
+### User Story Dependencies
+
+- US1 (P1): after Phase 2. No dependency on other stories.
+- US2 (P2): after Phase 2. Reuses shared sinks; no hard dependency on US1.
+- US3 (P3): after Phase 1. Independent of US1/US2.
+
+### Within Each User Story
+
+- Tests written first and expected to FAIL before implementation.
+- Domain mapping (entities) → application service → CLI wiring.
+
+### Parallel Opportunities
+
+- Phase 1: T002 ∥ T001 setup steps.
+- Phase 2: T003 ∥ T004 ∥ T005 ∥ T006 ∥ T008 (distinct files); then T007/T009/T010 (sinks/dispatcher); tests T012–T015 ∥.
+- US1 tests T016 ∥ T017; US2 tests T022 ∥ T023.
+- US3 (T028–T031) can be developed alongside Phase 2 by a second person.
+- Polish T032 ∥ T033.
+
+---
+
+## Parallel Example: Foundational Phase
+
+```bash
+# Distinct files, no interdependencies — launch together:
+Task: "Create alerting domain entities in ziran/domain/entities/alerting.py"
+Task: "Define AlertSink ABC in ziran/domain/ports/alert_sink.py"
+Task: "Implement !env YAML loader in ziran/infrastructure/config/env_yaml.py"
+Task: "Implement AlertSinkConfig/AlertConfig in ziran/application/alerting/config.py"
+Task: "Implement DryRunSink in ziran/infrastructure/alert_sinks/dry_run_sink.py"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Phase 1 Setup → 2. Phase 2 Foundational (CRITICAL) → 3. Phase 3 US1 → 4. STOP & validate `watch-registry` alerting independently → 5. Demo MVP.
+
+### Incremental Delivery
+
+Setup + Foundational → US1 (MVP, #272) → US2 (#274) → US3 (#273), each independently testable and shippable. US3 can land in parallel since it shares no code with the sinks.
+
+### Parallel Team Strategy
+
+After Foundational: Dev A → US1, Dev B → US2. Dev C can take US3 immediately after Setup (no Foundational dependency).
+
+---
+
+## Notes
+
+- [P] = different files, no incomplete-task dependencies.
+- The GitHub sink (T010) is the shared dedup-bearing adapter reused by both US1 and US2 — its idempotency test (T015) is foundational.
+- Preserve the existing `watch-registry` severity-gate exit behavior; layer the delivery-failure exit (2) on top (research R3).
+- Commit after each task or logical group; never leave CI red (per CLAUDE.md).

--- a/tests/fixtures/alerting.py
+++ b/tests/fixtures/alerting.py
@@ -1,0 +1,30 @@
+"""Shared builders for alerting tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ziran.domain.entities.alerting import AlertableFinding, AlertLink
+
+if TYPE_CHECKING:
+    from ziran.domain.entities.attack import Severity
+
+
+def make_finding(
+    *,
+    fingerprint: str = "abcdef0123456789",
+    severity: Severity = "high",
+    kind: str = "registry_drift",
+    remediation: str | None = None,
+) -> AlertableFinding:
+    """Build a representative finding for sink/dispatch tests."""
+    return AlertableFinding(
+        fingerprint=fingerprint,
+        kind=kind,  # type: ignore[arg-type]
+        severity=severity,
+        title="Permission escalation on tool write_file (prod-mcp-server)",
+        summary="Tool 'write_file' permissions changed on server 'prod-mcp-server'",
+        fields={"Server": "prod-mcp-server", "Tool": "write_file", "Drift": "permission_changed"},
+        links=[AlertLink(label="Snapshot diff", url="https://ci.example.com/snap/123")],
+        remediation=remediation,
+    )

--- a/tests/integration/test_github_issue_sink.py
+++ b/tests/integration/test_github_issue_sink.py
@@ -1,0 +1,84 @@
+"""Integration test: GitHub issue sink create + marker-search dedup (respx)."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from tests.fixtures.alerting import make_finding
+from ziran.infrastructure.alert_sinks.github_issue_sink import GitHubIssueSink
+
+pytestmark = pytest.mark.integration
+
+REPO = "myorg/ai-agent-infra"
+SEARCH = "https://api.github.com/search/issues"
+CREATE = f"https://api.github.com/repos/{REPO}/issues"
+
+
+def _stateful_github(created: list[dict[str, Any]]) -> None:
+    """Wire respx routes that emulate GitHub's search + create with dedup."""
+
+    def search_handler(request: httpx.Request) -> httpx.Response:
+        q = request.url.params.get("q", "")
+        hit = next((i for i in created if i["fingerprint"] in q), None)
+        items = [{"html_url": hit["html_url"]}] if hit else []
+        return httpx.Response(200, json={"total_count": len(items), "items": items})
+
+    def create_handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.read().decode())
+        # Recover the embedded fingerprint marker to register the new issue.
+        match = re.search(r"ziran-fingerprint:\s*([0-9a-f]{16})", payload["body"])
+        fp = match.group(1) if match else ""
+        num = len(created) + 1
+        url = f"https://github.com/{REPO}/issues/{num}"
+        created.append({"fingerprint": fp, "html_url": url})
+        return httpx.Response(201, json={"html_url": url, "number": num})
+
+    respx.get(SEARCH).mock(side_effect=search_handler)
+    respx.post(CREATE).mock(side_effect=create_handler)
+
+
+@respx.mock
+async def test_create_then_dedup_on_rerun() -> None:
+    created: list[dict[str, Any]] = []
+    _stateful_github(created)
+    sink = GitHubIssueSink(repo=REPO, token="tok", labels=["mcp-drift"])
+    finding = make_finding()
+
+    first = await sink.emit(finding)
+    assert first.status == "sent"
+    assert first.detail and first.detail.endswith("/issues/1")
+    assert len(created) == 1
+
+    # Re-run on the same finding: search finds the marker → no new POST.
+    second = await sink.emit(finding)
+    assert second.status == "deduped"
+    assert second.detail == first.detail
+    assert len(created) == 1  # zero duplicate issues
+
+
+@respx.mock
+async def test_missing_token_fails_cleanly() -> None:
+    sink = GitHubIssueSink(repo=REPO, token=None)
+    result = await sink.emit(make_finding())
+    assert result.status == "failed"
+    assert "token" in (result.detail or "").lower()
+
+
+@respx.mock
+async def test_create_sends_labels_and_marker() -> None:
+    created: list[dict[str, Any]] = []
+    _stateful_github(created)
+    route = respx.post(CREATE)
+    sink = GitHubIssueSink(repo=REPO, token="tok", labels=["mcp-drift", "security"])
+
+    await sink.emit(make_finding(fingerprint="0123456789abcdef"))
+
+    body = route.calls.last.request.read().decode()
+    assert "ziran-fingerprint: 0123456789abcdef" in body
+    assert "mcp-drift" in body

--- a/tests/integration/test_slack_sink.py
+++ b/tests/integration/test_slack_sink.py
@@ -1,0 +1,40 @@
+"""Integration test: Slack webhook sink request shape (respx-mocked)."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from tests.fixtures.alerting import make_finding
+from ziran.infrastructure.alert_sinks.slack_sink import SlackWebhookSink
+
+pytestmark = pytest.mark.integration
+
+WEBHOOK = "https://hooks.slack.test/services/T/B/xxx"
+
+
+@respx.mock
+async def test_slack_sink_posts_block_kit_payload() -> None:
+    route = respx.post(WEBHOOK).mock(return_value=httpx.Response(200, text="ok"))
+    sink = SlackWebhookSink(webhook_url=WEBHOOK)
+
+    result = await sink.emit(make_finding(severity="critical"))
+
+    assert result.status == "sent"
+    assert route.called
+    body = route.calls.last.request.read().decode()
+    assert '"blocks"' in body
+    assert "rotating_light" in body  # critical emoji
+    assert "prod-mcp-server" in body
+
+
+@respx.mock
+async def test_slack_sink_reports_failure_on_non_200() -> None:
+    respx.post(WEBHOOK).mock(return_value=httpx.Response(500, text="boom"))
+    sink = SlackWebhookSink(webhook_url=WEBHOOK)
+
+    result = await sink.emit(make_finding())
+
+    assert result.status == "failed"
+    assert "500" in (result.detail or "")

--- a/tests/integration/test_watch_registry_alerting.py
+++ b/tests/integration/test_watch_registry_alerting.py
@@ -1,0 +1,125 @@
+"""Integration test: watch-registry alerting end-to-end + dedup (respx)."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from ziran.application.registry_watch.watcher_service import emit_findings
+from ziran.domain.entities.alerting import AlertConfig, AlertSinkConfig
+from ziran.domain.entities.registry import DriftFinding
+from ziran.infrastructure.alert_sinks.factory import build_sinks
+
+pytestmark = pytest.mark.integration
+
+REPO = "myorg/ai-agent-infra"
+SEARCH = "https://api.github.com/search/issues"
+CREATE = f"https://api.github.com/repos/{REPO}/issues"
+WEBHOOK = "https://hooks.slack.test/abc"
+
+
+def _drift() -> list[DriftFinding]:
+    return [
+        DriftFinding(
+            server_name="prod-mcp-server",
+            drift_type="permission_changed",
+            severity="high",
+            tool_name="write_file",
+            field="permissions",
+            previous_value="[]",
+            current_value="['fs:write']",
+            message="permissions changed",
+        ),
+        DriftFinding(
+            server_name="prod-mcp-server",
+            drift_type="tool_added",
+            severity="medium",
+            tool_name="exec_shell",
+            current_value="run a shell command",
+            message="new tool added",
+        ),
+    ]
+
+
+def _wire_github(created: list[dict[str, Any]]) -> None:
+    def search_handler(request: httpx.Request) -> httpx.Response:
+        q = request.url.params.get("q", "")
+        hit = next((i for i in created if i["fingerprint"] in q), None)
+        items = [{"html_url": hit["html_url"]}] if hit else []
+        return httpx.Response(200, json={"total_count": len(items), "items": items})
+
+    def create_handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.read().decode())
+        match = re.search(r"ziran-fingerprint:\s*([0-9a-f]{16})", payload["body"])
+        fp = match.group(1) if match else ""
+        num = len(created) + 1
+        url = f"https://github.com/{REPO}/issues/{num}"
+        created.append({"fingerprint": fp, "html_url": url})
+        return httpx.Response(201, json={"html_url": url, "number": num})
+
+    respx.get(SEARCH).mock(side_effect=search_handler)
+    respx.post(CREATE).mock(side_effect=create_handler)
+
+
+@respx.mock
+async def test_drift_reaches_both_sinks_then_dedups_on_rerun() -> None:
+    created: list[dict[str, Any]] = []
+    _wire_github(created)
+    slack = respx.post(WEBHOOK).mock(return_value=httpx.Response(200, text="ok"))
+
+    config = AlertConfig(
+        alerts=[
+            AlertSinkConfig(kind="slack", webhook_url=WEBHOOK, severity_floor="low"),
+            AlertSinkConfig(kind="github_issue", repo=REPO, token="tok", labels=["mcp-drift"]),
+        ]
+    )
+    sinks = build_sinks(config)
+    findings = _drift()
+
+    outcome = await emit_findings(findings, sinks)
+    assert outcome.sent == 4  # 2 findings x 2 sinks
+    assert slack.call_count == 2
+    assert len(created) == 2
+
+    # Re-run: GitHub dedups (no new issues), Slack re-posts (stateless).
+    outcome2 = await emit_findings(findings, sinks)
+    assert outcome2.deduped == 2  # both GitHub issues deduped
+    assert len(created) == 2  # zero new issues
+
+
+@respx.mock
+async def test_severity_floor_filters_github_sink() -> None:
+    created: list[dict[str, Any]] = []
+    _wire_github(created)
+    config = AlertConfig(
+        alerts=[AlertSinkConfig(kind="github_issue", repo=REPO, token="tok", severity_floor="high")]
+    )
+    sinks = build_sinks(config)
+
+    outcome = await emit_findings(_drift(), sinks)
+
+    # Only the 'high' permission_changed finding clears the floor; 'medium' is skipped.
+    assert outcome.sent == 1
+    assert sum(1 for r in outcome.results if r.status == "skipped_below_floor") == 1
+    assert len(created) == 1
+
+
+@respx.mock
+async def test_dry_run_contacts_no_services() -> None:
+    config = AlertConfig(
+        alerts=[
+            AlertSinkConfig(kind="slack", webhook_url=WEBHOOK),
+            AlertSinkConfig(kind="github_issue", repo=REPO, token="tok"),
+        ]
+    )
+    sinks = build_sinks(config, dry_run=True)
+
+    outcome = await emit_findings(_drift(), sinks)
+
+    assert all(r.status == "dry_run" for r in outcome.results)
+    assert not respx.calls  # zero network I/O

--- a/tests/unit/test_alert_dispatch.py
+++ b/tests/unit/test_alert_dispatch.py
@@ -1,0 +1,51 @@
+"""Unit tests for the alert dispatcher: floor filtering, fan-out, aggregation."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.fixtures.alerting import make_finding
+from ziran.application.alerting.dispatch import dispatch
+from ziran.domain.entities.alerting import AlertableFinding, DeliveryResult
+from ziran.domain.ports.alert_sink import AlertSink
+
+pytestmark = pytest.mark.unit
+
+
+class RecordingSink(AlertSink):
+    def __init__(self, name: str, *, fail: bool = False) -> None:
+        self.name = name
+        self._fail = fail
+        self.emitted: list[str] = []
+
+    async def emit(self, finding: AlertableFinding) -> DeliveryResult:
+        self.emitted.append(finding.fingerprint)
+        status = "failed" if self._fail else "sent"
+        return DeliveryResult(sink_name=self.name, fingerprint=finding.fingerprint, status=status)
+
+
+async def test_below_floor_is_skipped_without_emit() -> None:
+    sink = RecordingSink("slack")
+    finding = make_finding(severity="low")
+    outcome = await dispatch([finding], [(sink, "high")])
+    assert sink.emitted == []  # never called
+    assert outcome.results[0].status == "skipped_below_floor"
+
+
+async def test_at_or_above_floor_is_emitted() -> None:
+    sink = RecordingSink("slack")
+    finding = make_finding(severity="high")
+    outcome = await dispatch([finding], [(sink, "high")])
+    assert sink.emitted == [finding.fingerprint]
+    assert outcome.sent == 1
+
+
+async def test_one_sink_failure_does_not_block_others() -> None:
+    good = RecordingSink("slack")
+    bad = RecordingSink("github_issue", fail=True)
+    finding = make_finding(severity="critical")
+    outcome = await dispatch([finding], [(bad, "low"), (good, "low")])
+    assert good.emitted == [finding.fingerprint]  # still delivered
+    assert outcome.failed == 1
+    assert outcome.sent == 1
+    assert outcome.any_failed is True

--- a/tests/unit/test_alert_fingerprint.py
+++ b/tests/unit/test_alert_fingerprint.py
@@ -1,0 +1,59 @@
+"""Unit tests for alerting fingerprint helpers and result aggregates."""
+
+from __future__ import annotations
+
+import pytest
+
+from ziran.domain.entities.alerting import (
+    AlertOutcome,
+    DeliveryResult,
+    digest_fingerprint,
+    drift_fingerprint,
+    severity_rank,
+    trace_fingerprint,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_drift_fingerprint_is_stable_and_value_independent() -> None:
+    a = drift_fingerprint("srv", "write_file", "permission_changed")
+    b = drift_fingerprint("srv", "write_file", "permission_changed")
+    assert a == b
+    assert len(a) == 16 and all(c in "0123456789abcdef" for c in a)
+
+
+def test_drift_fingerprint_differs_by_kind_and_tool() -> None:
+    base = drift_fingerprint("srv", "write_file", "permission_changed")
+    assert base != drift_fingerprint("srv", "write_file", "description_changed")
+    assert base != drift_fingerprint("srv", "read_file", "permission_changed")
+
+
+def test_trace_and_digest_prefixes_avoid_cross_type_collision() -> None:
+    assert trace_fingerprint("chainX", "sess1") != drift_fingerprint("chainX", "sess1", "x")
+
+
+def test_digest_fingerprint_ignores_order_and_run_date() -> None:
+    # Same chain set in any order → same digest (no run-date component).
+    assert digest_fingerprint(["aa", "bb"]) == digest_fingerprint(["bb", "aa"])
+    # Different chain set → different digest.
+    assert digest_fingerprint(["aa", "bb"]) != digest_fingerprint(["aa", "cc"])
+
+
+def test_severity_rank_ordering() -> None:
+    assert severity_rank("low") < severity_rank("medium") < severity_rank("high")
+    assert severity_rank("high") < severity_rank("critical")
+
+
+def test_alert_outcome_counts() -> None:
+    outcome = AlertOutcome(
+        results=[
+            DeliveryResult(sink_name="s", fingerprint="a" * 16, status="sent"),
+            DeliveryResult(sink_name="s", fingerprint="b" * 16, status="deduped"),
+            DeliveryResult(sink_name="g", fingerprint="c" * 16, status="failed"),
+        ]
+    )
+    assert outcome.sent == 1
+    assert outcome.deduped == 1
+    assert outcome.failed == 1
+    assert outcome.any_failed is True

--- a/tests/unit/test_drift_alertable.py
+++ b/tests/unit/test_drift_alertable.py
@@ -1,0 +1,51 @@
+"""Unit tests for DriftFinding fingerprint + alertable mapping."""
+
+from __future__ import annotations
+
+import pytest
+
+from ziran.domain.entities.alerting import drift_fingerprint
+from ziran.domain.entities.registry import DriftFinding
+
+pytestmark = pytest.mark.unit
+
+
+def _finding(**kw: object) -> DriftFinding:
+    base = {
+        "server_name": "prod-mcp-server",
+        "drift_type": "permission_changed",
+        "severity": "high",
+        "tool_name": "write_file",
+        "field": "permissions",
+        "previous_value": "[]",
+        "current_value": "['fs:write']",
+        "message": "Tool 'write_file' permissions changed on server 'prod-mcp-server'",
+    }
+    base.update(kw)
+    return DriftFinding(**base)  # type: ignore[arg-type]
+
+
+def test_fingerprint_matches_helper_and_ignores_value() -> None:
+    f = _finding()
+    assert f.fingerprint() == drift_fingerprint(
+        "prod-mcp-server", "write_file", "permission_changed"
+    )
+    # Changing only the after-value must NOT change the fingerprint.
+    assert f.fingerprint() == _finding(current_value="['fs:write','net']").fingerprint()
+
+
+def test_fingerprint_changes_with_drift_kind() -> None:
+    assert _finding().fingerprint() != _finding(drift_type="description_changed").fingerprint()
+
+
+def test_to_alertable_maps_fields_and_inline_diff() -> None:
+    a = _finding().to_alertable()
+    assert a.kind == "registry_drift"
+    assert a.severity == "high"
+    assert a.fields["Server"] == "prod-mcp-server"
+    assert a.fields["Tool"] == "write_file"
+    # Before/after included inline (no remote snapshot URL available).
+    assert a.fields["Previous"] == "[]"
+    assert a.fields["Current"] == "['fs:write']"
+    assert a.links == []
+    assert a.fingerprint == _finding().fingerprint()

--- a/tests/unit/test_env_yaml.py
+++ b/tests/unit/test_env_yaml.py
@@ -1,0 +1,31 @@
+"""Unit tests for the !env / ${VAR} YAML loader."""
+
+from __future__ import annotations
+
+import pytest
+
+from ziran.infrastructure.config.env_yaml import EnvVarError, load_yaml_with_env
+
+pytestmark = pytest.mark.unit
+
+
+def test_env_tag_resolves(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MY_HOOK", "https://hooks.example/abc")
+    data = load_yaml_with_env("url: !env MY_HOOK\n")
+    assert data["url"] == "https://hooks.example/abc"
+
+
+def test_interpolation_resolves(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TOK", "secret123")
+    data = load_yaml_with_env("token: ${TOK}\n")
+    assert data["token"] == "secret123"
+
+
+def test_unset_env_raises() -> None:
+    with pytest.raises(EnvVarError, match="ZIRAN_DOES_NOT_EXIST"):
+        load_yaml_with_env("url: !env ZIRAN_DOES_NOT_EXIST\n")
+
+
+def test_plain_values_unaffected() -> None:
+    data = load_yaml_with_env("a: 1\nb: hello\n")
+    assert data == {"a": 1, "b": "hello"}

--- a/ziran/application/alerting/dispatch.py
+++ b/ziran/application/alerting/dispatch.py
@@ -1,0 +1,44 @@
+"""Alert dispatch: severity-floor filtering + concurrent fan-out + aggregation."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from ziran.domain.entities.alerting import (
+    AlertableFinding,
+    AlertOutcome,
+    DeliveryResult,
+    severity_rank,
+)
+
+if TYPE_CHECKING:
+    from ziran.domain.entities.attack import Severity
+    from ziran.domain.ports.alert_sink import AlertSink
+
+# (sink, severity_floor) — the floor is applied by the dispatcher, not the sink.
+SinkBinding = tuple["AlertSink", "Severity"]
+
+
+async def _emit_one(sink: AlertSink, floor: Severity, finding: AlertableFinding) -> DeliveryResult:
+    if severity_rank(finding.severity) < severity_rank(floor):
+        return DeliveryResult(
+            sink_name=sink.name,
+            fingerprint=finding.fingerprint,
+            status="skipped_below_floor",
+        )
+    return await sink.emit(finding)
+
+
+async def dispatch(
+    findings: list[AlertableFinding],
+    sinks: list[SinkBinding],
+) -> AlertOutcome:
+    """Deliver every finding to every sink at/above its severity floor.
+
+    Sinks never raise per the :class:`AlertSink` contract, so a single failure
+    is captured as a failed :class:`DeliveryResult` and never blocks the rest.
+    """
+    tasks = [_emit_one(sink, floor, finding) for finding in findings for sink, floor in sinks]
+    results = await asyncio.gather(*tasks)
+    return AlertOutcome(results=list(results))

--- a/ziran/application/registry_watch/typosquat_detector.py
+++ b/ziran/application/registry_watch/typosquat_detector.py
@@ -7,7 +7,12 @@ the allowlist.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from ziran.domain.entities.registry import DriftFinding
+
+if TYPE_CHECKING:
+    from ziran.domain.entities.attack import Severity
 
 # Common substitution pairs used in typosquatting attacks.
 # Each tuple is (original_substring, substitution_substring).
@@ -92,7 +97,7 @@ def detect(
         is_sub = _has_substitution(name, canonical)
 
         if distance <= 2 or is_sub:
-            severity = "high" if distance == 1 or is_sub else "medium"
+            severity: Severity = "high" if distance == 1 or is_sub else "medium"
 
             findings.append(
                 DriftFinding(

--- a/ziran/application/registry_watch/watcher_service.py
+++ b/ziran/application/registry_watch/watcher_service.py
@@ -11,6 +11,7 @@ import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Protocol
 
+from ziran.application.alerting.dispatch import dispatch
 from ziran.application.registry_watch.typosquat_detector import detect as detect_typosquat
 from ziran.domain.entities.registry import (
     DriftFinding,
@@ -21,6 +22,8 @@ from ziran.domain.entities.registry import (
 )
 
 if TYPE_CHECKING:
+    from ziran.application.alerting.dispatch import SinkBinding
+    from ziran.domain.entities.alerting import AlertOutcome
     from ziran.domain.ports.snapshot_store import SnapshotStore
 
 logger = logging.getLogger(__name__)
@@ -204,3 +207,12 @@ async def watch(
         snapshot_store.save(server.name, new_snapshot)
 
     return all_findings
+
+
+async def emit_findings(
+    findings: list[DriftFinding],
+    sinks: list[SinkBinding],
+) -> AlertOutcome:
+    """Deliver drift findings to the configured alert sinks."""
+    alertable = [f.to_alertable() for f in findings]
+    return await dispatch(alertable, sinks)

--- a/ziran/application/skill_cve/__init__.py
+++ b/ziran/application/skill_cve/__init__.py
@@ -9,7 +9,7 @@ OWASP LLM Top 10 and framework security documentation.
 from __future__ import annotations
 
 import logging
-from datetime import datetime  # noqa: TC003 — Pydantic needs at runtime
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, Field

--- a/ziran/domain/entities/alerting.py
+++ b/ziran/domain/entities/alerting.py
@@ -1,0 +1,138 @@
+"""Alerting domain entities.
+
+Normalized finding shape consumed by every :class:`~ziran.domain.ports.alert_sink.AlertSink`,
+plus the per-delivery and per-run result aggregates and the pure fingerprint
+helpers used for stateless deduplication.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+from ziran.domain.entities.attack import Severity  # noqa: TC001 — Pydantic needs it at runtime
+
+AlertKind = Literal["registry_drift", "dangerous_chain"]
+DeliveryStatus = Literal["sent", "deduped", "skipped_below_floor", "failed", "dry_run"]
+SinkKind = Literal["slack", "github_issue"]
+
+# Canonical severity ordering (shared with policy export).
+SEVERITY_RANK: dict[Severity, int] = {"low": 0, "medium": 1, "high": 2, "critical": 3}
+
+
+def severity_rank(severity: Severity) -> int:
+    """Return the numeric rank of *severity* for floor comparisons."""
+    return SEVERITY_RANK[severity]
+
+
+def _digest16(payload: str) -> str:
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def drift_fingerprint(server: str, tool: str, drift_type: str) -> str:
+    """Fingerprint a registry drift finding by ``(server, tool, drift-kind)``.
+
+    Deliberately excludes the changed value so a recurring drift of the same
+    kind on the same tool reuses one issue.
+    """
+    return _digest16(f"drift|{server}|{tool}|{drift_type}")
+
+
+def trace_fingerprint(tool_chain_hash: str, session_id: str) -> str:
+    """Fingerprint a dangerous-chain trace finding by chain identity + session."""
+    return _digest16(f"trace|{tool_chain_hash}|{session_id}")
+
+
+def digest_fingerprint(chain_fingerprints: list[str]) -> str:
+    """Fingerprint a trace digest from the sorted set of contained chain fingerprints.
+
+    The run date is intentionally excluded so re-running on unchanged traces —
+    even on a later day — reuses the same digest issue rather than filing a duplicate.
+    """
+    joined = "|".join(sorted(set(chain_fingerprints)))
+    return _digest16(f"trace-digest|{joined}")
+
+
+class AlertLink(BaseModel):
+    """A labeled, remote-resolvable link attached to a finding."""
+
+    label: str
+    url: str
+
+
+class AlertableFinding(BaseModel):
+    """A normalized unit of information eligible for delivery to a sink."""
+
+    fingerprint: str = Field(pattern=r"^[0-9a-f]{16}$")
+    kind: AlertKind
+    severity: Severity
+    title: str
+    summary: str
+    fields: dict[str, str] = Field(default_factory=dict)
+    links: list[AlertLink] = Field(default_factory=list)
+    remediation: str | None = None
+
+
+class DeliveryResult(BaseModel):
+    """Outcome of delivering one finding to one sink."""
+
+    model_config = {"frozen": True}
+
+    sink_name: str
+    fingerprint: str
+    status: DeliveryStatus
+    detail: str | None = None
+
+
+class AlertOutcome(BaseModel):
+    """Aggregate of every per-(finding, sink) delivery in a single run."""
+
+    results: list[DeliveryResult] = Field(default_factory=list)
+
+    @property
+    def any_failed(self) -> bool:
+        return any(r.status == "failed" for r in self.results)
+
+    @property
+    def sent(self) -> int:
+        return sum(1 for r in self.results if r.status == "sent")
+
+    @property
+    def deduped(self) -> int:
+        return sum(1 for r in self.results if r.status == "deduped")
+
+    @property
+    def failed(self) -> int:
+        return sum(1 for r in self.results if r.status == "failed")
+
+
+class AlertSinkConfig(BaseModel):
+    """Configuration for a single notification destination (from the ``alerts:`` block)."""
+
+    kind: SinkKind
+    severity_floor: Severity = "low"
+
+    # slack
+    webhook_url: str | None = None
+
+    # github_issue
+    repo: str | None = None
+    token: str | None = None
+    labels: list[str] = Field(default_factory=list)
+    assignees: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _check_required(self) -> AlertSinkConfig:
+        if self.kind == "slack" and not self.webhook_url:
+            raise ValueError("slack alert sink requires 'webhook_url'")
+        if self.kind == "github_issue" and not self.repo:
+            raise ValueError("github_issue alert sink requires 'repo' (owner/name)")
+        return self
+
+
+class AlertConfig(BaseModel):
+    """The ``alerts:`` block: a list of sink configurations."""
+
+    alerts: list[AlertSinkConfig] = Field(default_factory=list)

--- a/ziran/domain/entities/alerting.py
+++ b/ziran/domain/entities/alerting.py
@@ -12,7 +12,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field, model_validator
 
-from ziran.domain.entities.attack import Severity  # noqa: TC001 — Pydantic needs it at runtime
+from ziran.domain.entities.attack import Severity
 
 AlertKind = Literal["registry_drift", "dangerous_chain"]
 DeliveryStatus = Literal["sent", "deduped", "skipped_below_floor", "failed", "dry_run"]

--- a/ziran/domain/entities/attack.py
+++ b/ziran/domain/entities/attack.py
@@ -11,7 +11,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
-from ziran.domain.entities.phase import ScanPhase  # noqa: TC001
+from ziran.domain.entities.phase import ScanPhase
 
 
 class TokenUsage(BaseModel):

--- a/ziran/domain/entities/capability.py
+++ b/ziran/domain/entities/capability.py
@@ -6,7 +6,7 @@ during reconnaissance and capability mapping phases.
 
 from __future__ import annotations
 
-from datetime import datetime  # noqa: TC003 — Pydantic needs at runtime
+from datetime import datetime
 from enum import StrEnum
 from typing import Any
 

--- a/ziran/domain/entities/phase.py
+++ b/ziran/domain/entities/phase.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
-from ziran.domain.entities.defence import DefenceProfile  # noqa: TC001 — Pydantic field type
+from ziran.domain.entities.defence import DefenceProfile
 
 
 class CoverageLevel(StrEnum):

--- a/ziran/domain/entities/registry.py
+++ b/ziran/domain/entities/registry.py
@@ -7,9 +7,18 @@ drift detection, and typosquat findings.
 from __future__ import annotations
 
 from datetime import datetime  # noqa: TC003 — Pydantic needs at runtime
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 from pydantic import BaseModel, Field
+
+from ziran.domain.entities.alerting import (
+    AlertableFinding,
+    AlertSinkConfig,
+    drift_fingerprint,
+)
+
+if TYPE_CHECKING:
+    from ziran.domain.entities.attack import Severity
 
 
 class ToolDescriptor(BaseModel):
@@ -45,6 +54,41 @@ class DriftFinding(BaseModel):
     suspected_canonical: str | None = None
     message: str
 
+    def fingerprint(self) -> str:
+        """Stable dedup key: ``(server, tool, drift-kind)``."""
+        return drift_fingerprint(self.server_name, self.tool_name or "", self.drift_type)
+
+    def to_alertable(self) -> AlertableFinding:
+        """Map this drift finding to the normalized alerting shape.
+
+        Before/after values are emitted as inline fields (the snapshot diff
+        summary), since registry snapshots are local and have no remote URL.
+        """
+        fields: dict[str, str] = {
+            "Server": self.server_name,
+            "Drift type": self.drift_type,
+        }
+        if self.tool_name:
+            fields["Tool"] = self.tool_name
+        if self.field:
+            fields["Field"] = self.field
+        if self.previous_value is not None:
+            fields["Previous"] = self.previous_value
+        if self.current_value is not None:
+            fields["Current"] = self.current_value
+        if self.suspected_canonical:
+            fields["Suspected canonical"] = self.suspected_canonical
+
+        tool_suffix = f" on tool '{self.tool_name}'" if self.tool_name else ""
+        return AlertableFinding(
+            fingerprint=self.fingerprint(),
+            kind="registry_drift",
+            severity=cast("Severity", self.severity),
+            title=f"{self.drift_type}{tool_suffix} ({self.server_name})",
+            summary=self.message,
+            fields=fields,
+        )
+
 
 class ServerEntry(BaseModel):
     """Configuration entry for an MCP server to monitor."""
@@ -61,3 +105,4 @@ class RegistryConfig(BaseModel):
     allowlist: list[str] = Field(default_factory=list)
     exemptions: list[str] = Field(default_factory=list)
     snapshot_dir: str | None = None
+    alerts: list[AlertSinkConfig] = Field(default_factory=list)

--- a/ziran/domain/entities/registry.py
+++ b/ziran/domain/entities/registry.py
@@ -6,8 +6,8 @@ drift detection, and typosquat findings.
 
 from __future__ import annotations
 
-from datetime import datetime  # noqa: TC003 — Pydantic needs at runtime
-from typing import TYPE_CHECKING, Any, cast
+from datetime import datetime
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -16,9 +16,7 @@ from ziran.domain.entities.alerting import (
     AlertSinkConfig,
     drift_fingerprint,
 )
-
-if TYPE_CHECKING:
-    from ziran.domain.entities.attack import Severity
+from ziran.domain.entities.attack import Severity
 
 
 class ToolDescriptor(BaseModel):
@@ -46,7 +44,7 @@ class DriftFinding(BaseModel):
 
     server_name: str
     drift_type: str  # tool_added, tool_removed, description_changed, schema_changed, permission_changed, typosquat
-    severity: str  # critical, high, medium, low
+    severity: Severity
     tool_name: str | None = None
     field: str | None = None
     previous_value: str | None = None
@@ -83,7 +81,7 @@ class DriftFinding(BaseModel):
         return AlertableFinding(
             fingerprint=self.fingerprint(),
             kind="registry_drift",
-            severity=cast("Severity", self.severity),
+            severity=self.severity,
             title=f"{self.drift_type}{tool_suffix} ({self.server_name})",
             summary=self.message,
             fields=fields,

--- a/ziran/domain/entities/trace.py
+++ b/ziran/domain/entities/trace.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime  # noqa: TC003 — Pydantic needs at runtime
+from datetime import datetime
 from typing import Any
 
 from pydantic import BaseModel, Field

--- a/ziran/domain/ports/alert_sink.py
+++ b/ziran/domain/ports/alert_sink.py
@@ -1,0 +1,31 @@
+"""Port for delivering findings to external notification destinations."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ziran.domain.entities.alerting import AlertableFinding, DeliveryResult
+
+
+class AlertSink(ABC):
+    """Abstract port: delivers one finding to one external destination.
+
+    Implementations (Slack webhook, GitHub issue, ...) live in infrastructure.
+
+    Contract:
+    - The ``github_issue`` sink MUST be idempotent: re-emitting a finding whose
+      fingerprint already exists (open *or* closed issue) returns
+      ``status="deduped"`` without creating a duplicate.
+    - ``emit`` MUST NOT raise on remote/transport errors; capture them as
+      ``DeliveryResult(status="failed", detail=...)``. Programmer errors MAY raise.
+    - ``emit`` MUST NOT perform network I/O when wrapped by the dry-run decorator.
+    """
+
+    name: str
+
+    @abstractmethod
+    async def emit(self, finding: AlertableFinding) -> DeliveryResult:
+        """Deliver one finding to this destination."""
+        raise NotImplementedError

--- a/ziran/infrastructure/alert_sinks/dry_run_sink.py
+++ b/ziran/infrastructure/alert_sinks/dry_run_sink.py
@@ -1,0 +1,37 @@
+"""Dry-run wrapper: prints the intended payload without any network I/O."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from ziran.domain.entities.alerting import DeliveryResult
+from ziran.domain.ports.alert_sink import AlertSink
+
+if TYPE_CHECKING:
+    from ziran.domain.entities.alerting import AlertableFinding
+
+
+class DryRunSink(AlertSink):
+    """Wraps a real sink; logs what *would* be sent and performs no I/O."""
+
+    def __init__(self, inner: AlertSink) -> None:
+        self._inner = inner
+        self.name = inner.name
+
+    async def emit(self, finding: AlertableFinding) -> DeliveryResult:
+        payload = {
+            "sink": self._inner.name,
+            "fingerprint": finding.fingerprint,
+            "severity": finding.severity,
+            "title": finding.title,
+            "fields": finding.fields,
+            "links": [link.model_dump() for link in finding.links],
+        }
+        print(f"[dry-run-alerts] would send -> {json.dumps(payload, default=str)}")
+        return DeliveryResult(
+            sink_name=self._inner.name,
+            fingerprint=finding.fingerprint,
+            status="dry_run",
+            detail="payload preview printed",
+        )

--- a/ziran/infrastructure/alert_sinks/factory.py
+++ b/ziran/infrastructure/alert_sinks/factory.py
@@ -9,16 +9,16 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING
 
+from ziran.domain.entities.attack import Severity
+from ziran.domain.ports.alert_sink import AlertSink
 from ziran.infrastructure.alert_sinks.dry_run_sink import DryRunSink
 from ziran.infrastructure.alert_sinks.github_issue_sink import GitHubIssueSink
 from ziran.infrastructure.alert_sinks.slack_sink import SlackWebhookSink
 
 if TYPE_CHECKING:
     from ziran.domain.entities.alerting import AlertConfig, AlertSinkConfig
-    from ziran.domain.entities.attack import Severity
-    from ziran.domain.ports.alert_sink import AlertSink
 
-SinkBinding = tuple["AlertSink", "Severity"]
+SinkBinding = tuple[AlertSink, Severity]
 
 
 def _build_one(cfg: AlertSinkConfig) -> AlertSink:

--- a/ziran/infrastructure/alert_sinks/factory.py
+++ b/ziran/infrastructure/alert_sinks/factory.py
@@ -1,0 +1,50 @@
+"""Build concrete alert sinks from configuration (composition helper).
+
+Lives in infrastructure because it wires concrete adapters; the domain and
+application layers depend only on the :class:`AlertSink` port.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from ziran.infrastructure.alert_sinks.dry_run_sink import DryRunSink
+from ziran.infrastructure.alert_sinks.github_issue_sink import GitHubIssueSink
+from ziran.infrastructure.alert_sinks.slack_sink import SlackWebhookSink
+
+if TYPE_CHECKING:
+    from ziran.domain.entities.alerting import AlertConfig, AlertSinkConfig
+    from ziran.domain.entities.attack import Severity
+    from ziran.domain.ports.alert_sink import AlertSink
+
+SinkBinding = tuple["AlertSink", "Severity"]
+
+
+def _build_one(cfg: AlertSinkConfig) -> AlertSink:
+    if cfg.kind == "slack":
+        assert cfg.webhook_url is not None  # guaranteed by AlertSinkConfig validation
+        return SlackWebhookSink(webhook_url=cfg.webhook_url)
+    assert cfg.repo is not None  # guaranteed by AlertSinkConfig validation
+    token = cfg.token or os.environ.get("GITHUB_TOKEN")
+    return GitHubIssueSink(
+        repo=cfg.repo,
+        token=token,
+        labels=cfg.labels,
+        assignees=cfg.assignees,
+    )
+
+
+def build_sinks(config: AlertConfig, *, dry_run: bool = False) -> list[SinkBinding]:
+    """Instantiate sink bindings ``(sink, severity_floor)`` from *config*.
+
+    When *dry_run* is set, every sink is wrapped in :class:`DryRunSink` so the
+    run performs zero network I/O.
+    """
+    bindings: list[SinkBinding] = []
+    for cfg in config.alerts:
+        sink = _build_one(cfg)
+        if dry_run:
+            sink = DryRunSink(sink)
+        bindings.append((sink, cfg.severity_floor))
+    return bindings

--- a/ziran/infrastructure/alert_sinks/github_issue_sink.py
+++ b/ziran/infrastructure/alert_sinks/github_issue_sink.py
@@ -1,0 +1,127 @@
+"""GitHub issue alert sink with stateless, marker-based deduplication."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from ziran.domain.entities.alerting import DeliveryResult
+from ziran.domain.ports.alert_sink import AlertSink
+
+if TYPE_CHECKING:
+    from ziran.domain.entities.alerting import AlertableFinding
+
+_API_ROOT = "https://api.github.com"
+_MARKER_PREFIX = "ziran-fingerprint:"
+
+
+def marker(fingerprint: str) -> str:
+    """Hidden HTML-comment marker embedded in issue bodies for dedup."""
+    return f"<!-- {_MARKER_PREFIX} {fingerprint} -->"
+
+
+class GitHubIssueSink(AlertSink):
+    """Opens a GitHub issue per finding, deduping via an embedded fingerprint marker.
+
+    Dedup is stateless: before creating, the sink searches open *and* closed
+    issues for the marker via the Search API; a hit short-circuits to ``deduped``.
+    """
+
+    name = "github_issue"
+
+    def __init__(
+        self,
+        repo: str,
+        token: str | None,
+        labels: list[str] | None = None,
+        assignees: list[str] | None = None,
+        timeout: float = 30.0,
+    ) -> None:
+        self._repo = repo
+        self._token = token
+        self._labels = labels or []
+        self._assignees = assignees or []
+        self._timeout = timeout
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+
+    def _body(self, finding: AlertableFinding) -> str:
+        lines = [finding.summary, ""]
+        for key, value in finding.fields.items():
+            lines.append(f"- **{key}:** {value}")
+        if finding.links:
+            lines.append("")
+            for link in finding.links:
+                lines.append(f"- [{link.label}]({link.url})")
+        if finding.remediation:
+            lines.extend(["", "## Suggested remediation", "", finding.remediation])
+        lines.extend(["", marker(finding.fingerprint)])
+        return "\n".join(lines)
+
+    async def emit(self, finding: AlertableFinding) -> DeliveryResult:
+        if not self._token:
+            return DeliveryResult(
+                sink_name=self.name,
+                fingerprint=finding.fingerprint,
+                status="failed",
+                detail="no GitHub token configured (set token or GITHUB_TOKEN)",
+            )
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout, headers=self._headers()) as client:
+                existing = await self._find_existing(client, finding.fingerprint)
+                if existing is not None:
+                    return DeliveryResult(
+                        sink_name=self.name,
+                        fingerprint=finding.fingerprint,
+                        status="deduped",
+                        detail=existing,
+                    )
+                return await self._create(client, finding)
+        except httpx.HTTPError as exc:
+            return DeliveryResult(
+                sink_name=self.name,
+                fingerprint=finding.fingerprint,
+                status="failed",
+                detail=f"github request error: {exc}",
+            )
+
+    async def _find_existing(self, client: httpx.AsyncClient, fingerprint: str) -> str | None:
+        query = f'repo:{self._repo} in:body "{_MARKER_PREFIX} {fingerprint}" is:issue'
+        resp = await client.get(f"{_API_ROOT}/search/issues", params={"q": query})
+        if resp.status_code != httpx.codes.OK:
+            return None
+        items = resp.json().get("items", [])
+        if items:
+            url: str = items[0].get("html_url", "")
+            return url
+        return None
+
+    async def _create(self, client: httpx.AsyncClient, finding: AlertableFinding) -> DeliveryResult:
+        payload: dict[str, Any] = {
+            "title": f"{finding.kind}: {finding.title}"[:256],
+            "body": self._body(finding),
+        }
+        if self._labels:
+            payload["labels"] = self._labels
+        if self._assignees:
+            payload["assignees"] = self._assignees
+        resp = await client.post(f"{_API_ROOT}/repos/{self._repo}/issues", json=payload)
+        if resp.status_code == httpx.codes.CREATED:
+            return DeliveryResult(
+                sink_name=self.name,
+                fingerprint=finding.fingerprint,
+                status="sent",
+                detail=resp.json().get("html_url"),
+            )
+        return DeliveryResult(
+            sink_name=self.name,
+            fingerprint=finding.fingerprint,
+            status="failed",
+            detail=f"github responded {resp.status_code}: {resp.text[:200]}",
+        )

--- a/ziran/infrastructure/alert_sinks/slack_sink.py
+++ b/ziran/infrastructure/alert_sinks/slack_sink.py
@@ -1,0 +1,85 @@
+"""Slack webhook alert sink (Block Kit + text fallback)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from ziran.domain.entities.alerting import DeliveryResult
+from ziran.domain.ports.alert_sink import AlertSink
+
+if TYPE_CHECKING:
+    from ziran.domain.entities.alerting import AlertableFinding
+
+_SEVERITY_EMOJI = {
+    "critical": ":rotating_light:",
+    "high": ":red_circle:",
+    "medium": ":large_orange_diamond:",
+    "low": ":white_circle:",
+}
+
+
+class SlackWebhookSink(AlertSink):
+    """Posts a Block Kit message per finding to a Slack incoming webhook."""
+
+    name = "slack"
+
+    def __init__(self, webhook_url: str, timeout: float = 15.0) -> None:
+        self._webhook_url = webhook_url
+        self._timeout = timeout
+
+    def _build_payload(self, finding: AlertableFinding) -> dict[str, Any]:
+        emoji = _SEVERITY_EMOJI.get(finding.severity, "")
+        blocks: list[dict[str, Any]] = [
+            {
+                "type": "header",
+                "text": {"type": "plain_text", "text": f"{emoji} {finding.title}"[:150]},
+            }
+        ]
+        if finding.fields:
+            blocks.append(
+                {
+                    "type": "section",
+                    "fields": [
+                        {"type": "mrkdwn", "text": f"*{k}:*\n{v}"}
+                        for k, v in finding.fields.items()
+                    ][:10],
+                }
+            )
+        if finding.links:
+            blocks.append(
+                {
+                    "type": "context",
+                    "elements": [
+                        {"type": "mrkdwn", "text": f"<{link.url}|{link.label}>"}
+                        for link in finding.links
+                    ],
+                }
+            )
+        return {
+            "text": f"{emoji} [{finding.kind}] {finding.summary}",
+            "blocks": blocks,
+        }
+
+    async def emit(self, finding: AlertableFinding) -> DeliveryResult:
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout) as client:
+                resp = await client.post(self._webhook_url, json=self._build_payload(finding))
+            if resp.status_code == httpx.codes.OK:
+                return DeliveryResult(
+                    sink_name=self.name, fingerprint=finding.fingerprint, status="sent"
+                )
+            return DeliveryResult(
+                sink_name=self.name,
+                fingerprint=finding.fingerprint,
+                status="failed",
+                detail=f"slack responded {resp.status_code}: {resp.text[:200]}",
+            )
+        except httpx.HTTPError as exc:
+            return DeliveryResult(
+                sink_name=self.name,
+                fingerprint=finding.fingerprint,
+                status="failed",
+                detail=f"slack request error: {exc}",
+            )

--- a/ziran/infrastructure/config/env_yaml.py
+++ b/ziran/infrastructure/config/env_yaml.py
@@ -1,0 +1,60 @@
+"""YAML loading with environment-variable resolution.
+
+Adds a ``!env VAR_NAME`` tag and ``${VAR}`` interpolation so secrets (webhook
+URLs, tokens) can live in the environment instead of committed config files.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any
+
+import yaml
+
+_INTERPOLATE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+class EnvVarError(ValueError):
+    """Raised when a referenced environment variable is unset."""
+
+
+class EnvSafeLoader(yaml.SafeLoader):
+    """SafeLoader subclass scoped to this module (does not affect global yaml)."""
+
+
+def _resolve(name: str) -> str:
+    try:
+        return os.environ[name]
+    except KeyError as exc:
+        raise EnvVarError(f"Environment variable '{name}' referenced in config is not set") from exc
+
+
+def _env_constructor(loader: yaml.SafeLoader, node: yaml.Node) -> str:
+    """Resolve ``!env VAR_NAME`` to the value of ``$VAR_NAME``."""
+    if not isinstance(node, yaml.ScalarNode):
+        raise EnvVarError("!env requires a scalar variable name")
+    name = str(loader.construct_scalar(node)).strip()
+    return _resolve(name)
+
+
+EnvSafeLoader.add_constructor("!env", _env_constructor)
+
+
+def _interpolate(value: Any) -> Any:
+    """Recursively expand ``${VAR}`` occurrences in all string values."""
+    if isinstance(value, str):
+        return _INTERPOLATE.sub(lambda m: _resolve(m.group(1)), value)
+    if isinstance(value, list):
+        return [_interpolate(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _interpolate(v) for k, v in value.items()}
+    return value
+
+
+def load_yaml_with_env(text: str) -> Any:
+    """Parse YAML *text*, resolving ``!env VAR`` tags and ``${VAR}`` interpolation.
+
+    Raises :class:`EnvVarError` if a referenced variable is unset.
+    """
+    return _interpolate(yaml.load(text, Loader=EnvSafeLoader))

--- a/ziran/interfaces/cli/watch_registry.py
+++ b/ziran/interfaces/cli/watch_registry.py
@@ -13,12 +13,14 @@ from pathlib import Path
 from typing import Any
 
 import click
-import yaml
 from rich.console import Console
 from rich.table import Table
 
-from ziran.application.registry_watch.watcher_service import watch
+from ziran.application.registry_watch.watcher_service import emit_findings, watch
+from ziran.domain.entities.alerting import AlertConfig
 from ziran.domain.entities.registry import DriftFinding, RegistryConfig, ServerEntry
+from ziran.infrastructure.alert_sinks.factory import build_sinks
+from ziran.infrastructure.config.env_yaml import load_yaml_with_env
 from ziran.infrastructure.snapshot_stores.json_file_store import JsonFileStore
 
 logger = logging.getLogger(__name__)
@@ -180,20 +182,26 @@ def _print_summary(findings: list[DriftFinding]) -> None:
     show_default=True,
     help="Report output format.",
 )
+@click.option(
+    "--dry-run-alerts",
+    is_flag=True,
+    help="Preview alert payloads without contacting Slack/GitHub.",
+)
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose logging.")
 def watch_registry(
     config_path: Path,
     snapshot_dir: Path,
     output_dir: Path,
     output_format: str,
+    dry_run_alerts: bool,
     verbose: bool,
 ) -> None:
     """Monitor MCP server registries for drift and typosquatting."""
     if verbose:
         logging.basicConfig(level=logging.DEBUG)
 
-    # Load config
-    raw_config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    # Load config (resolving !env / ${VAR} references for alert secrets)
+    raw_config = load_yaml_with_env(config_path.read_text(encoding="utf-8"))
     registry_config = RegistryConfig.model_validate(raw_config)
 
     # Override snapshot dir if specified in config
@@ -218,7 +226,19 @@ def watch_registry(
     console.print(f"Report written to [bold]{report_path}[/bold]")
     _print_summary(findings)
 
-    # Exit with non-zero if critical/high findings exist
+    # Deliver findings to configured alert sinks
+    delivery_failed = False
+    if registry_config.alerts and findings:
+        sinks = build_sinks(AlertConfig(alerts=registry_config.alerts), dry_run=dry_run_alerts)
+        outcome = asyncio.run(emit_findings(findings, sinks))
+        console.print(
+            f"Alerts: {outcome.sent} sent, {outcome.deduped} deduped, {outcome.failed} failed."
+        )
+        delivery_failed = outcome.any_failed
+
+    # Exit-code contract: delivery-failure (2) > severity-gate (1) > success (0).
+    if delivery_failed:
+        raise SystemExit(2)
     high_or_critical = [f for f in findings if f.severity in ("critical", "high")]
     if high_or_critical:
         raise SystemExit(1)


### PR DESCRIPTION
## Summary

First slice of the Runtime Loop alerting feature (spec 017). Adds a shared, reusable **AlertSink** notification capability and wires it into `watch-registry` so MCP drift findings reach humans and trackers instead of a log file. Closes #272.

This is **PR 1 of 3** for spec 017 — kept small per gitflow. US2 (#274 analyze-traces alerting) and US3 (#273 policy-refresh Action) follow as separate PRs branched off `develop` after this merges, since they reuse this sink layer.

## What's included

**Shared foundation (reused by the later stories):**
- `AlertSink` port + `AlertableFinding`/`DeliveryResult`/`AlertOutcome` domain entities + fingerprint helpers
- `SlackWebhookSink` (Block Kit) and `GitHubIssueSink` (stateless dedup: fingerprint marker embedded in the issue body, rediscovered via the Search API across open + closed issues)
- `DryRunSink` wrapper (zero network I/O) and a config-driven sink factory
- Async dispatcher: severity-floor filtering, concurrent fan-out, partial-failure aggregation
- `!env VAR` / `${VAR}` YAML loader so secrets stay in the environment

**watch-registry wiring (#272):**
- `DriftFinding.fingerprint()` = `(server, tool, drift-kind)` + `to_alertable()`
- `RegistryConfig.alerts:` block (parsed via the `!env` loader)
- `--dry-run-alerts` flag and exit-code contract: delivery-failure (2) > severity-gate (1) > 0

Full spec-kit artifacts for spec 017 are included under `specs/017-runtime-loop-alerting/`.

## Architecture / constitution notes

- Hexagonal boundaries respected: port + pure mapping in `domain/`, adapters + `!env` loader in `infrastructure/`, dispatcher in `application/`, composition at the CLI. Config models live in `domain/` (matching `RegistryConfig`'s precedent) so the application layer never imports infrastructure.
- Added a separate `watcher_service.emit_findings()` rather than changing `watch()`'s signature.

## Test plan

- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy ziran/` clean (strict, 185 files)
- [x] 24 new unit + integration tests pass (respx-mocked Slack/GitHub; dedup idempotency; severity floor; dry-run = zero I/O)
- [x] No regressions (pre-existing web-UI / pentest failures are from uninstalled optional extras, identical on the clean tree)