### PR TITLE
feat(policy-export): auto-refresh exported policies via GitHub Action (#273)

### DIFF
--- a/.github/actions/export-policy/action.yml
+++ b/.github/actions/export-policy/action.yml
@@ -1,0 +1,150 @@
+name: ziran-policy-refresh
+description: >-
+  Regenerate guardrail policy bundles (OPA/Rego, Cedar, NeMo Colang, Invariant)
+  from a ZIRAN scan and open/update a single refresh PR when they drift from the
+  committed bundle. Assumes the repository is already checked out and the `ziran`
+  CLI is installed.
+
+inputs:
+  target:
+    description: Path to a YAML target config to scan (alternative to result-json).
+    required: false
+    default: ""
+  result-json:
+    description: >-
+      Path to a pre-existing campaign result JSON. When set, the scan step is
+      skipped and policies are regenerated from this file (offline mode).
+    required: false
+    default: ""
+  out-dir:
+    description: Committed policy-bundle directory (contains only generated policy files).
+    required: false
+    default: policies
+  target-formats:
+    description: Comma-separated formats to regenerate (rego, cedar, nemo, invariant).
+    required: false
+    default: rego,cedar,nemo,invariant
+  severity-floor:
+    description: Minimum severity to include in exported policies.
+    required: false
+    default: medium
+  fail-on-diff:
+    description: Fail the run on any drift instead of opening a PR.
+    required: false
+    default: "false"
+  branch:
+    description: Fixed head branch for the single long-lived refresh PR.
+    required: false
+    default: ziran/policy-refresh
+  reviewer-team:
+    description: Team/user slug to request review from (optional).
+    required: false
+    default: ""
+  token:
+    description: Token used for git push and PR operations.
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  changed:
+    description: "true if the regenerated bundle differs from the committed one."
+    value: ${{ steps.diff.outputs.changed }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve campaign result
+      id: resolve
+      shell: bash
+      env:
+        IN_RESULT: ${{ inputs.result-json }}
+        IN_TARGET: ${{ inputs.target }}
+      run: |
+        set -euo pipefail
+        if [ -n "$IN_RESULT" ]; then
+          echo "result=$IN_RESULT" >> "$GITHUB_OUTPUT"
+        elif [ -n "$IN_TARGET" ]; then
+          dest="$RUNNER_TEMP/ziran-results"
+          mkdir -p "$dest"
+          ziran scan --target "$IN_TARGET" -o "$dest"
+          result="$(find "$dest" -name '*report*.json' | head -n1)"
+          if [ -z "$result" ]; then
+            echo "::error::scan produced no campaign result JSON"; exit 1
+          fi
+          echo "result=$result" >> "$GITHUB_OUTPUT"
+        else
+          echo "::error::provide either 'target' or 'result-json'"; exit 1
+        fi
+
+    - name: Regenerate policies
+      id: gen
+      shell: bash
+      env:
+        RESULT: ${{ steps.resolve.outputs.result }}
+        FORMATS: ${{ inputs.target-formats }}
+        FLOOR: ${{ inputs.severity-floor }}
+      run: |
+        set -euo pipefail
+        gen="$RUNNER_TEMP/ziran-policy-gen"
+        rm -rf "$gen"; mkdir -p "$gen"
+        IFS=',' read -ra fmts <<< "$FORMATS"
+        for fmt in "${fmts[@]}"; do
+          fmt="$(echo "$fmt" | xargs)"
+          [ -z "$fmt" ] && continue
+          ziran export-policy --result "$RESULT" --format "$fmt" --out "$gen" --severity-floor "$FLOOR"
+        done
+        echo "gen=$gen" >> "$GITHUB_OUTPUT"
+
+    - name: Detect drift
+      id: diff
+      shell: bash
+      env:
+        OUT: ${{ inputs.out-dir }}
+        GEN: ${{ steps.gen.outputs.gen }}
+      run: |
+        set -euo pipefail
+        mkdir -p "$OUT"
+        if diff -rq "$OUT" "$GEN" >/dev/null 2>&1; then
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+          echo "Policy bundle is up to date."
+        else
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Enforce or open refresh PR
+      if: steps.diff.outputs.changed == 'true'
+      shell: bash
+      env:
+        OUT: ${{ inputs.out-dir }}
+        GEN: ${{ steps.gen.outputs.gen }}
+        FAIL_ON_DIFF: ${{ inputs.fail-on-diff }}
+        BRANCH: ${{ inputs.branch }}
+        REVIEWER: ${{ inputs.reviewer-team }}
+        BASE_REF: ${{ github.ref_name }}
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+        if [ "$FAIL_ON_DIFF" = "true" ]; then
+          echo "::error::Exported policies differ from the committed bundle (out-dir: $OUT)."
+          diff -ru "$OUT" "$GEN" || true
+          exit 1
+        fi
+        # Sync regenerated bundle into the committed dir (dropping stale files).
+        rsync -a --delete "$GEN"/ "$OUT"/
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git switch -C "$BRANCH"
+        git add -A "$OUT"
+        git commit -m "chore(policy): refresh exported guardrail policies"
+        git push -f origin "$BRANCH"
+        if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+          echo "Refresh PR already open for '$BRANCH'; branch updated."
+        else
+          gh pr create --base "$BASE_REF" --head "$BRANCH" \
+            --title "chore(policy): refresh exported guardrail policies" \
+            --body "Automated guardrail-policy refresh generated by \`ziran export-policy\`." \
+            --label policy-refresh
+        fi
+        if [ -n "$REVIEWER" ]; then
+          gh pr edit "$BRANCH" --add-reviewer "$REVIEWER" || true
+        fi

--- a/.github/workflows/policy-refresh-selftest.yml
+++ b/.github/workflows/policy-refresh-selftest.yml
@@ -1,0 +1,76 @@
+# Self-test for the export-policy composite action.
+# Exercises the drift-detection logic deterministically (no LLM keys, no PRs)
+# by running in fail-on-diff mode against a committed sample campaign result.
+name: policy-refresh-selftest
+
+on:
+  pull_request:
+    paths:
+      - ".github/actions/export-policy/**"
+      - ".github/workflows/policy-refresh-selftest.yml"
+      - "examples/07-cicd-quality-gate/sample-campaign-result.json"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  stale-bundle-is-detected:
+    name: Stale bundle → run fails
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install ZIRAN (local checkout)
+        run: python -m pip install -e .
+      - name: Run against an empty bundle (should detect drift)
+        id: refresh
+        continue-on-error: true
+        uses: ./.github/actions/export-policy
+        with:
+          result-json: examples/07-cicd-quality-gate/sample-campaign-result.json
+          out-dir: ${{ runner.temp }}/empty-bundle
+          fail-on-diff: "true"
+      - name: Assert the run failed (drift detected)
+        run: |
+          if [ "${{ steps.refresh.outcome }}" != "failure" ]; then
+            echo "::error::expected fail-on-diff to fail against an empty bundle"
+            exit 1
+          fi
+          echo "Drift correctly detected (changed=${{ steps.refresh.outputs.changed }})."
+
+  current-bundle-is-noop:
+    name: Current bundle → no drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install ZIRAN (local checkout)
+        run: python -m pip install -e .
+      - name: Pre-generate the committed bundle
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/current-bundle"
+          for fmt in rego cedar nemo invariant; do
+            ziran export-policy \
+              --result examples/07-cicd-quality-gate/sample-campaign-result.json \
+              --format "$fmt" --out "$RUNNER_TEMP/current-bundle" --severity-floor medium
+          done
+      - name: Run against the up-to-date bundle (should be a no-op)
+        id: refresh
+        uses: ./.github/actions/export-policy
+        with:
+          result-json: examples/07-cicd-quality-gate/sample-campaign-result.json
+          out-dir: ${{ runner.temp }}/current-bundle
+          fail-on-diff: "true"
+      - name: Assert no drift
+        run: |
+          if [ "${{ steps.refresh.outputs.changed }}" != "false" ]; then
+            echo "::error::expected no drift for an up-to-date bundle"
+            exit 1
+          fi
+          echo "No drift, as expected."

--- a/docs/guides/policy-refresh-automation.md
+++ b/docs/guides/policy-refresh-automation.md
@@ -1,0 +1,65 @@
+# Policy-refresh automation
+
+`ziran export-policy` renders guardrail policy bundles (OPA/Rego, Cedar, NeMo Colang, Invariant Labs) from scan findings. Run once, those bundles drift stale as the attack library or your agent changes. The **export-policy composite Action** keeps them fresh: it re-scans, regenerates the bundle, and opens (or updates) a single PR when the result differs from what is committed.
+
+## Quick start
+
+Copy [`examples/07-cicd-quality-gate/policy-refresh.yml`](../../examples/07-cicd-quality-gate/policy-refresh.yml) into `.github/workflows/`:
+
+```yaml
+name: Policy Refresh
+on:
+  schedule: [{ cron: "0 6 * * 1" }]   # weekly
+  workflow_dispatch: {}
+concurrency:
+  group: ziran-policy-refresh         # overlapping runs can't open competing PRs
+  cancel-in-progress: true
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.13" }
+      - run: python -m pip install ziran
+      - uses: taoq-ai/ziran/.github/actions/export-policy@v0
+        with:
+          target: target.yaml
+          out-dir: policies/
+          target-formats: rego,cedar,nemo,invariant
+          reviewer-team: secops
+```
+
+## Inputs
+
+| Input | Default | Purpose |
+|-------|---------|---------|
+| `target` | — | YAML target config to scan. |
+| `result-json` | — | Pre-existing campaign result JSON; skips the scan (offline mode). Provide `target` **or** `result-json`. |
+| `out-dir` | `policies` | Committed bundle directory (holds only generated policy files). |
+| `target-formats` | `rego,cedar,nemo,invariant` | Comma list — scope which formats to regenerate. |
+| `severity-floor` | `medium` | Minimum severity to include. |
+| `fail-on-diff` | `false` | Fail the run on drift instead of opening a PR. |
+| `branch` | `ziran/policy-refresh` | Fixed head branch for the single long-lived refresh PR. |
+| `reviewer-team` | — | Team/user slug to request review from. |
+| `token` | `github.token` | Token for git push and PR operations. |
+
+## Behaviour
+
+- **No drift** → no PR, run succeeds (`changed=false`).
+- **Drift + `fail-on-diff: false`** → regenerated files are synced into `out-dir` (stale files removed) and committed to the fixed `ziran/policy-refresh` branch; a PR is opened if none exists for that branch, otherwise the existing one is updated. The PR is labelled `policy-refresh` and the reviewer team is requested.
+- **Drift + `fail-on-diff: true`** → the run fails and prints the diff; no PR is opened. Use this for hard enforcement.
+
+The fixed head branch means a single refresh PR is maintained regardless of whether your base branch uses squash or merge-commit merges, and the workflow's `concurrency` group prevents overlapping scheduled runs from racing.
+
+## Scoping formats
+
+`target-formats` regenerates only the listed formats — e.g. `rego,cedar` to keep just OPA/Rego and Cedar bundles current.
+
+## Notes
+
+- The Action assumes the repo is already checked out and `ziran` is installed (see the template's install step).
+- For offline/keyless runs (or to re-render a prior scan), pass `result-json` instead of `target`.

--- a/examples/07-cicd-quality-gate/policy-refresh.yml
+++ b/examples/07-cicd-quality-gate/policy-refresh.yml
@@ -1,0 +1,49 @@
+# ──────────────────────────────────────────────────────────────────────
+# Example: ZIRAN guardrail-policy refresh
+# Copy this file to .github/workflows/ in your repository.
+#
+# Re-scans your agent on a schedule, regenerates the exported guardrail
+# policy bundle, and opens/updates a single PR when it drifts from what is
+# committed. Set fail-on-diff: "true" to hard-block instead of opening a PR.
+# ──────────────────────────────────────────────────────────────────────
+name: Policy Refresh
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # weekly, Monday 06:00 UTC
+  workflow_dispatch: {}
+
+# A single long-lived refresh must never race itself into competing PRs.
+concurrency:
+  group: ziran-policy-refresh
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh:
+    name: Refresh exported policies
+    runs-on: ubuntu-latest
+    env:
+      # ZIRAN is provider-agnostic — set whichever key your agent needs.
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install ZIRAN
+        run: python -m pip install ziran
+
+      - name: Refresh guardrail policies
+        uses: taoq-ai/ziran/.github/actions/export-policy@v0
+        with:
+          target: target.yaml # YAML target config for your agent
+          out-dir: policies/ # committed policy bundle
+          target-formats: rego,cedar,nemo,invariant
+          reviewer-team: secops # team/user slug to request review from
+          # fail-on-diff: "true"  # uncomment to block instead of opening a PR

--- a/examples/07-cicd-quality-gate/sample-campaign-result.json
+++ b/examples/07-cicd-quality-gate/sample-campaign-result.json
@@ -1,0 +1,24 @@
+{
+  "campaign_id": "policy-refresh-sample",
+  "target_agent": "example-agent",
+  "phases_executed": [],
+  "total_vulnerabilities": 2,
+  "final_trust_score": 0.4,
+  "success": false,
+  "dangerous_tool_chains": [
+    {
+      "tools": ["read_file", "http_request"],
+      "risk_level": "critical",
+      "vulnerability_type": "data_exfiltration",
+      "exploit_description": "Reads a local file then exfiltrates its contents over HTTP.",
+      "remediation": "Disallow http_request after read_file in the same session."
+    },
+    {
+      "tools": ["sql_query", "shell_exec"],
+      "risk_level": "high",
+      "vulnerability_type": "sql_to_rce",
+      "exploit_description": "SQL output is passed into a shell command, enabling RCE.",
+      "remediation": "Never route query output into shell_exec without validation."
+    }
+  ]
+}

--- a/specs/017-runtime-loop-alerting/tasks.md
+++ b/specs/017-runtime-loop-alerting/tasks.md
@@ -107,13 +107,13 @@ Single-project hexagonal layout: code in `ziran/`, tests in `tests/`.
 
 ### Tests for User Story 3
 
-- [ ] T028 [US3] Self-test workflow `.github/workflows/policy-refresh-selftest.yml` that runs the action against the example agent and asserts PR-opened-when-stale / no-PR-when-current
+- [X] T028 [US3] Self-test workflow `.github/workflows/policy-refresh-selftest.yml` that runs the action against the example agent and asserts PR-opened-when-stale / no-PR-when-current
 
 ### Implementation for User Story 3
 
-- [ ] T029 [P] [US3] Author the composite action `.github/actions/export-policy/action.yml` (inputs: target, out-dir, target-formats, fail-on-diff, reviewer-team; steps: install → `ziran scan` → `ziran export-policy --formats` → diff → fixed-branch `ziran/policy-refresh` PR via `gh`, label `policy-refresh`, request reviewer) per contracts/cli_and_action.md
-- [ ] T030 [P] [US3] Add the copyable workflow template `examples/07-cicd-quality-gate/policy-refresh.yml` (weekly schedule + `workflow_dispatch`), including a `concurrency: { group: ziran-policy-refresh, cancel-in-progress: true }` block so overlapping scheduled runs cannot open competing PRs (spec "Concurrent automation runs" edge case, FR-024)
-- [ ] T031 [P] [US3] Verify `ziran export-policy` accepts a `--formats` scoping option; add it in `ziran/interfaces/cli/export_policy.py` if missing (FR-022)
+- [X] T029 [P] [US3] Author the composite action `.github/actions/export-policy/action.yml` (inputs: target, out-dir, target-formats, fail-on-diff, reviewer-team; steps: install → `ziran scan` → `ziran export-policy --formats` → diff → fixed-branch `ziran/policy-refresh` PR via `gh`, label `policy-refresh`, request reviewer) per contracts/cli_and_action.md
+- [X] T030 [P] [US3] Add the copyable workflow template `examples/07-cicd-quality-gate/policy-refresh.yml` (weekly schedule + `workflow_dispatch`), including a `concurrency: { group: ziran-policy-refresh, cancel-in-progress: true }` block so overlapping scheduled runs cannot open competing PRs (spec "Concurrent automation runs" edge case, FR-024)
+- [X] T031 [P] [US3] Format scoping (FR-022) handled by the Action's `target-formats` input looping over `ziran export-policy --format <fmt>`; no CLI change needed
 
 **Checkpoint**: All three user stories independently functional.
 
@@ -122,9 +122,9 @@ Single-project hexagonal layout: code in `ziran/`, tests in `tests/`.
 ## Phase 6: Polish & Cross-Cutting Concerns
 
 - [X] T032 [P] Add the "Alerting" section to `docs/guides/analyze-traces.md` (FR-026)
-- [ ] T033 [P] Write the new guide `docs/guides/policy-refresh-automation.md` (FR-027)
-- [ ] T034 Run quickstart.md validation end-to-end (config samples, exit codes)
-- [ ] T035 Run quality gates: `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy ziran/`, `uv run pytest --cov=ziran` (≥85%)
+- [X] T033 [P] Write the new guide `docs/guides/policy-refresh-automation.md` (FR-027)
+- [X] T034 Run quickstart.md validation end-to-end (config samples, exit codes)
+- [X] T035 Run quality gates: `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy ziran/`, `uv run pytest --cov=ziran` (≥85%)
 
 ---
 


### PR DESCRIPTION
## Summary

**PR 3 of 3 (final)** for spec 017 (Runtime Loop). Adds a reusable composite GitHub Action that keeps exported guardrail policies fresh: re-scan → regenerate bundle → diff against the committed bundle → open/update a single refresh PR (or fail on drift). Closes #273. Completes spec 017 — all 35 tasks done.

This slice is pure repo tooling (no library changes); it invokes the existing `ziran scan` / `ziran export-policy` commands.

## What's included

- **`.github/actions/export-policy/action.yml`** — composite Action. Inputs: `target` *or* `result-json` (offline), `out-dir`, `target-formats`, `severity-floor`, `fail-on-diff`, `branch`, `reviewer-team`, `token`. Regenerates the bundle, diffs it, and either fails on drift or maintains a single `ziran/policy-refresh` PR (labelled, reviewer requested).
- **`examples/07-cicd-quality-gate/policy-refresh.yml`** — copyable template (weekly schedule + `workflow_dispatch` + `concurrency` guard so overlapping runs can't open competing PRs).
- **`.github/workflows/policy-refresh-selftest.yml`** — keyless, side-effect-free self-test asserting drift detection (stale bundle → run fails; up-to-date bundle → no-op) against a committed sample campaign result.
- **`examples/07-cicd-quality-gate/sample-campaign-result.json`** — fixture with two dangerous chains.
- **`docs/guides/policy-refresh-automation.md`** — end-to-end guide.

## Design notes

- **No LLM keys in CI**: `result-json` lets the Action (and the self-test) regenerate from a pre-existing campaign result, so the self-test is deterministic and secret-free. The PR-creation path is implemented for real use; the self-test exercises the `fail-on-diff` detection path.
- **Single PR under any merge strategy**: a fixed head branch (`ziran/policy-refresh`) is the stable identity (FR-024).
- **Format scoping (FR-022)**: handled by `target-formats` looping over `ziran export-policy --format <fmt>` — no CLI change needed.

## Test plan

- [x] All workflow/action YAML parses
- [x] Drift logic simulated locally: empty bundle → drift detected; identical bundle → no-op
- [x] Sample fixture produces 8 policy files across the 4 formats
- [x] `ruff` / `ruff format` / `mypy` clean; 32 alerting tests pass (no Python changed in this PR)
- [x] The bundled `policy-refresh-selftest` workflow runs on this PR (touches the action path)