### PR TITLE
fix(report): surface composition findings so the verdict isn't misleading

### DIFF
--- a/tests/unit/test_html_report.py
+++ b/tests/unit/test_html_report.py
@@ -319,6 +319,10 @@ class TestBuildHtmlReport:
 
         assert "VULNERABLE" in html
         assert "0.60" in html  # trust score
+        # Composition findings must be a first-class metric so a VULNERABLE
+        # verdict is never shown next to a lone "0 vulnerabilities".
+        assert "Composition findings" in html
+        assert "Prompt-level vulns" in html
 
     def test_includes_layout_and_filter_controls(
         self,

--- a/tests/unit/test_reports.py
+++ b/tests/unit/test_reports.py
@@ -138,6 +138,10 @@ class TestReportGenerator:
         out = gen.save_markdown(result)
         content = out.read_text()
         assert "⚠️ VULNERABLE" in content
+        # The verdict must be backed by a visible finding count, not a bare
+        # "Total Vulnerabilities: 0" — surface the composition findings.
+        assert "Prompt-level Vulnerabilities" in content
+        assert "Composition Findings (tool chains)" in content
         assert "Prompt Injection" in content
         assert "Token Usage" in content
         assert "Dangerous Tool Chains" in content

--- a/ziran/interfaces/cli/html_report.py
+++ b/ziran/interfaces/cli/html_report.py
@@ -175,6 +175,8 @@ def build_html_report(
     campaign_id = result_data.get("campaign_id", "unknown")
     target_agent = result_data.get("target_agent", "unknown")
     total_vulns = result_data.get("total_vulnerabilities", 0)
+    critical_chains = result_data.get("critical_chain_count", 0)
+    total_chains = len(result_data.get("dangerous_tool_chains", []))
     trust_score = result_data.get("final_trust_score", 0)
     success = result_data.get("success", False)
     phases = result_data.get("phases_executed", [])
@@ -217,6 +219,8 @@ def build_html_report(
         campaign_id=html.escape(campaign_id),
         target_agent=html.escape(target_agent),
         total_vulns=total_vulns,
+        total_chains=total_chains,
+        chain_class="danger" if critical_chains else ("orange" if total_chains else "accent"),
         trust_score=f"{trust_score:.2f}",
         trust_pct=int(trust_score * 100),
         success_label="VULNERABLE" if success else "PASSED",
@@ -1144,8 +1148,12 @@ _HTML_TEMPLATE = """\
         <div class="metric-label">Result</div>
       </div>
       <div class="metric">
-        <div class="metric-value danger">{total_vulns}</div>
-        <div class="metric-label">Vulnerabilities</div>
+        <div class="metric-value {chain_class}">{total_chains}</div>
+        <div class="metric-label">Composition findings</div>
+      </div>
+      <div class="metric">
+        <div class="metric-value">{total_vulns}</div>
+        <div class="metric-label">Prompt-level vulns</div>
       </div>
       <div class="metric">
         <div class="metric-value orange">{num_paths}</div>

--- a/ziran/interfaces/cli/main.py
+++ b/ziran/interfaces/cli/main.py
@@ -1506,7 +1506,7 @@ def _display_results(result: CampaignResult) -> None:
     summary_table.add_row("Target Agent", result.target_agent)
     summary_table.add_row("Phases Executed", str(len(result.phases_executed)))
     summary_table.add_row(
-        "Total Vulnerabilities",
+        "Prompt-level Vulnerabilities",
         f"[bold red]{result.total_vulnerabilities}[/bold red]"
         if result.total_vulnerabilities > 0
         else "[green]0[/green]",

--- a/ziran/interfaces/cli/reports.py
+++ b/ziran/interfaces/cli/reports.py
@@ -178,7 +178,11 @@ class ReportGenerator:
         lines.append("| Metric | Value |")
         lines.append("|--------|-------|")
         lines.append(f"| Phases Executed | {len(result.phases_executed)} |")
-        lines.append(f"| Total Vulnerabilities | {result.total_vulnerabilities} |")
+        lines.append(f"| Prompt-level Vulnerabilities | {result.total_vulnerabilities} |")
+        lines.append(
+            "| Composition Findings (tool chains) | "
+            f"{len(result.dangerous_tool_chains)} ({result.critical_chain_count} critical) |"
+        )
         lines.append(f"| Critical Attack Paths | {len(result.critical_paths)} |")
         lines.append(f"| Final Trust Score | {result.final_trust_score:.2f} |")
         lines.append(f"| Overall Result | {'⚠️ VULNERABLE' if result.success else '✅ PASSED'} |")


### PR DESCRIPTION
Closes #361.

A focused scan that flags a dangerous **tool-chain** (no prompt-level findings) showed up as **⚠️ VULNERABLE** next to **Total Vulnerabilities: 0** — the real finding was buried in the 'Dangerous Tool Chains' section. The verdict (`success`) already includes `critical_chain_count`, but the headline metric didn't.

**Changes (report surfaces only — no scoring change):**
- **HTML** (`html_report.py`): new first-class **Composition findings** metric card (danger colour when there's a critical chain); the old red `Vulnerabilities` card is relabelled **Prompt-level vulns** and de-emphasised.
- **Markdown** (`reports.py`): `Total Vulnerabilities` → **Prompt-level Vulnerabilities**, plus a new **Composition Findings (tool chains)** row with the critical count.
- **CLI** (`main.py`): same vuln-row relabel (chain + critical-composition rows already existed).
- Tests assert both surfaces show the composition metric.

Now a VULNERABLE verdict is always backed by a visible count. ruff · format · mypy · affected tests (112) green.