### PR TITLE
feat(analyze-traces): file issues for dangerous production chains (#274)

### DIFF
--- a/docs/guides/analyze-traces.md
+++ b/docs/guides/analyze-traces.md
@@ -1,0 +1,50 @@
+# Analyzing production traces
+
+`ziran analyze-traces` ingests production traces (OTel JSONL or Langfuse), reconstructs per-session tool-call sequences, and flags sequences that match dangerous tool chains. See [OTel tracing](otel-tracing.md) for how to export traces.
+
+```bash
+ziran analyze-traces --source otel --input traces.jsonl --out ./reports
+```
+
+## Alerting
+
+By default the command writes a report file. With `--alert`, dangerous-chain matches are also delivered to the notification sinks declared in a config file, so the operator who can fix the issue hears about it.
+
+```bash
+ziran analyze-traces --source otel --input traces.jsonl \
+  --alert --config alerts.yaml
+```
+
+`alerts.yaml` carries an `alerts:` block (the same schema used by `watch-registry`). Secrets are resolved from the environment via the `!env` tag — never commit them:
+
+```yaml
+alerts:
+  - kind: github_issue
+    repo: myorg/ai-agent-infra
+    token: !env GH_TOKEN
+    labels: [trace-finding, security]
+    severity_floor: high
+  - kind: slack
+    webhook_url: !env SLACK_WEBHOOK_URL
+    severity_floor: medium
+```
+
+Each filed GitHub issue includes the observed tool sequence, the session ID, the trace source, the (inherited) severity, and a suggested remediation when available.
+
+### Per-session vs. digest
+
+- Default: one issue per `(chain, session)` execution.
+- `--digest`: aggregate all matches from the run into a single digest issue.
+
+### Deduplication
+
+Issues are deduplicated by a stateless fingerprint embedded in the issue body (`(tool-chain, session)` for per-session, the chain set for a digest). Re-running on the same traces opens **no** new issues. The digest fingerprint excludes the run date, so an unchanged set of chains reuses the same digest issue across days.
+
+### Correlating pre-deploy findings
+
+Pass `--predeploy-result scan.json` (a prior `CampaignResult`) to correlate production matches against pre-deploy findings by tool sequence. Matched findings inherit the pre-deploy severity and remediation, and the issue links back to the pre-deploy finding.
+
+### Previewing and exit codes
+
+- `--dry-run-alerts` prints what each sink would send and performs zero network I/O.
+- Exit codes: `0` success · `2` partial delivery failure (detection ran, ≥1 sink failed) · `1` fatal/usage error.

--- a/specs/017-runtime-loop-alerting/tasks.md
+++ b/specs/017-runtime-loop-alerting/tasks.md
@@ -85,15 +85,15 @@ Single-project hexagonal layout: code in `ziran/`, tests in `tests/`.
 
 ### Tests for User Story 2
 
-- [ ] T022 [P] [US2] Integration test (respx) for `analyze-traces` per-session issue + dedup on re-run in `tests/integration/test_analyze_traces_alerting.py`
-- [ ] T023 [P] [US2] Unit test for trace fingerprint `(tool_chain_hash + session_id)` and digest grouping/fingerprint (assert the digest fingerprint excludes the run date, so unchanged traces dedup across days) in `tests/unit/test_trace_alertable.py`
+- [X] T022 [P] [US2] Integration test (respx) for `analyze-traces` per-session issue + dedup on re-run in `tests/integration/test_analyze_traces_alerting.py`
+- [X] T023 [P] [US2] Unit test for trace fingerprint `(tool_chain_hash + session_id)` and digest grouping/fingerprint (assert the digest fingerprint excludes the run date, so unchanged traces dedup across days) in `tests/unit/test_trace_alertable.py`
 
 ### Implementation for User Story 2
 
-- [ ] T024 [US2] Implement `DangerousChain` (observed-in-production) → `AlertableFinding` mapping: tool sequence, matched-finding link, existing-issue link via marker search, session ID, trace source link, inherited severity, remediation from a covering `GuardrailPolicy`, in `ziran/application/trace_analysis/` (new mapping module) (depends on T003)
-- [ ] T025 [US2] Implement `AnalyzerService.emit_findings(sinks, digest=False)` with per-`(chain, session)` and aggregated-digest modes in `ziran/application/trace_analysis/analyzer_service.py` (depends on T007, T024)
-- [ ] T026 [US2] Extend the analyze config loader to parse the `alerts:` block (`!env`) in `ziran/application/trace_analysis/` config (depends on T005, T006)
-- [ ] T027 [US2] Wire the `analyze-traces` CLI: `--alert` / `--digest` flags, build sinks via factory, map `AlertOutcome` to exit codes in `ziran/interfaces/cli/analyze_traces.py` (depends on T011, T025, T026)
+- [X] T024 [US2] Implement `DangerousChain` (observed-in-production) → `AlertableFinding` mapping: tool sequence, matched-finding link, existing-issue link via marker search, session ID, trace source link, inherited severity, remediation from a covering `GuardrailPolicy`, in `ziran/application/trace_analysis/` (new mapping module) (depends on T003)
+- [X] T025 [US2] Implement `AnalyzerService.emit_findings(sinks, digest=False)` with per-`(chain, session)` and aggregated-digest modes in `ziran/application/trace_analysis/analyzer_service.py` (depends on T007, T024)
+- [X] T026 [US2] Extend the analyze config loader to parse the `alerts:` block (`!env`) in `ziran/application/trace_analysis/` config (depends on T005, T006)
+- [X] T027 [US2] Wire the `analyze-traces` CLI: `--alert` / `--digest` flags, build sinks via factory, map `AlertOutcome` to exit codes in `ziran/interfaces/cli/analyze_traces.py` (depends on T011, T025, T026)
 
 **Checkpoint**: US1 and US2 both work independently.
 
@@ -121,7 +121,7 @@ Single-project hexagonal layout: code in `ziran/`, tests in `tests/`.
 
 ## Phase 6: Polish & Cross-Cutting Concerns
 
-- [ ] T032 [P] Add the "Alerting" section to `docs/guides/analyze-traces.md` (FR-026)
+- [X] T032 [P] Add the "Alerting" section to `docs/guides/analyze-traces.md` (FR-026)
 - [ ] T033 [P] Write the new guide `docs/guides/policy-refresh-automation.md` (FR-027)
 - [ ] T034 Run quickstart.md validation end-to-end (config samples, exit codes)
 - [ ] T035 Run quality gates: `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy ziran/`, `uv run pytest --cov=ziran` (≥85%)

--- a/tests/integration/test_analyze_traces_alerting.py
+++ b/tests/integration/test_analyze_traces_alerting.py
@@ -1,0 +1,121 @@
+"""Integration test: analyze-traces alerting end-to-end + dedup (respx)."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from ziran.application.trace_analysis.analyzer_service import AnalyzerService
+from ziran.domain.entities.alerting import AlertConfig, AlertSinkConfig
+from ziran.domain.entities.trace import ToolCallEvent, TraceSession
+from ziran.domain.ports.trace_ingestor import TraceIngestor
+from ziran.infrastructure.alert_sinks.factory import build_sinks
+
+pytestmark = pytest.mark.integration
+
+REPO = "myorg/ai-agent-infra"
+SEARCH = "https://api.github.com/search/issues"
+CREATE = f"https://api.github.com/repos/{REPO}/issues"
+
+
+class _Ingestor(TraceIngestor):
+    def __init__(self, sessions: list[TraceSession]) -> None:
+        self._sessions = sessions
+
+    async def ingest(self, source: Path | str, **kwargs: Any) -> list[TraceSession]:
+        return self._sessions
+
+
+def _session(session_id: str, tools: list[str]) -> TraceSession:
+    ts = datetime(2026, 5, 29, 12, 0, 0, tzinfo=UTC)
+    return TraceSession(
+        session_id=session_id,
+        tool_calls=[
+            ToolCallEvent(tool_name=t, timestamp=datetime(2026, 5, 29, 12, 0, i, tzinfo=UTC))
+            for i, t in enumerate(tools)
+        ],
+        start_time=ts,
+        end_time=ts,
+        source="otel",
+    )
+
+
+def _wire_github(created: list[dict[str, Any]]) -> None:
+    def search_handler(request: httpx.Request) -> httpx.Response:
+        q = request.url.params.get("q", "")
+        hit = next((i for i in created if i["fingerprint"] in q), None)
+        items = [{"html_url": hit["html_url"]}] if hit else []
+        return httpx.Response(200, json={"total_count": len(items), "items": items})
+
+    def create_handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.read().decode())
+        match = re.search(r"ziran-fingerprint:\s*([0-9a-f]{16})", payload["body"])
+        fp = match.group(1) if match else ""
+        num = len(created) + 1
+        url = f"https://github.com/{REPO}/issues/{num}"
+        created.append({"fingerprint": fp, "html_url": url})
+        return httpx.Response(201, json={"html_url": url, "number": num})
+
+    respx.get(SEARCH).mock(side_effect=search_handler)
+    respx.post(CREATE).mock(side_effect=create_handler)
+
+
+def _github_sinks() -> list[Any]:
+    config = AlertConfig(alerts=[AlertSinkConfig(kind="github_issue", repo=REPO, token="tok")])
+    return build_sinks(config)
+
+
+@respx.mock
+async def test_dangerous_chain_files_one_issue_then_dedups() -> None:
+    created: list[dict[str, Any]] = []
+    _wire_github(created)
+    service = AnalyzerService(_Ingestor([_session("sess-1", ["read_file", "http_request"])]))
+
+    outcome = await service.emit_findings(Path("dummy"), _github_sinks())
+    assert outcome.sent == 1
+    assert len(created) == 1
+
+    # Re-run on the same trace → dedup, zero new issues.
+    outcome2 = await service.emit_findings(Path("dummy"), _github_sinks())
+    assert outcome2.deduped == 1
+    assert len(created) == 1
+
+
+@respx.mock
+async def test_digest_mode_files_single_issue_for_multiple_sessions() -> None:
+    created: list[dict[str, Any]] = []
+    _wire_github(created)
+    service = AnalyzerService(
+        _Ingestor(
+            [
+                _session("sess-1", ["read_file", "http_request"]),
+                _session("sess-2", ["read_file", "http_request"]),
+            ]
+        )
+    )
+
+    outcome = await service.emit_findings(Path("dummy"), _github_sinks(), digest=True)
+
+    assert outcome.sent == 1  # one aggregated digest issue
+    assert len(created) == 1
+
+
+@respx.mock
+async def test_issue_body_contains_tool_sequence_and_session() -> None:
+    created: list[dict[str, Any]] = []
+    _wire_github(created)
+    route = respx.post(CREATE)
+    service = AnalyzerService(_Ingestor([_session("sess-xyz", ["read_file", "http_request"])]))
+
+    await service.emit_findings(Path("dummy"), _github_sinks())
+
+    body = json.loads(route.calls.last.request.read().decode())["body"]
+    assert "read_file → http_request" in body
+    assert "sess-xyz" in body

--- a/tests/unit/test_trace_alertable.py
+++ b/tests/unit/test_trace_alertable.py
@@ -1,0 +1,96 @@
+"""Unit tests for trace dangerous-chain → alertable mapping + digest."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from ziran.application.trace_analysis.alerting import (
+    build_digest,
+    chain_to_alertable,
+    match_predeploy,
+)
+from ziran.domain.entities.alerting import trace_fingerprint
+from ziran.domain.entities.capability import DangerousChain
+from ziran.domain.entities.trace import TraceSession
+
+pytestmark = pytest.mark.unit
+
+
+def _chain(tools: list[str] | None = None, **kw: object) -> DangerousChain:
+    base: dict[str, object] = {
+        "tools": tools or ["read_file", "http_request"],
+        "risk_level": "high",
+        "vulnerability_type": "data_exfiltration",
+        "exploit_description": "read then exfiltrate",
+        "remediation": "deny http_request after read_file",
+        "occurrence_count": 2,
+    }
+    base.update(kw)
+    return DangerousChain(**base)  # type: ignore[arg-type]
+
+
+def _session(session_id: str = "sess-1", **kw: object) -> TraceSession:
+    ts = datetime(2026, 5, 29, tzinfo=UTC)
+    base: dict[str, object] = {
+        "session_id": session_id,
+        "tool_calls": [],
+        "start_time": ts,
+        "end_time": ts,
+        "source": "langfuse",
+    }
+    base.update(kw)
+    return TraceSession(**base)  # type: ignore[arg-type]
+
+
+def test_fingerprint_combines_chain_and_session() -> None:
+    a = chain_to_alertable(_chain(), _session("sess-1"))
+    assert a.fingerprint == trace_fingerprint("read_file->http_request", "sess-1")
+    # Same chain, different session → different fingerprint.
+    b = chain_to_alertable(_chain(), _session("sess-2"))
+    assert a.fingerprint != b.fingerprint
+
+
+def test_mapping_includes_required_context() -> None:
+    a = chain_to_alertable(_chain(), _session("sess-1", metadata={"trace_url": "https://lf/t/1"}))
+    assert a.kind == "dangerous_chain"
+    assert a.severity == "high"
+    assert a.fields["Tool sequence"] == "read_file → http_request"
+    assert a.fields["Session"] == "sess-1"
+    assert a.fields["Trace source"] == "langfuse"
+    assert a.remediation == "deny http_request after read_file"
+    assert a.links[0].url == "https://lf/t/1"
+
+
+def test_matched_predeploy_inherits_severity_and_remediation() -> None:
+    predeploy = [
+        {
+            "tools": ["read_file", "http_request"],
+            "risk_level": "critical",
+            "remediation": "block it",
+        }
+    ]
+    chain = _chain(risk_level="medium")
+    matched = match_predeploy(chain, predeploy)
+    assert matched is not None
+    a = chain_to_alertable(chain, _session(), matched=matched, predeploy_ref="scan.json")
+    assert a.severity == "critical"  # inherited from pre-deploy finding
+    assert a.remediation == "block it"
+    assert a.fields["Matched pre-deploy finding"] == "scan.json"
+
+
+def test_no_match_returns_none() -> None:
+    assert match_predeploy(_chain(["a", "b"]), [{"tools": ["x", "y"]}]) is None
+
+
+def test_digest_aggregates_and_takes_top_severity() -> None:
+    findings = [
+        chain_to_alertable(_chain(risk_level="medium"), _session("s1")),
+        chain_to_alertable(_chain(["sql", "exec"], risk_level="critical"), _session("s2")),
+    ]
+    digest = build_digest(findings)
+    assert digest.severity == "critical"
+    assert "2 dangerous chain" in digest.title
+    # Digest fingerprint is independent of ordering.
+    assert build_digest(findings).fingerprint == build_digest(list(reversed(findings))).fingerprint

--- a/ziran/application/trace_analysis/alerting.py
+++ b/ziran/application/trace_analysis/alerting.py
@@ -1,0 +1,112 @@
+"""Map production dangerous-chain matches to alertable findings."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from ziran.domain.entities.alerting import (
+    AlertableFinding,
+    AlertLink,
+    digest_fingerprint,
+    severity_rank,
+    trace_fingerprint,
+)
+
+if TYPE_CHECKING:
+    from ziran.domain.entities.attack import Severity
+    from ziran.domain.entities.capability import DangerousChain
+    from ziran.domain.entities.trace import TraceSession
+
+_VALID_SEVERITIES = {"low", "medium", "high", "critical"}
+
+
+def _to_severity(risk_level: str) -> Severity:
+    """Coerce a chain risk level to a canonical severity (default ``medium``)."""
+    value = risk_level.lower().strip()
+    if value in _VALID_SEVERITIES:
+        return value  # type: ignore[return-value]
+    return "medium"
+
+
+def _tool_chain_hash(chain: DangerousChain) -> str:
+    return "->".join(chain.tools)
+
+
+def match_predeploy(
+    chain: DangerousChain,
+    predeploy_chains: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Find a pre-deploy finding whose tool sequence matches this chain."""
+    target = list(chain.tools)
+    for candidate in predeploy_chains:
+        if list(candidate.get("tools", [])) == target:
+            return candidate
+    return None
+
+
+def chain_to_alertable(
+    chain: DangerousChain,
+    session: TraceSession,
+    *,
+    matched: dict[str, Any] | None = None,
+    predeploy_ref: str | None = None,
+) -> AlertableFinding:
+    """Map a dangerous chain observed in *session* to an alertable finding.
+
+    When *matched* (a pre-deploy finding) is supplied, severity and remediation
+    are inherited from it and a link to the pre-deploy finding is attached.
+    """
+    severity = (
+        _to_severity(str(matched["risk_level"])) if matched else _to_severity(chain.risk_level)
+    )
+    remediation = (matched.get("remediation") if matched else None) or chain.remediation or None
+
+    fields: dict[str, str] = {
+        "Tool sequence": " → ".join(chain.tools),
+        "Vulnerability type": chain.vulnerability_type,
+        "Session": session.session_id,
+        "Trace source": session.source,
+        "Occurrences": str(chain.occurrence_count),
+    }
+    if matched:
+        fields["Matched pre-deploy finding"] = predeploy_ref or "yes"
+
+    links: list[AlertLink] = []
+    trace_url = session.metadata.get("trace_url")
+    if isinstance(trace_url, str) and trace_url:
+        links.append(AlertLink(label=f"Trace ({session.source})", url=trace_url))
+
+    return AlertableFinding(
+        fingerprint=trace_fingerprint(_tool_chain_hash(chain), session.session_id),
+        kind="dangerous_chain",
+        severity=severity,
+        title=f"{chain.vulnerability_type} chain observed in production ({session.session_id})",
+        summary=chain.exploit_description,
+        fields=fields,
+        links=links,
+        remediation=remediation,
+    )
+
+
+def build_digest(findings: list[AlertableFinding]) -> AlertableFinding:
+    """Aggregate per-session findings into a single digest finding.
+
+    The digest fingerprint is derived solely from the contained chain
+    fingerprints (no run date), so re-running on unchanged traces reuses the
+    same digest issue.
+    """
+    fingerprints = [f.fingerprint for f in findings]
+    top_severity: Severity = "low"
+    for finding in findings:
+        if severity_rank(finding.severity) > severity_rank(top_severity):
+            top_severity = finding.severity
+
+    lines = [f"- {f.title}" for f in findings]
+    return AlertableFinding(
+        fingerprint=digest_fingerprint(fingerprints),
+        kind="dangerous_chain",
+        severity=top_severity,
+        title=f"Trace analysis digest: {len(findings)} dangerous chain execution(s)",
+        summary="Multiple dangerous tool-chain executions were observed in production traces.",
+        fields={"Chains": "\n".join(lines)},
+    )

--- a/ziran/application/trace_analysis/analyzer_service.py
+++ b/ziran/application/trace_analysis/analyzer_service.py
@@ -10,15 +10,23 @@ import logging
 import uuid
 from typing import TYPE_CHECKING, Any
 
+from ziran.application.alerting.dispatch import dispatch
 from ziran.application.knowledge_graph.chain_analyzer import (
     ToolChainAnalyzer,
 )
 from ziran.application.knowledge_graph.graph import AttackKnowledgeGraph
+from ziran.application.trace_analysis.alerting import (
+    build_digest,
+    chain_to_alertable,
+    match_predeploy,
+)
 from ziran.domain.entities.phase import CampaignResult, PhaseResult, ScanPhase
 
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from ziran.application.alerting.dispatch import SinkBinding
+    from ziran.domain.entities.alerting import AlertableFinding, AlertOutcome
     from ziran.domain.entities.capability import DangerousChain
     from ziran.domain.entities.trace import TraceSession
     from ziran.domain.ports.trace_ingestor import TraceIngestor
@@ -90,6 +98,37 @@ class AnalyzerService:
                 "trace_source": (sessions[0].source if sessions else "unknown"),
             },
         )
+
+    async def emit_findings(
+        self,
+        source: Path | str,
+        sinks: list[SinkBinding],
+        *,
+        digest: bool = False,
+        predeploy_chains: list[dict[str, Any]] | None = None,
+        predeploy_ref: str | None = None,
+        **kwargs: Any,
+    ) -> AlertOutcome:
+        """Deliver dangerous-chain matches from production traces to alert sinks.
+
+        Findings are produced per ``(chain, session)``. When *predeploy_chains*
+        is supplied, each match is correlated by tool sequence to inherit
+        severity/remediation and link the pre-deploy finding. With *digest*,
+        all matches are aggregated into a single digest finding.
+        """
+        sessions = await self._ingestor.ingest(source, **kwargs)
+        findings: list[AlertableFinding] = []
+        for session in sessions:
+            for chain in self._analyze_session(session):
+                matched = match_predeploy(chain, predeploy_chains) if predeploy_chains else None
+                findings.append(
+                    chain_to_alertable(chain, session, matched=matched, predeploy_ref=predeploy_ref)
+                )
+
+        if digest and findings:
+            findings = [build_digest(findings)]
+
+        return await dispatch(findings, sinks)
 
     def _analyze_session(self, session: TraceSession) -> list[DangerousChain]:
         """Build a temp graph for one session and run chain analysis."""

--- a/ziran/interfaces/cli/analyze_traces.py
+++ b/ziran/interfaces/cli/analyze_traces.py
@@ -58,6 +58,35 @@ console = Console()
     default="json",
     help="Report format.",
 )
+@click.option(
+    "--alert",
+    is_flag=True,
+    help="Deliver dangerous-chain matches to the sinks in --config.",
+)
+@click.option(
+    "--digest",
+    is_flag=True,
+    help="Aggregate matches into a single digest issue (default: one per session).",
+)
+@click.option(
+    "--config",
+    "config_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="YAML config with an 'alerts:' block (required with --alert).",
+)
+@click.option(
+    "--predeploy-result",
+    "predeploy_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="Pre-deploy CampaignResult JSON to correlate matches against.",
+)
+@click.option(
+    "--dry-run-alerts",
+    is_flag=True,
+    help="Preview alert payloads without contacting Slack/GitHub.",
+)
 @click.option("--verbose", "-v", is_flag=True, help="Verbose output.")
 def analyze_traces(
     source: str,
@@ -66,6 +95,11 @@ def analyze_traces(
     since: str,
     out: str,
     output_format: str,
+    alert: bool,
+    digest: bool,
+    config_path: Path | None,
+    predeploy_path: Path | None,
+    dry_run_alerts: bool,
     verbose: bool,
 ) -> None:
     """Analyze production traces for dangerous tool chains.
@@ -129,6 +163,64 @@ def analyze_traces(
         report_path.write_text(json.dumps(result.model_dump(mode="json"), indent=2))
 
     console.print(f"\n[dim]Report saved to {report_path}[/dim]")
+
+    # Deliver dangerous-chain matches to configured alert sinks
+    if alert:
+        if config_path is None:
+            console.print("[red]Error:[/red] --alert requires --config with an 'alerts:' block.")
+            raise SystemExit(1)
+        _emit_alerts(
+            service,
+            ingest_source,
+            kwargs,
+            config_path=config_path,
+            predeploy_path=predeploy_path,
+            digest=digest,
+            dry_run_alerts=dry_run_alerts,
+        )
+
+
+def _emit_alerts(
+    service: Any,
+    ingest_source: Path | str,
+    kwargs: dict[str, Any],
+    *,
+    config_path: Path,
+    predeploy_path: Path | None,
+    digest: bool,
+    dry_run_alerts: bool,
+) -> None:
+    """Build sinks from config and dispatch trace findings; map exit codes."""
+    from ziran.domain.entities.alerting import AlertConfig
+    from ziran.infrastructure.alert_sinks.factory import build_sinks
+    from ziran.infrastructure.config.env_yaml import load_yaml_with_env
+
+    raw = load_yaml_with_env(config_path.read_text(encoding="utf-8"))
+    alert_config = AlertConfig.model_validate(raw)
+    sinks = build_sinks(alert_config, dry_run=dry_run_alerts)
+
+    predeploy_chains: list[dict[str, Any]] | None = None
+    predeploy_ref: str | None = None
+    if predeploy_path is not None:
+        predeploy_data = json.loads(predeploy_path.read_text(encoding="utf-8"))
+        predeploy_chains = predeploy_data.get("dangerous_tool_chains", [])
+        predeploy_ref = str(predeploy_path)
+
+    outcome = asyncio.run(
+        service.emit_findings(
+            ingest_source,
+            sinks,
+            digest=digest,
+            predeploy_chains=predeploy_chains,
+            predeploy_ref=predeploy_ref,
+            **kwargs,
+        )
+    )
+    console.print(
+        f"Alerts: {outcome.sent} sent, {outcome.deduped} deduped, {outcome.failed} failed."
+    )
+    if outcome.any_failed:
+        raise SystemExit(2)
 
 
 def _build_ingestor(source: str) -> Any:


### PR DESCRIPTION
## Summary

**PR 2 of 3** for spec 017 (Runtime Loop alerting). Wires `analyze-traces` into the shared `AlertSink` layer from #311 so dangerous tool-chains observed in production traces open (deduplicated) GitHub issues / Slack alerts. Closes #274.

Depends on the foundation merged in #311. PR 3 (#273 policy-refresh Action) follows.

## What's included

- **Mapping** (`application/trace_analysis/alerting.py`): `chain_to_alertable` + `build_digest` — emits tool sequence, session, trace-source link, inherited severity, and remediation.
- **`AnalyzerService.emit_findings(source, sinks, *, digest=, predeploy_chains=, predeploy_ref=)`** — per-`(chain, session)` findings, optional pre-deploy correlation (FR-014/FR-015), and digest aggregation.
- **CLI**: `--alert`, `--digest`, `--config` (an `alerts:` block resolved via `!env`), `--predeploy-result`, `--dry-run-alerts`, and the delivery-failure exit code (2).
- **Dedup**: per-session findings keyed by `(tool-chain, session)`; digest keyed by the chain set (no run date) — re-running on unchanged traces opens **no** new issues.
- **Docs**: new `docs/guides/analyze-traces.md` with an Alerting section.

## Scope notes

- Pre-deploy correlation is opt-in via `--predeploy-result` (matches by tool sequence); when matched, severity + remediation are inherited and the finding links back. Without it, the chain's own risk level / remediation are used.
- `--alert` re-ingests the traces (separate from the report pass); fine for file sources.

## Test plan

- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy ziran/` clean (strict, 186 files)
- [x] New unit tests (mapping, digest, pre-deploy match) + integration tests (respx: one issue per novel chain, dedup on re-run, digest = single issue, body carries tool sequence + session)
- [x] No regressions in existing analyzer / analyze-traces CLI tests