### PR TITLE
docs(graph): document interactive knowledge graph features

### DIFF
--- a/docs/concepts/knowledge-graph.md
+++ b/docs/concepts/knowledge-graph.md
@@ -16,6 +16,7 @@ ZIRAN uses a **NetworkX-based directed multigraph** to track all discoveries, re
 
 | Type | Icon | Description |
 |------|------|-------------|
+| `agent` | :star: | An agent in a multi-agent topology |
 | `capability` | :gear: | A discovered agent capability |
 | `tool` | :wrench: | An invokable tool the agent has access to |
 | `vulnerability` | :warning: | A discovered vulnerability |
@@ -35,10 +36,45 @@ ZIRAN uses a **NetworkX-based directed multigraph** to track all discoveries, re
 | `discovered_in` | Vulnerability discovered in a phase |
 | `exploits` | Attack exploits a vulnerability |
 | `leads_to` | One state leads to another |
+| `delegates_to` | One agent delegates work to another (multi-agent) |
+| `shares_context` | One agent shares context/data with another (multi-agent) |
+| `trust_boundary` | A trust boundary between two agents (multi-agent) |
 
 ## Visualization
 
-The knowledge graph is rendered interactively in HTML reports using vis-network, with color-coded nodes and edges. Dangerous tool chains are highlighted in red.
+The knowledge graph renders interactively with **vis-network**, and the **web UI and the self-contained HTML report share a single styling/mapping spec** so both surfaces look and behave identically. (The report is standalone — the only network dependency is the vis-network library from a CDN; no backend access is required.)
+
+### Layout modes
+
+Switch how the graph is arranged:
+
+- **Force** — physics-based force-directed layout (the classic view).
+- **By phase** — a hierarchical, left-to-right layout that bands nodes by the campaign phase they were discovered in (reconnaissance → … → exfiltration), so the structure reads as a story.
+- **Centrality** — emphasizes the most pivotal nodes.
+
+### Importance encoding
+
+The graph encodes analysis directly into the visuals:
+
+- **Node size ∝ betweenness centrality** — pivotal "chokepoint" nodes (compromising them unlocks the most attack paths) appear larger.
+- **Severity** — vulnerability nodes are colored/bordered by severity.
+- **Dangerous capabilities** carry a distinct marker.
+- **Attack-relevant edges** (`exploits`, `can_chain_to`, `leads_to`) are weighted and directional so attack flow stands out.
+
+### Filtering
+
+The **legend doubles as a filter** — toggle node types, edge types, and severity bands on/off. Text search and attack-path highlighting are also available. When a filter combination hides everything, a "nothing matches" state offers a one-click reset.
+
+### Drill-down
+
+- **Clustering** — collapse the graph into labeled super-nodes by **phase**, **type**, or **agent**, and expand on demand. Large graphs auto-cluster on first render so they open as a navigable overview instead of a hairball.
+- **Attack-chain walker** — select a discovered attack path and step through it node-by-node with the current step focused and its context highlighted.
+- **Cross-linking** — clicking a graph node scrolls to its attack-log entry (and OWASP/ATLAS mapping); activating an attack-log row focuses the matching node.
+- **Multi-agent topology** — delegation, trust-boundary, and context-sharing edges render distinctly, and agents can be grouped into clusters.
+
+### Timeline scrubber
+
+For runs with per-phase snapshots, a **phase timeline scrubber** steps the graph through each phase so you can watch the campaign *grow* — nodes and edges appear as they were discovered. Older runs without per-phase snapshots fall back to showing the final end-state.
 
 ## Graph API
 

--- a/docs/guides/interpreting-results.md
+++ b/docs/guides/interpreting-results.md
@@ -9,9 +9,21 @@ How to read and act on ZIRAN scan results.
 The interactive HTML report includes:
 
 - **Campaign summary** — Overall metrics and status
-- **Knowledge graph** — Interactive visualization of agent capabilities and attack paths
+- **Knowledge graph** — Interactive visualization of agent capabilities and attack paths (see below)
 - **Phase timeline** — Results from each scan phase
 - **Dangerous tool chains** — Highlighted with risk levels and remediation
+
+#### Working with the knowledge graph
+
+The graph is the same interactive component in both the HTML report and the web UI:
+
+- **Layout modes** — switch between *Force*, *By phase* (hierarchical bands per campaign phase), and *Centrality*.
+- **Importance at a glance** — node size reflects betweenness centrality (chokepoints look bigger), severity drives node color/border, dangerous capabilities are marked, and attack edges (`exploits`/`can_chain_to`/`leads_to`) are emphasized.
+- **Filter** — the legend toggles node types, edge types, and severity bands; text search and path highlighting are also available.
+- **Drill down** — collapse into super-nodes by phase/type/agent (large graphs auto-cluster), step a discovered attack path with the **chain walker**, and click a node to jump to its **attack-log** entry (and back).
+- **Replay over time** — the **phase timeline scrubber** steps the graph through each phase so you watch the campaign grow; older runs fall back to the final state.
+
+See [Knowledge Graph](../concepts/knowledge-graph.md) for the full reference.
 
 ### Markdown Report
 


### PR DESCRIPTION
## Summary

Documents the spec **026 / issue #331** interactive knowledge graph now that PR1–PR3 are merged — so the feature is described ahead of cutting a release.

Updates:
- [`docs/concepts/knowledge-graph.md`](docs/concepts/knowledge-graph.md): completes the node-type table (`agent`) and edge-type table (`delegates_to` / `shares_context` / `trust_boundary`), and rewrites the **Visualization** section to cover layout modes, importance encoding, legend-as-filter, clustering, the attack-chain walker, cross-linking, multi-agent topology, and the phase timeline scrubber — noting the web UI and HTML report share one styling spec.
- [`docs/guides/interpreting-results.md`](docs/guides/interpreting-results.md): expands the HTML-report knowledge-graph entry into a "Working with the knowledge graph" subsection and cross-links to the concept page.

## Validation
- `mkdocs build --strict` (mkdocs-material): my two edited pages produce **no warnings**. (The 6 pre-existing strict warnings are anchor links in the unrelated `reference/benchmarks/coverage-comparison.md`; the docs deploy job uses non-strict `gh-deploy`.)

`docs(...)`-scoped so it doesn't itself trigger a release-please bump — the `feat(graph)` commits from PR1–PR3 drive the minor version bump when `develop` is released.

Refs #331