### PR TITLE
ci(release): run release-please when its own release PR merges

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,10 +35,13 @@ jobs:
             --jq '.[0].head.ref // ""')
           echo "Merged branch: $HEAD_REF"
 
-          if echo "$HEAD_REF" | grep -qE '^(release/|hotfix/)'; then
+          # Also match release-please's OWN release PR branch — merging it is
+          # exactly when release-please must run to create the tag + GitHub
+          # release. Omitting it left the release stuck (manifest bumped, no tag).
+          if echo "$HEAD_REF" | grep -qE '^(release/|hotfix/|release-please--)'; then
             echo "is-release-merge=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Skipping — not a release or hotfix merge"
+            echo "Skipping — not a release, hotfix, or release-please merge"
             echo "is-release-merge=false" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
## Problem

v0.32.0 got **stuck half-released**: the release-please PR (#317) merged, bumping the manifest to 0.32.0 and updating CHANGELOG, but **no `v0.32.0` tag or GitHub release was created**.

Root cause: the `check-source-branch` guard in `release-please.yml` only allowed head branches matching `^(release/|hotfix/)`. release-please's *own* release PR merges from `release-please--branches--main--components--ziran`, which didn't match — so the run that should create the tag/release was skipped (`release-please: skipped`).

## Fix

Allow the `release-please--` branch prefix in the guard, so the tag/release step runs when the release PR merges:

```diff
- if echo "$HEAD_REF" | grep -qE '^(release/|hotfix/)'; then
+ if echo "$HEAD_REF" | grep -qE '^(release/|hotfix/|release-please--)'; then
```

## Immediate remediation (already done)

v0.32.0 was unblocked by triggering `release-please.yml` via `workflow_dispatch` (that path bypasses the guard): tag `v0.32.0` + GitHub release are now created and the publish workflow ran. This PR prevents the next release from getting stuck the same way.

## Why develop (not a direct main hotfix)

Release branches are cut from `develop`, so `develop` must carry the fix or the next `release/* → main` promotion would overwrite main's workflow with the broken version. It reaches `main` with the next release promotion, before the next release-please PR merge needs it.