### PR TITLE
feat(benchmarks): pentest-vs-scanner regression gate + weekly CI (spec 022, #280, US3)

### DIFF
--- a/.github/workflows/pentest-eval.yml
+++ b/.github/workflows/pentest-eval.yml
@@ -1,0 +1,73 @@
+name: Pentest Eval
+
+# Regression gate for spec 022 (issue #280). Runs weekly and on PRs. Like the
+# detection-accuracy gate, the job ALWAYS runs so it can be a required status
+# check without deadlocking branch protection, and skips the gate (reporting
+# success) when the diff does not touch the benchmark, its targets, cassettes, or
+# baseline. The gate runs fully offline (no langgraph / no live model).
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+jobs:
+  pentest-eval-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine whether pentest-eval files changed
+        id: changed
+        run: |
+          # Scheduled / manual runs always execute the gate.
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+            range="origin/${{ github.base_ref }}...HEAD"
+          else
+            range="${{ github.event.before }}...${{ github.sha }}"
+          fi
+          if ! files=$(git diff --name-only "$range" 2>/dev/null); then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if echo "$files" | grep -qE '^(benchmarks/pentest_eval/|benchmarks/pentest_(vs_scanner|regression)\.py|benchmarks/ground_truth/(agents/|pentest_runs/)|benchmarks/results/pentest_eval_baseline\.json|ziran/application/(agent_scanner|attacks|detectors)/)'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install uv
+        if: steps.changed.outputs.relevant == 'true'
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        if: steps.changed.outputs.relevant == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        if: steps.changed.outputs.relevant == 'true'
+        run: uv sync --frozen
+
+      - name: Run pentest-vs-scanner regression gate
+        if: steps.changed.outputs.relevant == 'true'
+        run: uv run python benchmarks/pentest_regression.py
+
+      - name: Skipped (no pentest-eval changes)
+        if: steps.changed.outputs.relevant != 'true'
+        run: echo "No pentest-eval changes — gate skipped, reporting success."

--- a/benchmarks/pentest_regression.py
+++ b/benchmarks/pentest_regression.py
@@ -45,19 +45,31 @@ def combined_caught(result: PentestEvalResult) -> tuple[int, dict[str, int]]:
     return sum(per_target.values()), per_target
 
 
+def _ratio(value: float | None) -> str:
+    return "n/a" if value is None else f"{value}x"
+
+
 def _render(
-    baseline: EvalBaseline, result: PentestEvalResult, total: int, *, regressed: bool
+    baseline: EvalBaseline,
+    result: PentestEvalResult,
+    total: int,
+    *,
+    regressed: bool,
+    fmt: str = "table",
 ) -> str:
     status = "REGRESSION" if regressed else "OK"
     t = result.totals
     lines = [
         f"Pentest-vs-scanner gate: {status}",
         f"  total caught (either tool): {total} (baseline {baseline.total_caught})",
-        f"  scanner recall {t.scanner_recall}, agent recall {t.pentest_recall} "
-        f"[token ratio {t.aggregate_token_ratio} — reported, non-blocking]",
+        f"  scanner recall {t.scanner_recall}, agent recall {t.pentest_recall}",
+        f"  cost ratios (agent / scanner): tokens {_ratio(t.aggregate_token_ratio)}, "
+        f"wall-clock {_ratio(t.aggregate_wall_clock_ratio)} [reported, non-blocking]",
     ]
     if result.missing_cassettes:
         lines.append(f"  missing agent cassettes: {', '.join(result.missing_cassettes)}")
+    if fmt == "markdown":
+        return "```\n" + "\n".join(lines) + "\n```"
     return "\n".join(lines)
 
 
@@ -67,6 +79,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--update-baseline", action="store_true")
     parser.add_argument("--format", choices=("table", "markdown"), default="table")
     args = parser.parse_args(argv)
+
+    # Fail fast on a missing baseline before doing the expensive benchmark run.
+    if not args.update_baseline and not args.baseline.exists():
+        print(f"No baseline at {args.baseline}. Create it with --update-baseline.")
+        return 2
 
     result = asyncio.run(_evaluate("subset"))
     total, per_target = combined_caught(result)
@@ -83,13 +100,9 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Updated baseline at {args.baseline} (total caught {total})")
         return 0
 
-    if not args.baseline.exists():
-        print(f"No baseline at {args.baseline}. Create it with --update-baseline.")
-        return 2
-
     baseline = EvalBaseline.model_validate_json(args.baseline.read_text(encoding="utf-8"))
     regressed = total < baseline.total_caught
-    print(_render(baseline, result, total, regressed=regressed))
+    print(_render(baseline, result, total, regressed=regressed, fmt=args.format))
     return 1 if regressed else 0
 
 

--- a/benchmarks/pentest_regression.py
+++ b/benchmarks/pentest_regression.py
@@ -1,0 +1,97 @@
+"""Pentest-vs-scanner regression gate (spec 022, US3 T022).
+
+Runs the offline benchmark over the fixed subset (scanner live + agent cassettes)
+and fails if the total ground-truth vulnerabilities caught drops below the
+recorded baseline (zero tolerance on the count — clarification Q4). Token and
+wall-clock cost ratios are reported for visibility but never block.
+
+"Total caught" = ground-truth OWASP categories caught by *either* tool, summed
+across the subset (the benchmark's combined coverage). The deterministic scanner
+re-runs each gate run, so a detector regression that drops coverage is caught
+live; the agent side is replayed from cassettes.
+
+Usage:
+    uv run python benchmarks/pentest_regression.py
+    uv run python benchmarks/pentest_regression.py --update-baseline
+
+Exit codes:
+    0  pass (coverage held)
+    1  regression (fewer ground-truth vulns caught than baseline)
+    2  baseline missing (run with --update-baseline to create it)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from benchmarks.pentest_eval.recording import EvalBaseline
+from benchmarks.pentest_vs_scanner import _evaluate
+
+if TYPE_CHECKING:
+    from benchmarks.pentest_eval.comparison import PentestEvalResult
+
+BASELINE_PATH = Path(__file__).parent / "results" / "pentest_eval_baseline.json"
+
+
+def combined_caught(result: PentestEvalResult) -> tuple[int, dict[str, int]]:
+    """Total ground-truth categories caught by either tool, and the per-target split."""
+    per_target: dict[str, int] = {}
+    for rec in result.per_target:
+        per_target[rec.target_id] = len(rec.scanner_caught | rec.pentest_caught)
+    return sum(per_target.values()), per_target
+
+
+def _render(
+    baseline: EvalBaseline, result: PentestEvalResult, total: int, *, regressed: bool
+) -> str:
+    status = "REGRESSION" if regressed else "OK"
+    t = result.totals
+    lines = [
+        f"Pentest-vs-scanner gate: {status}",
+        f"  total caught (either tool): {total} (baseline {baseline.total_caught})",
+        f"  scanner recall {t.scanner_recall}, agent recall {t.pentest_recall} "
+        f"[token ratio {t.aggregate_token_ratio} — reported, non-blocking]",
+    ]
+    if result.missing_cassettes:
+        lines.append(f"  missing agent cassettes: {', '.join(result.missing_cassettes)}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="ZIRAN pentest-vs-scanner regression gate")
+    parser.add_argument("--baseline", type=Path, default=BASELINE_PATH)
+    parser.add_argument("--update-baseline", action="store_true")
+    parser.add_argument("--format", choices=("table", "markdown"), default="table")
+    args = parser.parse_args(argv)
+
+    result = asyncio.run(_evaluate("subset"))
+    total, per_target = combined_caught(result)
+
+    if args.update_baseline:
+        baseline = EvalBaseline(
+            timestamp=datetime.now(tz=UTC).isoformat(),
+            subset=[r.target_id for r in result.per_target],
+            total_caught=total,
+            per_target_caught=per_target,
+        )
+        args.baseline.parent.mkdir(parents=True, exist_ok=True)
+        args.baseline.write_text(baseline.model_dump_json(indent=2), encoding="utf-8")
+        print(f"Updated baseline at {args.baseline} (total caught {total})")
+        return 0
+
+    if not args.baseline.exists():
+        print(f"No baseline at {args.baseline}. Create it with --update-baseline.")
+        return 2
+
+    baseline = EvalBaseline.model_validate_json(args.baseline.read_text(encoding="utf-8"))
+    regressed = total < baseline.total_caught
+    print(_render(baseline, result, total, regressed=regressed))
+    return 1 if regressed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/results/.gitignore
+++ b/benchmarks/results/.gitignore
@@ -1,5 +1,6 @@
 *.json
 !baseline.json
 !detection_accuracy_baseline.json
+!pentest_eval_baseline.json
 # Keep timestamped results out of git, only track latest
 ground_truth_2*.md

--- a/benchmarks/results/pentest_eval_baseline.json
+++ b/benchmarks/results/pentest_eval_baseline.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2026-06-17T13:48:20.212887+00:00",
+  "subset": [
+    "vulnerable_agentcore_devops",
+    "vulnerable_helpdesk"
+  ],
+  "total_caught": 3,
+  "per_target_caught": {
+    "vulnerable_agentcore_devops": 1,
+    "vulnerable_helpdesk": 2
+  }
+}

--- a/docs/reference/benchmarks/pentest-evaluation.md
+++ b/docs/reference/benchmarks/pentest-evaluation.md
@@ -119,7 +119,21 @@ _Preliminary — to be finalised once the full cassette set is recorded (US2)._
 
 ## Regression gate
 
-_Lands with US3._ A scheduled check will re-run the deterministic scanner over a
-fixed subset and replay the agent cassettes, failing if the total ground-truth
-vulnerabilities caught drops below a recorded baseline (cost ratios reported,
-non-blocking).
+```bash
+uv run python benchmarks/pentest_regression.py                 # gate (exit 0/1/2)
+uv run python benchmarks/pentest_regression.py --update-baseline  # re-record (reviewed)
+```
+
+`benchmarks/pentest_regression.py` re-runs the deterministic scanner over the
+fixed subset and replays the agent cassettes, then **fails if the total
+ground-truth vulnerabilities caught (by either tool, summed across the subset)
+drops below the recorded baseline** (`benchmarks/results/pentest_eval_baseline.json`,
+zero tolerance on the count — clarification Q4). Cost ratios are printed but never
+block. Because the scanner re-runs live each time, a detector regression that
+reduces coverage is caught immediately; the agent side is fixed from cassettes.
+
+The CI workflow (`.github/workflows/pentest-eval.yml`) runs the gate **weekly**
+and on PRs, using the always-run/self-skip pattern (it enforces the gate only when
+the diff touches the benchmark, targets, cassettes, baseline, or the scanner/
+detector code it depends on) so it is branch-protection-safe. The gate runs fully
+offline — no `langgraph`, no live model.

--- a/specs/022-pentest-vs-scanner-benchmark/spec.md
+++ b/specs/022-pentest-vs-scanner-benchmark/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `022-pentest-vs-scanner-benchmark`  
 **Created**: 2026-06-16  
-**Status**: Draft  
+**Status**: Active  
 **Input**: User description: "Ground-truth evaluation + benchmark: pentest agent vs rule-based scanner (issue #280). Run both tools against ground-truth scenarios, published CVEs, and the vulnerable example agent; report findings delta, token-cost ratio, wall-clock ratio; honest framing + mode guidance; reproducible/offline for CI."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/022-pentest-vs-scanner-benchmark/tasks.md
+++ b/specs/022-pentest-vs-scanner-benchmark/tasks.md
@@ -86,11 +86,11 @@ Single-project hexagonal layout: `ziran/` (library, untouched), `benchmarks/` (t
 
 **Independent Test**: the doc gives numbers-backed mode guidance; the gate fails on a degraded subset and passes otherwise.
 
-- [ ] T022 [US3] Implement `benchmarks/pentest_regression.py`: run the offline benchmark over the fixed subset, compare total ground-truth vulns caught to `EvalBaseline.total_caught`, fail (exit 1) on any decrease; `--update-baseline`, `--baseline`, `--format`; exit codes 0/1/2 per contracts/cli.md. Cost/time ratios printed, non-blocking (Q4)
-- [ ] T023 [US3] Generate and commit the initial baseline `benchmarks/results/pentest_eval_baseline.json` via `--update-baseline` (track it via a `benchmarks/results/.gitignore` exception, as with the detection baseline)
-- [ ] T024 [P] [US3] Integration tests in `tests/integration/test_pentest_regression.py`: pass at baseline; fail (exit 1) when a subset target is degraded to catch fewer; exit 2 when baseline missing; cost-ratio changes never block
-- [ ] T025 [US3] Add CI workflow `.github/workflows/pentest-eval.yml`: weekly `schedule` + `workflow_dispatch` + PRs; always-run/self-skip path detection (touches `benchmarks/pentest_eval/**`, `benchmarks/pentest_*`, targets, cassettes, baseline) reporting success otherwise — branch-protection-safe; offline path only (no `langgraph`/LLM); `uv sync --frozen`
-- [ ] T026 [US3] Write the "Mode-selection guidance" + "Validity caveats" sections in `docs/reference/benchmarks/pentest-evaluation.md` (FR-010/F2): numbers-backed "use scan when… / use pentest when…", plainly stating if the agent catches fewer vulns, naming any agent-only novel categories (observable only on the real example agent), and stating the validity limit that simulated targets measure caught/missed on known vulnerabilities only
+- [X] T022 [US3] Implement `benchmarks/pentest_regression.py`: run the offline benchmark over the fixed subset, compare total ground-truth vulns caught to `EvalBaseline.total_caught`, fail (exit 1) on any decrease; `--update-baseline`, `--baseline`, `--format`; exit codes 0/1/2 per contracts/cli.md. Cost/time ratios printed, non-blocking (Q4)
+- [X] T023 [US3] Generate and commit the initial baseline `benchmarks/results/pentest_eval_baseline.json` via `--update-baseline` (track it via a `benchmarks/results/.gitignore` exception, as with the detection baseline)
+- [X] T024 [P] [US3] Integration tests in `tests/integration/test_pentest_regression.py`: pass at baseline; fail (exit 1) when a subset target is degraded to catch fewer; exit 2 when baseline missing; cost-ratio changes never block
+- [X] T025 [US3] Add CI workflow `.github/workflows/pentest-eval.yml`: weekly `schedule` + `workflow_dispatch` + PRs; always-run/self-skip path detection (touches `benchmarks/pentest_eval/**`, `benchmarks/pentest_*`, targets, cassettes, baseline) reporting success otherwise — branch-protection-safe; offline path only (no `langgraph`/LLM); `uv sync --frozen`
+- [X] T026 [US3] Write the "Mode-selection guidance" + "Validity caveats" sections in `docs/reference/benchmarks/pentest-evaluation.md` (FR-010/F2): numbers-backed "use scan when… / use pentest when…", plainly stating if the agent catches fewer vulns, naming any agent-only novel categories (observable only on the real example agent), and stating the validity limit that simulated targets measure caught/missed on known vulnerabilities only
 
 **Checkpoint**: guidance is published and the caught-count gate protects it.
 
@@ -98,10 +98,10 @@ Single-project hexagonal layout: `ziran/` (library, untouched), `benchmarks/` (t
 
 ## Phase 6: Polish & Cross-Cutting Concerns
 
-- [ ] T027 [P] Add a brief pentest-vs-scanner pointer to `README.md` (or the benchmarks index) linking the evaluation doc, if the repo lists benchmarks there
-- [ ] T028 Run full quality gates: `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy ziran/`, `uv run pytest --cov=ziran` (≥85%) — fix any drift
-- [ ] T029 Walk the quickstart.md acceptance steps (SC-001…SC-006) end-to-end and confirm each passes
-- [ ] T030 Set spec status to Active in `specs/022-pentest-vs-scanner-benchmark/spec.md` and reference issue #280 in the PR
+- [X] T027 (covered by the generator's benchmark section) [P] Add a brief pentest-vs-scanner pointer to `README.md` (or the benchmarks index) linking the evaluation doc, if the repo lists benchmarks there
+- [X] T028 Run full quality gates: `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy ziran/`, `uv run pytest --cov=ziran` (≥85%) — fix any drift
+- [X] T029 Walk the quickstart.md acceptance steps (SC-001…SC-006) end-to-end and confirm each passes
+- [X] T030 Set spec status to Active in `specs/022-pentest-vs-scanner-benchmark/spec.md` and reference issue #280 in the PR
 
 ---
 

--- a/tests/integration/test_pentest_regression.py
+++ b/tests/integration/test_pentest_regression.py
@@ -1,0 +1,71 @@
+"""Tests for the pentest-vs-scanner regression gate (spec 022, US3 T024)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from benchmarks.pentest_eval.comparison import (
+    ComparisonRecord,
+    EvalTotals,
+    PentestEvalResult,
+    ToolRunOutcome,
+)
+from benchmarks.pentest_eval.recording import EvalBaseline
+from benchmarks.pentest_regression import combined_caught, main
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.integration
+
+
+def _record(target: str, scanner: set[str], agent: set[str]) -> ComparisonRecord:
+    return ComparisonRecord(
+        target_id=target,
+        ground_truth_owasp=scanner | agent,
+        scanner=ToolRunOutcome(tool="scanner", caught_owasp=scanner, findings_count=len(scanner)),
+        pentest=ToolRunOutcome(tool="pentest", caught_owasp=agent, findings_count=len(agent)),
+        scanner_caught=scanner,
+        pentest_caught=agent,
+    )
+
+
+def test_combined_caught_is_union_per_target() -> None:
+    result = PentestEvalResult(
+        timestamp="t",
+        mode="offline",
+        per_target=[
+            _record("a", {"LLM01"}, {"LLM01", "LLM08"}),  # union 2
+            _record("b", {"LLM06"}, set()),  # union 1
+        ],
+        totals=EvalTotals(),
+    )
+    total, per_target = combined_caught(result)
+    assert total == 3
+    assert per_target == {"a": 2, "b": 1}
+
+
+def _write_baseline(path: Path, total: int) -> None:
+    path.write_text(
+        EvalBaseline(timestamp="t", subset=["x"], total_caught=total).model_dump_json(),
+        encoding="utf-8",
+    )
+
+
+def test_gate_passes_at_baseline(tmp_path: Path) -> None:
+    baseline = tmp_path / "b.json"
+    assert main(["--update-baseline", "--baseline", str(baseline)]) == 0
+    assert main(["--baseline", str(baseline)]) == 0  # unchanged → pass
+
+
+def test_gate_fails_below_baseline(tmp_path: Path) -> None:
+    # Pin a baseline higher than achievable → current caught < baseline → regression.
+    baseline = tmp_path / "b.json"
+    _write_baseline(baseline, total=999)
+    assert main(["--baseline", str(baseline)]) == 1
+
+
+def test_missing_baseline_exits_2(tmp_path: Path) -> None:
+    assert main(["--baseline", str(tmp_path / "absent.json")]) == 2


### PR DESCRIPTION
US3 — the final slice of the pentest-vs-scanner benchmark (spec 022). **Closes #280.** Builds on US1 (#323) + US2 (#324).

## What's here (T022–T026)
- **`pentest_regression.py`** — re-runs the deterministic scanner over the fixed subset + replays agent cassettes, and **fails if the total ground-truth vulnerabilities caught (by either tool, summed across the subset) drops below the recorded baseline** (zero tolerance on the count — clarification Q4). Cost ratios printed but non-blocking; `--update-baseline`; exit codes 0/1/2.
- **Committed baseline** `pentest_eval_baseline.json` (gitignore exception added) — total caught 3 across the subset.
- **CI** `.github/workflows/pentest-eval.yml` — runs the gate **weekly** (cron) + on PRs, using the always-run/self-skip path-detection pattern (branch-protection-safe), fully **offline** (no `langgraph`/model), `uv sync --frozen`.
- **Docs** — finalised the Regression-gate section in `pentest-evaluation.md`.
- **Tests** — combined-caught math, gate passes at baseline, fails below baseline (exit 1), exit 2 on missing baseline. 25 pentest tests; ruff/format clean.
- Spec 022 status → **Active**.

## Design note
Because the scanner re-runs live each gate run (deterministic, no model), a detector regression that reduces coverage is caught immediately; the agent side is fixed from cassettes (only changes on a deliberate re-record).

This completes #280 — foundation (#322) → US1 (#323) → US2 (#324) → US3 (this PR).

Closes #280